### PR TITLE
fix: CI Node.js 22対応 & PR build対応

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -13,6 +15,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -22,11 +25,13 @@ jobs:
       - run: bun install
       - run: bun run build
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: apps/main/dist/
 
   deploy:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -23,7 +23,8 @@
     "lucide-react": "^1.11.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "tailwindcss": "^4.2.4"
+    "tailwindcss": "^4.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwindcss": "^4.2.4",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",


### PR DESCRIPTION
## 背景

PR #111マージ後もCIが失敗していたため追加修正

## やったこと

- `apps/main/package.json`にzodを明示的に依存追加（CI環境でモジュール解決できなかった）
- PRへのpushでもbuildが走るよう`pull_request`トリガーを追加
- draftのPRはbuildをスキップ
- masterへのpush時のみdeployを実行

## できなくなること

無し