### PR TITLE
編集リクエストボタンを設置

### DIFF
--- a/src/applications/sites/index.ts
+++ b/src/applications/sites/index.ts
@@ -21,5 +21,8 @@ export const SitesApp = {
   },
   getPageSize() {
     return PAGE_SIZE
+  },
+  getGithubEditURL() {
+    return 'https://github.com/mijime/mijime.github.io/edit/master'
   }
 }

--- a/src/components/atoms/github-edit-button/index.tsx
+++ b/src/components/atoms/github-edit-button/index.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from 'react'
+import Link from 'next/link'
+
+export type GithubEditButtonProps = {
+  githubURL: string
+  filepath: string
+}
+
+export default function GithubEditButton({
+  githubURL,
+  filepath,
+  children
+}: PropsWithChildren<GithubEditButtonProps>) {
+  return (
+    <button className="button">
+      <Link href={`${githubURL}/${filepath}`}>
+        {children !== undefined ? children : 'Edit'}
+      </Link>
+    </button>
+  )
+}

--- a/src/components/molecules/article-card/index.tsx
+++ b/src/components/molecules/article-card/index.tsx
@@ -1,13 +1,16 @@
 import { PropsWithChildren } from 'react'
+import Link from 'next/link'
 import TagList from '@/components/molecules/tag-list/'
 
 type ArticleCardProps = {
+  slug: string
   title: string
   date: string
   tags: string[]
 }
 
 export default function ArticleCard({
+  slug,
   title,
   date,
   tags = [],
@@ -19,7 +22,9 @@ export default function ArticleCard({
         <div className="card-content">
           <div className="article-title">
             <div className="has-text-centered">
-              <p className="title">{title}</p>
+              <p className="title">
+                <Link href={`/${slug}/`}>{title}</Link>
+              </p>
             </div>
             <TagList tags={tags} date={date} />
           </div>

--- a/src/components/molecules/article-item/index.tsx
+++ b/src/components/molecules/article-item/index.tsx
@@ -19,7 +19,7 @@ export default function ArticleItem({
       <div className="card">
         <div className="card-content">
           <div className="article-title">
-            <Link href={`/post/${slug}`}>{title}</Link>
+            <Link href={`/${slug}`}>{title}</Link>
             <TagList tags={tags} date={date} />
           </div>
         </div>

--- a/src/components/pages/index.tsx
+++ b/src/components/pages/index.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head'
-import Link from 'next/link'
 import Pagination from '@/components/molecules/pagination/'
 import ArticleCard from '@/components/molecules/article-card/'
 import ArticleList from '@/components/organisms/article-list/'
@@ -27,7 +26,6 @@ export function IndexPage({
       <div className="block">
         <ArticleCard {...posts[0]}>
           <div className="message">{posts[0].description}</div>
-          <Link href={`/post/${posts[0].slug}/`}>Read more</Link>
         </ArticleCard>
       </div>
       <ArticleList posts={posts.slice(1)} />

--- a/src/components/pages/post/index.tsx
+++ b/src/components/pages/post/index.tsx
@@ -3,11 +3,14 @@ import Head from 'next/head'
 
 import { SitesApp } from '@/applications/sites/'
 import ArticleCard from '@/components/molecules/article-card/'
-import { buildMetadataByFrontMatter } from '@/infrastructures/functions/markdown/'
 import DefaultLayout from '@/components/templates/default/'
+import { buildMetadataByFrontMatter } from '@/infrastructures/functions/markdown/'
 
 type PostPageProps = {
-  frontMatter: { [key: string]: any }
+  frontMatter: {
+    __resourcePath: string
+    [key: string]: any
+  }
 }
 
 export default function PostPage({

--- a/src/components/pages/post/index.tsx
+++ b/src/components/pages/post/index.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from 'react'
 import Head from 'next/head'
 
 import { SitesApp } from '@/applications/sites/'
+import GithubEditButton from '@/components/atoms/github-edit-button/'
 import ArticleCard from '@/components/molecules/article-card/'
 import DefaultLayout from '@/components/templates/default/'
 import { buildMetadataByFrontMatter } from '@/infrastructures/functions/markdown/'
@@ -19,6 +20,7 @@ export default function PostPage({
 }: PropsWithChildren<PostPageProps>) {
   const metadata = buildMetadataByFrontMatter(frontMatter)
   const siteName = SitesApp.getSiteName()
+  const githubEditURL = SitesApp.getGithubEditURL()
   return (
     <DefaultLayout siteName={siteName}>
       <Head>
@@ -26,7 +28,16 @@ export default function PostPage({
           {metadata.title} | {siteName}
         </title>
       </Head>
-      <ArticleCard {...metadata}>{children}</ArticleCard>
+      <ArticleCard {...metadata}>
+        {children}
+
+        <div className="has-text-right">
+          <GithubEditButton
+            githubURL={githubEditURL}
+            filepath={`pages/${frontMatter.__resourcePath}`}
+          ></GithubEditButton>
+        </div>
+      </ArticleCard>
     </DefaultLayout>
   )
 }

--- a/src/infrastructures/functions/markdown/index.ts
+++ b/src/infrastructures/functions/markdown/index.ts
@@ -1,4 +1,5 @@
 interface Metadata {
+  slug: string
   title: string
   description: string
   date: string
@@ -14,7 +15,11 @@ export function buildMetadataByFrontMatter(data: {
     description: data.description || data.Description || '',
     date: data.date || data.Date || new Date().toISOString(),
     tags: data.tags || data.Tags || [],
-    draft: !!data.draft || !!data.Draft
+    draft: !!data.draft || !!data.Draft,
+    slug:
+      data.__resourcePath !== undefined
+        ? data.__resourcePath.replace(/\/index\.mdx?$/, '')
+        : ''
   }
   return {
     ...originMetadata,

--- a/src/infrastructures/repositories/markdown-posts/index.ts
+++ b/src/infrastructures/repositories/markdown-posts/index.ts
@@ -37,12 +37,12 @@ export class MarkdownPostsRepository implements PostsRepository {
       .replace(/\.mdx?$/, '')
       .replace(/index$/, '')
       .replace(/\/$/, '')
-      .replace(/^.*\/pages\/post\//, '')
+      .replace(/^.*\/pages\//, '')
   }
 
   async fetchPostBySlug(slug: Slug) {
     const md = await fetchMarkdownFromFile(
-      path.resolve(`pages/post/${slug}/index.md`)
+      path.resolve(`pages/${slug}/index.md`)
     )
     return this.convertPostFromMarkdown(md)
   }


### PR DESCRIPTION
fix #9

- slug のフォーマットを変更
- 記事のタイトルをリンクに変更
- 編集リクエストボタンの追加
