### PR TITLE
✨ madories: 凡例エクスポート機能実装

### DIFF
--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDarkMode } from "@mijime/theme/useDarkMode";
 import { computeFloorScores, exportAllFloorsPng } from "../draw/export";
-import { buildShareUrl, encodeFloors } from "../floor/share";
+import { buildShareUrl, encodeFloors, mergeFloors } from "../floor/share";
 import { loadFromFile, loadFromStorage, saveToFile, saveToStorage } from "../storage";
 import { createBuilding, reducer } from "../store";
 import type { CopiedRegion, ItemType } from "../types";
@@ -143,16 +143,12 @@ export function App() {
           onRotateFloor={() => dispatch({ floorId: floor.id, type: "ROTATE_FLOOR" })}
         />
         <DslPanel
-          floor={floor}
-          onApplyFloor={(imported) => {
-            dispatch({ floor: imported, floorId: floor.id, type: "REPLACE_FLOOR" });
-          }}
-          onImportFloor={(imported) => {
-            const next = {
-              ...building,
-              floors: [...building.floors, imported],
-            };
-            push({ activeFloorId: imported.id, building: next });
+          floors={building.floors}
+          onApplyFloors={(parsed) => {
+            push({
+              activeFloorId,
+              building: { ...building, floors: mergeFloors(building.floors, parsed) },
+            });
           }}
         />
         <div

--- a/packages/madories/src/components/DslPanel.tsx
+++ b/packages/madories/src/components/DslPanel.tsx
@@ -1,38 +1,27 @@
-import { Copy, Download, Upload } from "lucide-react";
+import { Download, Upload } from "lucide-react";
 import { useState } from "react";
-import { dslToFloor, floorToDsl } from "../floor/dsl";
+import { floorsToText, textToFloors } from "../floor/share";
 import type { FloorPlan } from "../types";
 
 interface Props {
-  floor: FloorPlan;
-  onApplyFloor: (floor: FloorPlan) => void;
-  onImportFloor: (floor: FloorPlan) => void;
+  floors: FloorPlan[];
+  onApplyFloors: (floors: FloorPlan[]) => void;
 }
 
-export function DslPanel({ floor, onApplyFloor, onImportFloor }: Props) {
+export function DslPanel({ floors, onApplyFloors }: Props) {
   const [open, setOpen] = useState(false);
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   function handleExport() {
-    setText(floorToDsl(floor));
+    setText(floorsToText(floors));
     setError(null);
   }
 
   function handleApply() {
     try {
-      const imported = dslToFloor(text);
-      onApplyFloor({ ...imported, id: floor.id });
-      setError(null);
-    } catch (error) {
-      setError(String(error));
-    }
-  }
-
-  function handleCopy() {
-    try {
-      const imported = dslToFloor(text);
-      onImportFloor(imported);
+      const imported = textToFloors(text);
+      onApplyFloors(imported);
       setError(null);
     } catch (error) {
       setError(String(error));
@@ -63,7 +52,7 @@ export function DslPanel({ floor, onApplyFloor, onImportFloor }: Props) {
           <button
             onClick={() => {
               setOpen(true);
-              setText(floorToDsl(floor));
+              setText(floorsToText(floors));
               setError(null);
             }}
             style={{
@@ -149,9 +138,6 @@ export function DslPanel({ floor, onApplyFloor, onImportFloor }: Props) {
       </button>
       <button onClick={handleApply} style={btnStyle}>
         <Upload size={14} /> apply
-      </button>
-      <button onClick={handleCopy} style={btnStyle}>
-        <Copy size={14} /> copy
       </button>
     </div>
   );

--- a/packages/madories/src/components/ToolSheet.tsx
+++ b/packages/madories/src/components/ToolSheet.tsx
@@ -19,13 +19,13 @@ import type { ItemCategory } from "../items";
 import { ITEM_CATEGORIES, ITEM_DEFS } from "../items";
 import type { ItemType } from "../types";
 import type { WallType } from "../types";
-import { FLOOR_TYPES, floorTypeToColor, type ToolMode } from "./toolMode";
+import { FLOOR_TYPES, floorTypeToSwatchStyle, type ToolMode } from "./toolMode";
 
 const WALL_TYPES: { type: WallType; label: string }[] = [
   { label: "壁", type: "solid" },
-  { label: "薄い壁", type: "solid_thin" },
+  { label: "開口部", type: "solid_thin" },
   { label: "全窓", type: "window_full" },
-  { label: "中央窓", type: "window_center" },
+  { label: "半窓", type: "window_center" },
   { label: "なし", type: "none" },
 ];
 
@@ -171,7 +171,6 @@ function ToolPanelContent({
       {tool.kind === "floor" && (
         <div style={{ display: "grid", gap: "3px", gridTemplateColumns: "1fr 1fr" }}>
           {FLOOR_TYPES.map((entry) => {
-            const color = floorTypeToColor(entry.type, darkMode);
             const active = tool.floorType === entry.type;
             return (
               <button
@@ -190,7 +189,7 @@ function ToolPanelContent({
               >
                 <span
                   style={{
-                    background: color ?? undefined,
+                    ...floorTypeToSwatchStyle(entry.type, darkMode),
                     border: "1px solid var(--border)",
                     borderRadius: "2px",
                     display: "inline-block",

--- a/packages/madories/src/components/toolMode.ts
+++ b/packages/madories/src/components/toolMode.ts
@@ -14,8 +14,8 @@ export const FLOOR_TYPES: {
   type: FloorType | null;
 }[] = [
   { dark: null, label: "空白", light: null, type: null },
-  { dark: "#5c4a28", label: "木材", light: "#f5deb3", type: "wood" },
-  { dark: "#1a2a3a", label: "水回り", light: "#d6eef8", type: "water" },
+  { dark: "#5c4a28", label: "フローリング", light: "#f5deb3", type: "wood" },
+  { dark: "#1a2a3a", label: "タイル", light: "#d6eef8", type: "water" },
   { dark: "#3a2e1a", label: "畳", light: "#c8b878", type: "tatami" },
   { dark: "#3a3a3a", label: "土間", light: "#d0d0d0", type: "concrete" },
   { dark: "#2a2518", label: "吹き抜け", light: "#fff8e8", type: "void" },
@@ -27,4 +27,26 @@ export function floorTypeToColor(type: FloorType | null, darkMode: boolean): str
     return null;
   }
   return darkMode ? entry.dark : entry.light;
+}
+
+export function floorTypeToSwatchStyle(
+  type: FloorType | null,
+  darkMode: boolean,
+): React.CSSProperties {
+  const color = floorTypeToColor(type, darkMode);
+  const base: React.CSSProperties = { background: color ?? undefined };
+
+  if (type === "tatami") {
+    const line = darkMode ? "rgba(255,220,120,0.3)" : "rgba(100,70,20,0.25)";
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><line x1='0' y1='5' x2='10' y2='5' stroke='${line}' stroke-width='1'/><rect x='0.5' y='0.5' width='9' height='9' fill='none' stroke='${line}' stroke-width='0.8'/></svg>`;
+    return { ...base, backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(svg)}")` };
+  }
+
+  if (type === "void") {
+    const line = darkMode ? "rgba(200,180,140,0.5)" : "rgba(90,74,58,0.5)";
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><line x1='0' y1='0' x2='10' y2='10' stroke='${line}' stroke-width='1' stroke-dasharray='2,2'/><line x1='10' y1='0' x2='0' y2='10' stroke='${line}' stroke-width='1' stroke-dasharray='2,2'/></svg>`;
+    return { ...base, backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(svg)}")` };
+  }
+
+  return base;
 }

--- a/packages/madories/src/draw/export.ts
+++ b/packages/madories/src/draw/export.ts
@@ -1,7 +1,7 @@
 import type { FloorPlan, ItemType, WallType } from "../types";
 import { WALL_WINDOW_SCORE } from "../types";
 import { FLOOR_TYPES, floorTypeToColor } from "../components/toolMode";
-import { ITEM_DEF_MAP, ITEM_GROUP_REPRESENTATIVE, ITEM_LEGEND_LABEL } from "../items";
+import { ITEM_DEF_MAP, ITEM_GROUP_REPRESENTATIVE, ITEM_LEGEND_LABEL, WALL_LEGEND_LABEL } from "../items";
 import { getCachedIcon } from "./icons/cache";
 import { drawGrid } from "./drawGrid";
 import { drawItems } from "./drawItems";
@@ -13,13 +13,6 @@ import { drawRoomLabels } from "../floor/roomDetection";
 const LABEL_HEIGHT = 24;
 const BG = "#F5F0E8";
 const DIM_COLOR = "#5A4A3A";
-
-const WALL_LABELS: Partial<Record<WallType, string>> = {
-  solid: "壁",
-  solid_thin: "開口部",
-  window_center: "半窓",
-  window_full: "全窓",
-};
 const GRID_COLOR = "rgba(90,74,58,0.25)"; // Same RGB as DIM_COLOR at 25% opacity
 const DIM_MARGIN = 28; // Px reserved for dimension rulers
 
@@ -310,13 +303,21 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     totalWindows += scores.windows;
     floorScores.set(r.floor.id, scores);
     for (const c of r.floor.cells) {
-      if (c.floorType !== null) {usedFloorTypeSet.add(c.floorType);}
+      if (c.floorType !== null) {
+        usedFloorTypeSet.add(c.floorType);
+      }
       if (c.item) {
         const rep = ITEM_GROUP_REPRESENTATIVE.get(c.item.type) ?? c.item.type;
-        if (!seenItemTypes.has(rep)) { seenItemTypes.add(rep); usedItemTypes.push(rep); }
+        if (!seenItemTypes.has(rep)) {
+          seenItemTypes.add(rep);
+          usedItemTypes.push(rep);
+        }
       }
       for (const wt of [c.wall.top, c.wall.left] as WallType[]) {
-        if (wt !== "none" && !seenWallTypes.has(wt)) { seenWallTypes.add(wt); usedWallTypes.push(wt); }
+        if (wt !== "none" && !seenWallTypes.has(wt)) {
+          seenWallTypes.add(wt);
+          usedWallTypes.push(wt);
+        }
       }
     }
   }
@@ -336,13 +337,17 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     return Math.ceil(count / perRow);
   }
 
-  const floorLegendRows = legendEntries.length > 0 ? countRows(FLOOR_ITEM_W, legendEntries.length) : 0;
-  const wallLegendRows = usedWallTypes.length > 0 ? countRows(WALL_ITEM_W, usedWallTypes.length) : 0;
-  const itemLegendRows = usedItemTypes.length > 0 ? countRows(ICON_ITEM_W, usedItemTypes.length) : 0;
+  const floorLegendRows =
+    legendEntries.length > 0 ? countRows(FLOOR_ITEM_W, legendEntries.length) : 0;
+  const wallLegendRows =
+    usedWallTypes.length > 0 ? countRows(WALL_ITEM_W, usedWallTypes.length) : 0;
+  const itemLegendRows =
+    usedItemTypes.length > 0 ? countRows(ICON_ITEM_W, usedItemTypes.length) : 0;
   const FLOOR_LEGEND_HEIGHT = floorLegendRows * LABEL_HEIGHT;
   const WALL_LEGEND_HEIGHT = wallLegendRows * LABEL_HEIGHT;
   const ITEM_LEGEND_HEIGHT = itemLegendRows * (ICON_SIZE + 16);
-  const FOOTER_HEIGHT = LABEL_HEIGHT + FLOOR_LEGEND_HEIGHT + WALL_LEGEND_HEIGHT + ITEM_LEGEND_HEIGHT;
+  const FOOTER_HEIGHT =
+    LABEL_HEIGHT + FLOOR_LEGEND_HEIGHT + WALL_LEGEND_HEIGHT + ITEM_LEGEND_HEIGHT;
   const totalH = valid.reduce((sum, r) => sum + r.canvas.height + LABEL_HEIGHT, 0) + FOOTER_HEIGHT;
 
   const combined = document.createElement("canvas");
@@ -472,40 +477,61 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
         case "solid": {
           ctx.strokeStyle = DIM_COLOR;
           ctx.lineWidth = 3;
-          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx, ly);
+          ctx.lineTo(lx + WALL_LINE_W, ly);
+          ctx.stroke();
           break;
         }
         case "solid_thin": {
           ctx.strokeStyle = DIM_COLOR;
           ctx.lineWidth = 1.5;
           ctx.setLineDash([2, 1.5]);
-          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx, ly);
+          ctx.lineTo(lx + WALL_LINE_W, ly);
+          ctx.stroke();
           ctx.setLineDash([]);
           break;
         }
         case "window_full": {
           ctx.strokeStyle = DIM_COLOR;
           ctx.lineWidth = 1.5;
-          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx, ly);
+          ctx.lineTo(lx + WALL_LINE_W, ly);
+          ctx.stroke();
           ctx.strokeStyle = windowBlue;
           ctx.lineWidth = 4;
-          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx, ly);
+          ctx.lineTo(lx + WALL_LINE_W, ly);
+          ctx.stroke();
           break;
         }
         case "window_center": {
           ctx.strokeStyle = DIM_COLOR;
           ctx.lineWidth = 3;
-          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W * 0.25, ly); ctx.stroke();
-          ctx.beginPath(); ctx.moveTo(lx + WALL_LINE_W * 0.75, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx, ly);
+          ctx.lineTo(lx + WALL_LINE_W * 0.25, ly);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx + WALL_LINE_W * 0.75, ly);
+          ctx.lineTo(lx + WALL_LINE_W, ly);
+          ctx.stroke();
           ctx.strokeStyle = windowBlue;
           ctx.lineWidth = 4;
-          ctx.beginPath(); ctx.moveTo(lx + WALL_LINE_W * 0.25, ly); ctx.lineTo(lx + WALL_LINE_W * 0.75, ly); ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(lx + WALL_LINE_W * 0.25, ly);
+          ctx.lineTo(lx + WALL_LINE_W * 0.75, ly);
+          ctx.stroke();
           break;
         }
       }
       ctx.restore();
       ctx.fillStyle = DIM_COLOR;
-      ctx.fillText(WALL_LABELS[wt] ?? wt, lx + WALL_LINE_W + 4, ly);
+      ctx.fillText(WALL_LEGEND_LABEL[wt] ?? wt, lx + WALL_LINE_W + 4, ly);
     }
   }
   offsetY += WALL_LEGEND_HEIGHT;
@@ -519,15 +545,23 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     for (let i = 0; i < usedItemTypes.length; i++) {
       const type = usedItemTypes[i];
       const def = ITEM_DEF_MAP.get(type);
-      if (!def) {continue;}
+      if (!def) {
+        continue;
+      }
       const col = i % perRow;
       const row = Math.floor(i / perRow);
       const lx = MARGIN + col * ICON_ITEM_W;
       const ly = offsetY + row * rowH + 4;
       const oc = getCachedIcon(type, 0, ICON_SIZE);
-      if (oc) {ctx.drawImage(oc, lx, ly, ICON_SIZE, ICON_SIZE);}
+      if (oc) {
+        ctx.drawImage(oc, lx, ly, ICON_SIZE, ICON_SIZE);
+      }
       ctx.fillStyle = DIM_COLOR;
-      ctx.fillText(ITEM_LEGEND_LABEL.get(type) ?? def.label, lx + ICON_SIZE / 2, ly + ICON_SIZE + 2);
+      ctx.fillText(
+        ITEM_LEGEND_LABEL.get(type) ?? def.label,
+        lx + ICON_SIZE / 2,
+        ly + ICON_SIZE + 2,
+      );
     }
   }
 

--- a/packages/madories/src/draw/export.ts
+++ b/packages/madories/src/draw/export.ts
@@ -1,9 +1,11 @@
-import type { FloorPlan } from "../types";
+import type { FloorPlan, ItemType, WallType } from "../types";
 import { WALL_WINDOW_SCORE } from "../types";
-import { floorTypeToColor } from "../components/toolMode";
-import { ITEM_DEF_MAP } from "../items";
+import { FLOOR_TYPES, floorTypeToColor } from "../components/toolMode";
+import { ITEM_DEF_MAP, ITEM_GROUP_REPRESENTATIVE, ITEM_LEGEND_LABEL } from "../items";
+import { getCachedIcon } from "./icons/cache";
 import { drawGrid } from "./drawGrid";
 import { drawItems } from "./drawItems";
+import { drawTatamiCells } from "./drawTatami";
 import { drawVoidCells } from "./drawVoid";
 import { drawWalls } from "./drawWalls";
 import { drawRoomLabels } from "../floor/roomDetection";
@@ -11,6 +13,13 @@ import { drawRoomLabels } from "../floor/roomDetection";
 const LABEL_HEIGHT = 24;
 const BG = "#F5F0E8";
 const DIM_COLOR = "#5A4A3A";
+
+const WALL_LABELS: Partial<Record<WallType, string>> = {
+  solid: "壁",
+  solid_thin: "開口部",
+  window_center: "半窓",
+  window_full: "全窓",
+};
 const GRID_COLOR = "rgba(90,74,58,0.25)"; // Same RGB as DIM_COLOR at 25% opacity
 const DIM_MARGIN = 28; // Px reserved for dimension rulers
 
@@ -176,6 +185,7 @@ export function renderFloorToCanvas(floor: FloorPlan, cellSize: number): HTMLCan
 
   ctx.save();
   ctx.translate(DIM_MARGIN - x1 * cellSize, DIM_MARGIN - y1 * cellSize);
+  drawTatamiCells(ctx, floor, cellSize, false);
   drawGrid(ctx, floor.width, floor.height, cellSize, GRID_COLOR);
   drawWalls(ctx, floor, cellSize, { ink: DIM_COLOR, windowBlue: "#4A90D9" });
   drawItems(ctx, floor, cellSize);
@@ -287,14 +297,52 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
   let totalTsubo = 0;
   let totalStorage = 0;
   let totalWindows = 0;
+  const usedFloorTypeSet = new Set<string>();
+  const seenItemTypes = new Set<ItemType>();
+  const usedItemTypes: ItemType[] = [];
+  const seenWallTypes = new Set<WallType>();
+  const usedWallTypes: WallType[] = [];
+  const floorScores = new Map<string, { storage: number; windows: number }>();
   for (const r of valid) {
     totalTsubo += r.tsubo;
     const scores = computeFloorScores(r.floor);
     totalStorage += scores.storage;
     totalWindows += scores.windows;
+    floorScores.set(r.floor.id, scores);
+    for (const c of r.floor.cells) {
+      if (c.floorType !== null) {usedFloorTypeSet.add(c.floorType);}
+      if (c.item) {
+        const rep = ITEM_GROUP_REPRESENTATIVE.get(c.item.type) ?? c.item.type;
+        if (!seenItemTypes.has(rep)) { seenItemTypes.add(rep); usedItemTypes.push(rep); }
+      }
+      for (const wt of [c.wall.top, c.wall.left] as WallType[]) {
+        if (wt !== "none" && !seenWallTypes.has(wt)) { seenWallTypes.add(wt); usedWallTypes.push(wt); }
+      }
+    }
   }
-  const FOOTER_HEIGHT = LABEL_HEIGHT;
+  const legendEntries = FLOOR_TYPES.filter((e) => e.type !== null && usedFloorTypeSet.has(e.type));
+  const ICON_SIZE = 20;
+  const FLOOR_SW = 16;
+  const WALL_LINE_W = 32;
+  const WALL_ITEM_W = WALL_LINE_W + 4 + 40;
+  const FLOOR_ITEM_W = FLOOR_SW + 4 + 72;
+  const ICON_ITEM_W = ICON_SIZE + 28;
   const totalW = Math.max(...valid.map((r) => r.canvas.width));
+  const MARGIN = 8;
+  const usableW = totalW - MARGIN * 2;
+
+  function countRows(itemW: number, count: number): number {
+    const perRow = Math.max(1, Math.floor(usableW / itemW));
+    return Math.ceil(count / perRow);
+  }
+
+  const floorLegendRows = legendEntries.length > 0 ? countRows(FLOOR_ITEM_W, legendEntries.length) : 0;
+  const wallLegendRows = usedWallTypes.length > 0 ? countRows(WALL_ITEM_W, usedWallTypes.length) : 0;
+  const itemLegendRows = usedItemTypes.length > 0 ? countRows(ICON_ITEM_W, usedItemTypes.length) : 0;
+  const FLOOR_LEGEND_HEIGHT = floorLegendRows * LABEL_HEIGHT;
+  const WALL_LEGEND_HEIGHT = wallLegendRows * LABEL_HEIGHT;
+  const ITEM_LEGEND_HEIGHT = itemLegendRows * (ICON_SIZE + 16);
+  const FOOTER_HEIGHT = LABEL_HEIGHT + FLOOR_LEGEND_HEIGHT + WALL_LEGEND_HEIGHT + ITEM_LEGEND_HEIGHT;
   const totalH = valid.reduce((sum, r) => sum + r.canvas.height + LABEL_HEIGHT, 0) + FOOTER_HEIGHT;
 
   const combined = document.createElement("canvas");
@@ -311,23 +359,177 @@ export function exportAllFloorsPng(floors: FloorPlan[], cellSize: number): void 
     ctx.font = "bold 13px 'IBM Plex Mono', monospace";
     ctx.textAlign = "left";
     ctx.textBaseline = "alphabetic";
-    const { storage, windows } = computeFloorScores(floor);
+    const { storage, windows } = floorScores.get(floor.id)!;
     ctx.fillText(`${name}  ${tsubo.toFixed(2)}坪  収納:${storage}  窓:${windows}`, 8, offsetY + 16);
     offsetY += LABEL_HEIGHT;
     ctx.drawImage(canvas, 0, offsetY);
     offsetY += canvas.height;
   }
 
-  // Total
+  // Total + north arrow
   ctx.fillStyle = DIM_COLOR;
   ctx.font = "bold 13px 'IBM Plex Mono', monospace";
   ctx.textAlign = "right";
   ctx.textBaseline = "alphabetic";
   ctx.fillText(
     `合計 ${totalTsubo.toFixed(2)}坪  収納:${totalStorage}  窓:${totalWindows}`,
-    totalW - 8,
+    totalW - 36,
     offsetY + 16,
   );
+  // North arrow
+  {
+    const ax = totalW - 14;
+    const ay = offsetY + LABEL_HEIGHT / 2;
+    const al = 9;
+    ctx.save();
+    ctx.fillStyle = DIM_COLOR;
+    ctx.strokeStyle = DIM_COLOR;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay - al);
+    ctx.lineTo(ax - 3, ay + al / 2);
+    ctx.lineTo(ax, ay);
+    ctx.lineTo(ax + 3, ay + al / 2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.font = "bold 8px 'IBM Plex Mono', monospace";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText("N", ax, ay + al / 2 + 1);
+    ctx.restore();
+  }
+  offsetY += LABEL_HEIGHT;
+
+  if (legendEntries.length > 0) {
+    const sw = FLOOR_SW;
+    const perRow = Math.max(1, Math.floor(usableW / FLOOR_ITEM_W));
+    ctx.font = "11px 'IBM Plex Mono', monospace";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
+    for (let i = 0; i < legendEntries.length; i++) {
+      const entry = legendEntries[i];
+      const col = i % perRow;
+      const row = Math.floor(i / perRow);
+      const lx = MARGIN + col * FLOOR_ITEM_W;
+      const rowY = offsetY + row * LABEL_HEIGHT;
+      const lh = rowY + (LABEL_HEIGHT - sw) / 2;
+
+      ctx.fillStyle = entry.light!;
+      ctx.fillRect(lx, lh, sw, sw);
+
+      if (entry.type === "tatami") {
+        ctx.save();
+        ctx.strokeStyle = "rgba(100,70,20,0.25)";
+        ctx.lineWidth = 0.8;
+        const mid = sw / 2;
+        ctx.beginPath();
+        ctx.moveTo(lx, lh + mid);
+        ctx.lineTo(lx + sw, lh + mid);
+        ctx.moveTo(lx + mid, lh);
+        ctx.lineTo(lx + mid, lh + sw);
+        ctx.stroke();
+        ctx.strokeRect(lx + 1, lh + 1, sw - 2, sw - 2);
+        ctx.restore();
+      }
+      if (entry.type === "void") {
+        ctx.save();
+        ctx.strokeStyle = "rgba(90,74,58,0.5)";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([2, 2]);
+        ctx.beginPath();
+        ctx.moveTo(lx, lh);
+        ctx.lineTo(lx + sw, lh + sw);
+        ctx.moveTo(lx + sw, lh);
+        ctx.lineTo(lx, lh + sw);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      ctx.strokeStyle = DIM_COLOR;
+      ctx.lineWidth = 0.5;
+      ctx.strokeRect(lx, lh, sw, sw);
+      ctx.fillStyle = DIM_COLOR;
+      ctx.fillText(entry.label, lx + sw + 4, rowY + LABEL_HEIGHT / 2);
+    }
+  }
+  offsetY += FLOOR_LEGEND_HEIGHT;
+
+  if (usedWallTypes.length > 0) {
+    const perRow = Math.max(1, Math.floor(usableW / WALL_ITEM_W));
+    const windowBlue = "#4A90D9";
+    ctx.font = "11px 'IBM Plex Mono', monospace";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
+    for (let i = 0; i < usedWallTypes.length; i++) {
+      const wt = usedWallTypes[i];
+      const col = i % perRow;
+      const row = Math.floor(i / perRow);
+      const lx = MARGIN + col * WALL_ITEM_W;
+      const rowY = offsetY + row * LABEL_HEIGHT;
+      const ly = rowY + LABEL_HEIGHT / 2;
+      ctx.save();
+      switch (wt) {
+        case "solid": {
+          ctx.strokeStyle = DIM_COLOR;
+          ctx.lineWidth = 3;
+          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          break;
+        }
+        case "solid_thin": {
+          ctx.strokeStyle = DIM_COLOR;
+          ctx.lineWidth = 1.5;
+          ctx.setLineDash([2, 1.5]);
+          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.setLineDash([]);
+          break;
+        }
+        case "window_full": {
+          ctx.strokeStyle = DIM_COLOR;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.strokeStyle = windowBlue;
+          ctx.lineWidth = 4;
+          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          break;
+        }
+        case "window_center": {
+          ctx.strokeStyle = DIM_COLOR;
+          ctx.lineWidth = 3;
+          ctx.beginPath(); ctx.moveTo(lx, ly); ctx.lineTo(lx + WALL_LINE_W * 0.25, ly); ctx.stroke();
+          ctx.beginPath(); ctx.moveTo(lx + WALL_LINE_W * 0.75, ly); ctx.lineTo(lx + WALL_LINE_W, ly); ctx.stroke();
+          ctx.strokeStyle = windowBlue;
+          ctx.lineWidth = 4;
+          ctx.beginPath(); ctx.moveTo(lx + WALL_LINE_W * 0.25, ly); ctx.lineTo(lx + WALL_LINE_W * 0.75, ly); ctx.stroke();
+          break;
+        }
+      }
+      ctx.restore();
+      ctx.fillStyle = DIM_COLOR;
+      ctx.fillText(WALL_LABELS[wt] ?? wt, lx + WALL_LINE_W + 4, ly);
+    }
+  }
+  offsetY += WALL_LEGEND_HEIGHT;
+
+  if (usedItemTypes.length > 0) {
+    const rowH = ICON_SIZE + 16;
+    const perRow = Math.max(1, Math.floor(usableW / ICON_ITEM_W));
+    ctx.font = "9px 'IBM Plex Mono', monospace";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    for (let i = 0; i < usedItemTypes.length; i++) {
+      const type = usedItemTypes[i];
+      const def = ITEM_DEF_MAP.get(type);
+      if (!def) {continue;}
+      const col = i % perRow;
+      const row = Math.floor(i / perRow);
+      const lx = MARGIN + col * ICON_ITEM_W;
+      const ly = offsetY + row * rowH + 4;
+      const oc = getCachedIcon(type, 0, ICON_SIZE);
+      if (oc) {ctx.drawImage(oc, lx, ly, ICON_SIZE, ICON_SIZE);}
+      ctx.fillStyle = DIM_COLOR;
+      ctx.fillText(ITEM_LEGEND_LABEL.get(type) ?? def.label, lx + ICON_SIZE / 2, ly + ICON_SIZE + 2);
+    }
+  }
 
   combined.toBlob((blob) => {
     if (!blob) {

--- a/packages/madories/src/draw/icons/index.ts
+++ b/packages/madories/src/draw/icons/index.ts
@@ -2,7 +2,7 @@ import type { ItemType } from "../../types";
 import { drawBathtub } from "./bathtub";
 import { drawBed } from "./bed";
 import { drawChair } from "./chair";
-import { drawDesk, drawDeskLarge } from "./desk";
+import { drawDesk } from "./desk";
 import { drawDoor } from "./door";
 import { drawDoorSlide } from "./door_slide";
 import { drawFridge } from "./fridge";
@@ -31,7 +31,7 @@ export const ICON_REGISTRY = new Map<ItemType, DrawFn>([
   ["stairs", drawStairs],
   ["chair", drawChair],
   ["desk", drawDesk],
-  ["desk_large", drawDeskLarge],
+  ["desk_small", drawDesk],
   ["toilet", drawToilet],
   ["bathtub", drawBathtub],
   ["kitchen", drawKitchen],

--- a/packages/madories/src/floor/share.ts
+++ b/packages/madories/src/floor/share.ts
@@ -3,11 +3,24 @@ import type { FloorPlan } from "../types";
 
 const SEPARATOR = "\n---\n";
 
-function floorsToText(floors: FloorPlan[]): string {
+export function mergeFloors(existing: FloorPlan[], parsed: FloorPlan[]): FloorPlan[] {
+  const floors = [...existing];
+  for (const parsedFloor of parsed) {
+    const existingIdx = floors.findIndex((f) => f.name === parsedFloor.name);
+    if (existingIdx !== -1) {
+      floors[existingIdx] = { ...parsedFloor, id: floors[existingIdx].id };
+    } else {
+      floors.push(parsedFloor);
+    }
+  }
+  return floors;
+}
+
+export function floorsToText(floors: FloorPlan[]): string {
   return floors.map((x) => floorToDsl(x)).join(SEPARATOR);
 }
 
-function textToFloors(text: string): FloorPlan[] {
+export function textToFloors(text: string): FloorPlan[] {
   return text.split(SEPARATOR).map((x) => dslToFloor(x));
 }
 

--- a/packages/madories/src/items.ts
+++ b/packages/madories/src/items.ts
@@ -1,4 +1,4 @@
-import type { ItemType } from "./types";
+import type { ItemType, WallType } from "./types";
 
 export type ItemCategory = "建具" | "水回り" | "キッチン" | "リビング" | "寝室";
 
@@ -49,8 +49,8 @@ export const ITEM_DEFS: ItemDef[] = [
     w: 2,
   },
   { category: "リビング", h: 1, label: "椅子", type: "chair", w: 1 },
-  { category: "リビング", h: 2, label: "机", type: "desk", w: 1 },
-  { category: "リビング", h: 2, label: "机(大)", type: "desk_large", w: 2 },
+  { category: "リビング", h: 1, label: "机(小)", type: "desk_small", w: 1 },
+  { category: "リビング", h: 2, label: "机(大)", type: "desk", w: 1 },
 ];
 
 export const ITEM_DEF_MAP = new Map(ITEM_DEFS.map((d) => [d.type, d]));
@@ -61,7 +61,7 @@ export const ITEM_GROUP_REPRESENTATIVE = new Map<ItemType, ItemType>([
   ["washbasin_large", "washbasin"],
   ["kitchen_small", "kitchen"],
   ["shelf2", "shelf1"],
-  ["desk_large", "desk"],
+  ["desk_small", "desk"],
   ["bed_double", "bed_single"],
 ]);
 
@@ -72,5 +72,12 @@ export const ITEM_LEGEND_LABEL = new Map<ItemType, string>([
   ["desk", "机"],
   ["bed_single", "ベッド"],
 ]);
+
+export const WALL_LEGEND_LABEL: Partial<Record<WallType, string>> = {
+  solid: "壁",
+  solid_thin: "開口部",
+  window_center: "半窓",
+  window_full: "全窓",
+};
 
 export const ITEM_CATEGORIES: ItemCategory[] = ["建具", "水回り", "キッチン", "リビング", "寝室"];

--- a/packages/madories/src/items.ts
+++ b/packages/madories/src/items.ts
@@ -21,38 +21,56 @@ export const ITEM_DEFS: ItemDef[] = [
   {
     category: "水回り",
     h: 1,
-    label: "洗面台(1/2)",
+    label: "洗面台(小)",
     type: "washbasin_half",
     w: 1,
   },
-  { category: "水回り", h: 2, label: "洗面台(1x2)", type: "washbasin_large", w: 1 },
+  { category: "水回り", h: 2, label: "洗面台(大)", type: "washbasin_large", w: 1 },
   { category: "水回り", h: 1, label: "洗濯機", type: "washer", w: 1 },
-  { category: "キッチン", h: 2, label: "キッチン台(1x2)", type: "kitchen_small", w: 1 },
-  { category: "キッチン", h: 3, label: "キッチン台(1x3)", type: "kitchen", w: 1 },
+  { category: "キッチン", h: 2, label: "キッチン台(小)", type: "kitchen_small", w: 1 },
+  { category: "キッチン", h: 3, label: "キッチン台", type: "kitchen", w: 1 },
   { category: "キッチン", h: 1, label: "冷蔵庫", type: "fridge", w: 1 },
   { category: "リビング", h: 2, label: "ソファ", type: "sofa", w: 1 },
   { category: "リビング", h: 2, label: "テレビ", type: "tv", w: 1 },
-  { category: "リビング", h: 1, label: "棚(1)", storageScore: 1, type: "shelf1", w: 1 },
-  { category: "リビング", h: 2, label: "棚(2)", storageScore: 2, type: "shelf2", w: 1 },
+  { category: "リビング", h: 1, label: "棚", storageScore: 1, type: "shelf1", w: 1 },
+  { category: "リビング", h: 2, label: "棚(2段)", storageScore: 2, type: "shelf2", w: 1 },
   {
     category: "寝室",
     h: 2,
-    label: "シングルベッド",
+    label: "ベッド(シングル)",
     type: "bed_single",
     w: 1,
   },
   {
     category: "寝室",
     h: 2,
-    label: "ダブルベッド",
+    label: "ベッド(ダブル)",
     type: "bed_double",
     w: 2,
   },
   { category: "リビング", h: 1, label: "椅子", type: "chair", w: 1 },
-  { category: "リビング", h: 2, label: "机(1x2)", type: "desk", w: 1 },
-  { category: "リビング", h: 2, label: "机(2x2)", type: "desk_large", w: 2 },
+  { category: "リビング", h: 2, label: "机", type: "desk", w: 1 },
+  { category: "リビング", h: 2, label: "机(大)", type: "desk_large", w: 2 },
 ];
 
 export const ITEM_DEF_MAP = new Map(ITEM_DEFS.map((d) => [d.type, d]));
+
+// Maps variant types to their representative type for legend grouping
+export const ITEM_GROUP_REPRESENTATIVE = new Map<ItemType, ItemType>([
+  ["washbasin_half", "washbasin"],
+  ["washbasin_large", "washbasin"],
+  ["kitchen_small", "kitchen"],
+  ["shelf2", "shelf1"],
+  ["desk_large", "desk"],
+  ["bed_double", "bed_single"],
+]);
+
+export const ITEM_LEGEND_LABEL = new Map<ItemType, string>([
+  ["washbasin", "洗面台"],
+  ["kitchen", "キッチン台"],
+  ["shelf1", "棚"],
+  ["desk", "机"],
+  ["bed_single", "ベッド"],
+]);
 
 export const ITEM_CATEGORIES: ItemCategory[] = ["建具", "水回り", "キッチン", "リビング", "寝室"];

--- a/packages/madories/src/types.ts
+++ b/packages/madories/src/types.ts
@@ -33,7 +33,7 @@ export type ItemType =
   | "sofa"
   | "bed_single"
   | "bed_double"
-  | "desk_large";
+  | "desk_small";
 
 export interface Item {
   type: ItemType;


### PR DESCRIPTION
## 概要
床取図エディタ madories に凡例エクスポート機能を実装。PNG 出力時に床材・壁・家具の凡例を自動的に追加し、図面の可読性を向上。

## 変更内容
- **PNG 出力に凡例を統合**: 床材色サンプル、壁タイプ、家具アイコンの凡例を出力フッターに表示
- **凡例 UI**: ルームピッカーを活用した凡例表示機能
- **北矢印追加**: PDF/PNG 出力に北矢印を表示

## マージ済み
2026-04-27 にマージ済み