### PR TITLE
✨ madories: 表示改善と機能追加

### DIFF
--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -14,6 +14,38 @@ import { FloorCanvas } from "./FloorCanvas";
 import { FloorTabs } from "./FloorTabs";
 import type { ToolMode } from "./toolMode";
 import { ToolSheet } from "./ToolSheet";
+import type { FloorPlan } from "../types";
+import { WALL_WINDOW_SCORE } from "../types";
+import { ITEM_DEF_MAP } from "../items";
+
+function FloorStats({ floor }: { floor: FloorPlan }) {
+  let shelfCount = 0;
+  let windowScore = 0;
+  for (const c of floor.cells) {
+    if (c.item) {shelfCount += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
+    for (const w of [c.wall.top, c.wall.left]) {
+      windowScore += WALL_WINDOW_SCORE[w] ?? 0;
+    }
+  }
+
+  return (
+    <div
+      style={{
+        borderBottom: "1px solid var(--border)",
+        color: "var(--ink)",
+        display: "flex",
+        fontFamily: "IBM Plex Mono, monospace",
+        fontSize: "11px",
+        gap: "16px",
+        opacity: 0.7,
+        padding: "4px 10px",
+      }}
+    >
+      <span>収納: {shelfCount}</span>
+      <span>窓: {windowScore}</span>
+    </div>
+  );
+}
 
 function init(): AppState {
   const saved = loadFromStorage();
@@ -132,7 +164,9 @@ export function App() {
             push({ activeFloorId: imported.id, building: next });
           }}
         />
-        <div className="flex-1 overflow-hidden relative" style={{ background: "var(--paper)" }}>
+        <div className="flex-1 overflow-hidden relative flex flex-col" style={{ background: "var(--paper)" }}>
+          <FloorStats floor={floor} />
+          <div className="flex-1 overflow-hidden relative">
           <FloorCanvas
             ref={canvasRef}
             floor={floor}
@@ -218,6 +252,7 @@ export function App() {
               dispatch({ cellIndex, floorId: floor.id, type: "ERASE_CELL" })
             }
           />
+          </div>
         </div>
       </div>
       {toast && (

--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDarkMode } from "@mijime/theme/useDarkMode";
-import { exportAllFloorsPng } from "../draw/export";
+import { computeFloorScores, exportAllFloorsPng } from "../draw/export";
 import { buildShareUrl, encodeFloors } from "../floor/share";
 import { loadFromFile, loadFromStorage, saveToFile, saveToStorage } from "../storage";
 import { createBuilding, reducer } from "../store";
@@ -15,18 +15,9 @@ import { FloorTabs } from "./FloorTabs";
 import type { ToolMode } from "./toolMode";
 import { ToolSheet } from "./ToolSheet";
 import type { FloorPlan } from "../types";
-import { WALL_WINDOW_SCORE } from "../types";
-import { ITEM_DEF_MAP } from "../items";
 
 function FloorStats({ floor }: { floor: FloorPlan }) {
-  let shelfCount = 0;
-  let windowScore = 0;
-  for (const c of floor.cells) {
-    if (c.item) {shelfCount += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
-    for (const w of [c.wall.top, c.wall.left]) {
-      windowScore += WALL_WINDOW_SCORE[w] ?? 0;
-    }
-  }
+  const { storage, windows } = computeFloorScores(floor);
 
   return (
     <div
@@ -41,8 +32,8 @@ function FloorStats({ floor }: { floor: FloorPlan }) {
         padding: "4px 10px",
       }}
     >
-      <span>収納: {shelfCount}</span>
-      <span>窓: {windowScore}</span>
+      <span>収納: {storage}</span>
+      <span>窓: {windows}</span>
     </div>
   );
 }
@@ -164,94 +155,97 @@ export function App() {
             push({ activeFloorId: imported.id, building: next });
           }}
         />
-        <div className="flex-1 overflow-hidden relative flex flex-col" style={{ background: "var(--paper)" }}>
+        <div
+          className="flex-1 overflow-hidden relative flex flex-col"
+          style={{ background: "var(--paper)" }}
+        >
           <FloorStats floor={floor} />
           <div className="flex-1 overflow-hidden relative">
-          <FloorCanvas
-            ref={canvasRef}
-            floor={floor}
-            ghostFloors={ghostFloors}
-            cellSize={building.cellSize}
-            darkMode={dark}
-            tool={tool}
-            onSetWall={(cellIndex, edge) => {
-              if (tool.kind !== "wall") {
-                return;
+            <FloorCanvas
+              ref={canvasRef}
+              floor={floor}
+              ghostFloors={ghostFloors}
+              cellSize={building.cellSize}
+              darkMode={dark}
+              tool={tool}
+              onSetWall={(cellIndex, edge) => {
+                if (tool.kind !== "wall") {
+                  return;
+                }
+                dispatch({
+                  cellIndex,
+                  edge,
+                  floorId: floor.id,
+                  type: "SET_WALL",
+                  wallType: tool.wallType,
+                });
+              }}
+              onSetFloorType={(cellIndex, floorType) =>
+                dispatch({
+                  cellIndex,
+                  floorId: floor.id,
+                  floorType,
+                  type: "SET_FLOOR_TYPE",
+                })
               }
-              dispatch({
-                cellIndex,
-                edge,
-                floorId: floor.id,
-                type: "SET_WALL",
-                wallType: tool.wallType,
-              });
-            }}
-            onSetFloorType={(cellIndex, floorType) =>
-              dispatch({
-                cellIndex,
-                floorId: floor.id,
-                floorType,
-                type: "SET_FLOOR_TYPE",
-              })
-            }
-            onFillRoom={(cellIndex) => {
-              if (tool.kind !== "floor" || tool.floorType === null) {
-                return;
+              onFillRoom={(cellIndex) => {
+                if (tool.kind !== "floor" || tool.floorType === null) {
+                  return;
+                }
+                dispatch({
+                  cellIndex,
+                  floorId: floor.id,
+                  floorType: tool.floorType,
+                  type: "FILL_ROOM",
+                });
+              }}
+              onPlaceItem={(cellIndex) => {
+                if (tool.kind !== "item") {
+                  return;
+                }
+                dispatch({
+                  cellIndex,
+                  floorId: floor.id,
+                  item: {
+                    rotation: 0,
+                    type: (tool as { kind: "item"; itemType: ItemType }).itemType,
+                  },
+                  type: "PLACE_ITEM",
+                });
+              }}
+              onRotateItem={(cellIndex) =>
+                dispatch({ cellIndex, floorId: floor.id, type: "ROTATE_ITEM" })
               }
-              dispatch({
-                cellIndex,
-                floorId: floor.id,
-                floorType: tool.floorType,
-                type: "FILL_ROOM",
-              });
-            }}
-            onPlaceItem={(cellIndex) => {
-              if (tool.kind !== "item") {
-                return;
+              onMoveItem={(fromIndex, toIndex) =>
+                dispatch({
+                  floorId: floor.id,
+                  fromIndex,
+                  toIndex,
+                  type: "MOVE_ITEM",
+                })
               }
-              dispatch({
-                cellIndex,
-                floorId: floor.id,
-                item: {
-                  rotation: 0,
-                  type: (tool as { kind: "item"; itemType: ItemType }).itemType,
-                },
-                type: "PLACE_ITEM",
-              });
-            }}
-            onRotateItem={(cellIndex) =>
-              dispatch({ cellIndex, floorId: floor.id, type: "ROTATE_ITEM" })
-            }
-            onMoveItem={(fromIndex, toIndex) =>
-              dispatch({
-                floorId: floor.id,
-                fromIndex,
-                toIndex,
-                type: "MOVE_ITEM",
-              })
-            }
-            onPasteRegion={(originIndex: number, region: CopiedRegion) =>
-              dispatch({
-                floorId: floor.id,
-                originIndex,
-                region,
-                type: "PASTE_REGION",
-              })
-            }
-            onEraseRegion={(x1, y1, x2, y2) =>
-              dispatch({
-                floorId: floor.id,
-                type: "ERASE_REGION",
-                x1,
-                x2,
-                y1,
-                y2,
-              })
-            }
-            onEraseCell={(cellIndex) =>
-              dispatch({ cellIndex, floorId: floor.id, type: "ERASE_CELL" })
-            }
-          />
+              onPasteRegion={(originIndex: number, region: CopiedRegion) =>
+                dispatch({
+                  floorId: floor.id,
+                  originIndex,
+                  region,
+                  type: "PASTE_REGION",
+                })
+              }
+              onEraseRegion={(x1, y1, x2, y2) =>
+                dispatch({
+                  floorId: floor.id,
+                  type: "ERASE_REGION",
+                  x1,
+                  x2,
+                  y1,
+                  y2,
+                })
+              }
+              onEraseCell={(cellIndex) =>
+                dispatch({ cellIndex, floorId: floor.id, type: "ERASE_CELL" })
+              }
+            />
           </div>
         </div>
       </div>

--- a/packages/madories/src/components/ToolSheet.tsx
+++ b/packages/madories/src/components/ToolSheet.tsx
@@ -252,6 +252,7 @@ function ToolPanelContent({
                   onClick={() => {
                     lastItemTypeRef.current[def.category] = def.type;
                     onToolChange({ itemType: def.type, kind: "item" });
+                    onClose?.();
                   }}
                 >
                   {def.label}

--- a/packages/madories/src/components/hooks/usePointerHandlers.ts
+++ b/packages/madories/src/components/hooks/usePointerHandlers.ts
@@ -330,6 +330,7 @@ export function usePointerHandlers(props: Props): {
           if (idx !== null && floor.cells[idx].item) {
             onRotateItem(idx);
             setSelectedItemCell(idx);
+            selectionRef.current = null;
           } else {
             setSelectedItemCell(null);
           }

--- a/packages/madories/src/components/hooks/usePointerHandlers.ts
+++ b/packages/madories/src/components/hooks/usePointerHandlers.ts
@@ -330,6 +330,7 @@ export function usePointerHandlers(props: Props): {
           if (idx !== null && floor.cells[idx].item) {
             onRotateItem(idx);
             setSelectedItemCell(idx);
+            // Must clear before onSelectionChangeRef fires below, otherwise popup stays visible
             selectionRef.current = null;
           } else {
             setSelectedItemCell(null);

--- a/packages/madories/src/draw/export.ts
+++ b/packages/madories/src/draw/export.ts
@@ -9,6 +9,7 @@ import { drawRoomLabels } from "../floor/roomDetection";
 const LABEL_HEIGHT = 24;
 const BG = "#F5F0E8";
 const DIM_COLOR = "#5A4A3A";
+const GRID_COLOR = "rgba(90,74,58,0.25)";
 const DIM_MARGIN = 28; // Px reserved for dimension rulers
 
 // 1 cell = 0.5 tatami = 910mm
@@ -159,7 +160,7 @@ export function renderFloorToCanvas(floor: FloorPlan, cellSize: number): HTMLCan
 
   ctx.save();
   ctx.translate(DIM_MARGIN - x1 * cellSize, DIM_MARGIN - y1 * cellSize);
-  drawGrid(ctx, floor.width, floor.height, cellSize, DIM_COLOR);
+  drawGrid(ctx, floor.width, floor.height, cellSize, GRID_COLOR);
   drawWalls(ctx, floor, cellSize, { ink: DIM_COLOR, windowBlue: "#4A90D9" });
   drawItems(ctx, floor, cellSize);
   drawRoomLabels(ctx, floor, cellSize, DIM_COLOR);

--- a/packages/madories/src/draw/export.ts
+++ b/packages/madories/src/draw/export.ts
@@ -11,11 +11,25 @@ import { drawRoomLabels } from "../floor/roomDetection";
 const LABEL_HEIGHT = 24;
 const BG = "#F5F0E8";
 const DIM_COLOR = "#5A4A3A";
-const GRID_COLOR = "rgba(90,74,58,0.25)";
+const GRID_COLOR = "rgba(90,74,58,0.25)"; // Same RGB as DIM_COLOR at 25% opacity
 const DIM_MARGIN = 28; // Px reserved for dimension rulers
 
 // 1 cell = 0.5 tatami = 910mm
 export const MM_PER_CELL = 910;
+
+export function computeFloorScores(floor: FloorPlan): { storage: number; windows: number } {
+  let storage = 0;
+  let windows = 0;
+  for (const c of floor.cells) {
+    if (c.item) {
+      storage += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;
+    }
+    for (const w of [c.wall.top, c.wall.left]) {
+      windows += WALL_WINDOW_SCORE[w] ?? 0;
+    }
+  }
+  return { storage, windows };
+}
 
 // For drawing crop (includes floor color and items)
 export function computeBounds(
@@ -275,10 +289,9 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
   let totalWindows = 0;
   for (const r of valid) {
     totalTsubo += r.tsubo;
-    for (const c of r.floor.cells) {
-      if (c.item) {totalStorage += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
-      for (const w of [c.wall.top, c.wall.left]) {totalWindows += WALL_WINDOW_SCORE[w] ?? 0;}
-    }
+    const scores = computeFloorScores(r.floor);
+    totalStorage += scores.storage;
+    totalWindows += scores.windows;
   }
   const FOOTER_HEIGHT = LABEL_HEIGHT;
   const totalW = Math.max(...valid.map((r) => r.canvas.width));
@@ -298,12 +311,7 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     ctx.font = "bold 13px 'IBM Plex Mono', monospace";
     ctx.textAlign = "left";
     ctx.textBaseline = "alphabetic";
-    let storage = 0;
-    let windows = 0;
-    for (const c of floor.cells) {
-      if (c.item) {storage += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
-      for (const w of [c.wall.top, c.wall.left]) {windows += WALL_WINDOW_SCORE[w] ?? 0;}
-    }
+    const { storage, windows } = computeFloorScores(floor);
     ctx.fillText(`${name}  ${tsubo.toFixed(2)}坪  収納:${storage}  窓:${windows}`, 8, offsetY + 16);
     offsetY += LABEL_HEIGHT;
     ctx.drawImage(canvas, 0, offsetY);
@@ -315,7 +323,11 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
   ctx.font = "bold 13px 'IBM Plex Mono', monospace";
   ctx.textAlign = "right";
   ctx.textBaseline = "alphabetic";
-  ctx.fillText(`合計 ${totalTsubo.toFixed(2)}坪  収納:${totalStorage}  窓:${totalWindows}`, totalW - 8, offsetY + 16);
+  ctx.fillText(
+    `合計 ${totalTsubo.toFixed(2)}坪  収納:${totalStorage}  窓:${totalWindows}`,
+    totalW - 8,
+    offsetY + 16,
+  );
 
   combined.toBlob((blob) => {
     if (!blob) {

--- a/packages/madories/src/draw/export.ts
+++ b/packages/madories/src/draw/export.ts
@@ -1,5 +1,7 @@
 import type { FloorPlan } from "../types";
+import { WALL_WINDOW_SCORE } from "../types";
 import { floorTypeToColor } from "../components/toolMode";
+import { ITEM_DEF_MAP } from "../items";
 import { drawGrid } from "./drawGrid";
 import { drawItems } from "./drawItems";
 import { drawVoidCells } from "./drawVoid";
@@ -254,11 +256,13 @@ export function exportFloorPng(floor: FloorPlan, cellSize: number): void {
 export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void {
   const tsuboPerFloor = floors.map((f) => ({
     canvas: renderFloorToCanvas(f, cellSize),
+    floor: f,
     name: f.name,
     tsubo: f.cells.filter((c) => c.floorType !== null).length / 4,
   }));
   const valid = tsuboPerFloor.filter((r) => r.canvas !== null) as {
     canvas: HTMLCanvasElement;
+    floor: FloorPlan;
     name: string;
     tsubo: number;
   }[];
@@ -266,7 +270,16 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     return;
   }
 
-  const totalTsubo = valid.reduce((sum, r) => sum + r.tsubo, 0);
+  let totalTsubo = 0;
+  let totalStorage = 0;
+  let totalWindows = 0;
+  for (const r of valid) {
+    totalTsubo += r.tsubo;
+    for (const c of r.floor.cells) {
+      if (c.item) {totalStorage += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
+      for (const w of [c.wall.top, c.wall.left]) {totalWindows += WALL_WINDOW_SCORE[w] ?? 0;}
+    }
+  }
   const FOOTER_HEIGHT = LABEL_HEIGHT;
   const totalW = Math.max(...valid.map((r) => r.canvas.width));
   const totalH = valid.reduce((sum, r) => sum + r.canvas.height + LABEL_HEIGHT, 0) + FOOTER_HEIGHT;
@@ -280,12 +293,18 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
   ctx.fillRect(0, 0, totalW, totalH);
 
   let offsetY = 0;
-  for (const { name, tsubo, canvas } of valid) {
+  for (const { name, tsubo, canvas, floor } of valid) {
     ctx.fillStyle = DIM_COLOR;
     ctx.font = "bold 13px 'IBM Plex Mono', monospace";
     ctx.textAlign = "left";
     ctx.textBaseline = "alphabetic";
-    ctx.fillText(`${name}  ${tsubo.toFixed(2)}坪`, 8, offsetY + 16);
+    let storage = 0;
+    let windows = 0;
+    for (const c of floor.cells) {
+      if (c.item) {storage += ITEM_DEF_MAP.get(c.item.type)?.storageScore ?? 0;}
+      for (const w of [c.wall.top, c.wall.left]) {windows += WALL_WINDOW_SCORE[w] ?? 0;}
+    }
+    ctx.fillText(`${name}  ${tsubo.toFixed(2)}坪  収納:${storage}  窓:${windows}`, 8, offsetY + 16);
     offsetY += LABEL_HEIGHT;
     ctx.drawImage(canvas, 0, offsetY);
     offsetY += canvas.height;
@@ -296,7 +315,7 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
   ctx.font = "bold 13px 'IBM Plex Mono', monospace";
   ctx.textAlign = "right";
   ctx.textBaseline = "alphabetic";
-  ctx.fillText(`合計 ${totalTsubo.toFixed(2)}坪`, totalW - 8, offsetY + 16);
+  ctx.fillText(`合計 ${totalTsubo.toFixed(2)}坪  収納:${totalStorage}  窓:${totalWindows}`, totalW - 8, offsetY + 16);
 
   combined.toBlob((blob) => {
     if (!blob) {

--- a/packages/madories/src/draw/icons/cache.ts
+++ b/packages/madories/src/draw/icons/cache.ts
@@ -30,7 +30,7 @@ export function getCachedIcon(
   const oc = new OffscreenCanvas(boundW, boundH);
   const ctx = oc.getContext("2d")!;
   ctx.translate(boundW / 2, boundH / 2);
-  ctx.rotate((-rotation * Math.PI) / 180);
+  ctx.rotate((rotation * Math.PI) / 180);
 
   const draw = ICON_REGISTRY.get(type);
   if (draw) {

--- a/packages/madories/src/draw/icons/kitchen.ts
+++ b/packages/madories/src/draw/icons/kitchen.ts
@@ -8,8 +8,8 @@ export function drawKitchen(
   h: number,
   darkMode = false,
 ): void {
-  const counterFill = darkMode ? "#7a6a4a" : "#EDE0C8";
-  const counterStroke = darkMode ? "#9a8a5a" : "#C8A878";
+  const counterFill = darkMode ? "#5a5a5a" : "#E0E8E8";
+  const counterStroke = darkMode ? "#7a7a7a" : "#90A8A8";
   const sinkFill = darkMode ? "#5aaac0" : "#B8E8EE";
   const sinkStroke = darkMode ? "#7acce0" : "#4682B4";
   const drainFill = darkMode ? "#3a7090" : "#4682B4";
@@ -109,7 +109,7 @@ export function drawKitchen(
     drawDivider(midRegionY);
 
     // Counter middle: カウンター質感のみ
-    ctx.fillStyle = darkMode ? "#6a5a3a" : "#E8D4B0";
+    ctx.fillStyle = darkMode ? "#505050" : "#D8E4E4";
     ctx.fillRect(px, midRegionY, w, third);
 
     drawDivider(stoveRegionY);

--- a/packages/madories/src/items.ts
+++ b/packages/madories/src/items.ts
@@ -8,6 +8,7 @@ export interface ItemDef {
   w: number; // マス数（回転前）
   h: number;
   category: ItemCategory;
+  storageScore?: number;
 }
 
 export const ITEM_DEFS: ItemDef[] = [
@@ -31,8 +32,8 @@ export const ITEM_DEFS: ItemDef[] = [
   { category: "キッチン", h: 1, label: "冷蔵庫", type: "fridge", w: 1 },
   { category: "リビング", h: 2, label: "ソファ", type: "sofa", w: 1 },
   { category: "リビング", h: 2, label: "テレビ", type: "tv", w: 1 },
-  { category: "リビング", h: 1, label: "棚(1)", type: "shelf1", w: 1 },
-  { category: "リビング", h: 2, label: "棚(2)", type: "shelf2", w: 1 },
+  { category: "リビング", h: 1, label: "棚(1)", storageScore: 1, type: "shelf1", w: 1 },
+  { category: "リビング", h: 2, label: "棚(2)", storageScore: 2, type: "shelf2", w: 1 },
   {
     category: "寝室",
     h: 2,

--- a/packages/madories/src/types.ts
+++ b/packages/madories/src/types.ts
@@ -1,5 +1,10 @@
 export type WallType = "none" | "solid" | "solid_thin" | "window_full" | "window_center";
 
+export const WALL_WINDOW_SCORE: Partial<Record<WallType, number>> = {
+  window_center: 0.5,
+  window_full: 1,
+};
+
 export type FloorType = "wood" | "water" | "tatami" | "concrete" | "void";
 
 export interface WallFlags {


### PR DESCRIPTION
## 概要

- UI・画像出力時に収納スコア（棚段数）と窓スコア（全窓/中央窓）を表示
- 家具クリック時にメニュー自動クローズ、アイコン回転方向の不整合を解消
- キッチンをステンレス系色に変更し木材床と視覚的に区別、グリッド線を薄く

## 変更内容

🐛 アイコン回転方向をCWに修正
🐛 選択メニューを家具クリック時に閉じる
🎨 キッチンをステンレス系色に変更し木材床と区別
🎨 画像出力のグリッド線を薄く
✨ 収納・窓スコア表示

## テスト

- 家具配置時のメニュー動作確認
- 画像出力時のスコア表示確認
- キッチン・グリッド線の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)