### PR TITLE
feat: add 3D preview to madories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+# Git worktrees
+.worktrees/
 

--- a/bun.lock
+++ b/bun.lock
@@ -85,8 +85,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@mijime/theme": "workspace:*",
-        "@react-three/drei": "^9.114.0",
-        "@react-three/fiber": "^8.17.0",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "lucide-react": "^1.14.0",
         "three": "^0.169.0",
         "uuid": "^14.0.0",
@@ -97,7 +97,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.169.0",
         "@types/uuid": "^11.0.0",
-        "@typescript/native-preview": "^7.0.0-dev.20260429.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260503.1",
         "bun-types": "^1.3.13",
         "oxfmt": "^0.46.0",
         "oxlint": "^1.62.0",
@@ -501,21 +501,9 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "https://npm.flatt.tech/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
 
-    "@react-spring/animated": ["@react-spring/animated@9.7.5", "", { "dependencies": { "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg=="],
+    "@react-three/drei": ["@react-three/drei@10.7.7", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@use-gesture/react": "^10.3.1", "camera-controls": "^3.1.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.8.3", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.4", "tunnel-rat": "^0.1.2", "use-sync-external-store": "^1.4.0", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^9.0.0", "react": "^19", "react-dom": "^19", "three": ">=0.159" }, "optionalPeers": ["react-dom"] }, "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ=="],
 
-    "@react-spring/core": ["@react-spring/core@9.7.5", "", { "dependencies": { "@react-spring/animated": "~9.7.5", "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w=="],
-
-    "@react-spring/rafz": ["@react-spring/rafz@9.7.5", "", {}, "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw=="],
-
-    "@react-spring/shared": ["@react-spring/shared@9.7.5", "", { "dependencies": { "@react-spring/rafz": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw=="],
-
-    "@react-spring/three": ["@react-spring/three@9.7.5", "", { "dependencies": { "@react-spring/animated": "~9.7.5", "@react-spring/core": "~9.7.5", "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "@react-three/fiber": ">=6.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0", "three": ">=0.126" } }, "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA=="],
-
-    "@react-spring/types": ["@react-spring/types@9.7.5", "", {}, "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g=="],
-
-    "@react-three/drei": ["@react-three/drei@9.122.0", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@react-spring/three": "~9.7.5", "@use-gesture/react": "^10.3.1", "camera-controls": "^2.9.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "react-composer": "^5.0.3", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.7.8", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.0", "tunnel-rat": "^0.1.2", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^8", "react": "^18", "react-dom": "^18", "three": ">=0.137" }, "optionalPeers": ["react-dom"] }, "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA=="],
-
-    "@react-three/fiber": ["@react-three/fiber@8.18.0", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/react-reconciler": "^0.26.7", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^1.0.6", "react-reconciler": "^0.27.0", "react-use-measure": "^2.1.7", "scheduler": "^0.21.0", "suspend-react": "^0.1.3", "zustand": "^3.7.1" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=18 <19", "react-dom": ">=18 <19", "react-native": ">=0.64", "three": ">=0.133" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ=="],
+    "@react-three/fiber": ["@react-three/fiber@9.6.1", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-use-measure": "^2.1.7", "scheduler": "^0.27.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=19 <19.3", "react-dom": ">=19 <19.3", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "https://npm.flatt.tech/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
 
@@ -803,7 +791,7 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "https://npm.flatt.tech/@types/react-dom/-/react-dom-19.2.3.tgz", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@types/react-reconciler": ["@types/react-reconciler@0.26.7", "", { "dependencies": { "@types/react": "*" } }, "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ=="],
+    "@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
@@ -971,7 +959,7 @@
 
     "camelcase": ["camelcase@8.0.0", "https://npm.flatt.tech/camelcase/-/camelcase-8.0.0.tgz", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
-    "camera-controls": ["camera-controls@2.10.1", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w=="],
+    "camera-controls": ["camera-controls@3.1.2", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001790", "https://npm.flatt.tech/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
@@ -1579,7 +1567,7 @@
 
     "isobject": ["isobject@3.0.1", "https://npm.flatt.tech/isobject/-/isobject-3.0.1.tgz", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
-    "its-fine": ["its-fine@1.2.5", "", { "dependencies": { "@types/react-reconciler": "^0.28.0" }, "peerDependencies": { "react": ">=18.0" } }, "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA=="],
+    "its-fine": ["its-fine@2.0.0", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng=="],
 
     "jackspeak": ["jackspeak@4.2.3", "https://npm.flatt.tech/jackspeak/-/jackspeak-4.2.3.tgz", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -1666,8 +1654,6 @@
     "lodash.uniqwith": ["lodash.uniqwith@4.5.0", "https://npm.flatt.tech/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz", {}, "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="],
 
     "longest-streak": ["longest-streak@3.1.0", "https://npm.flatt.tech/longest-streak/-/longest-streak-3.1.0.tgz", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
-
-    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@11.3.5", "https://npm.flatt.tech/lru-cache/-/lru-cache-11.3.5.tgz", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
@@ -1997,8 +1983,6 @@
 
     "prompts": ["prompts@2.4.2", "https://npm.flatt.tech/prompts/-/prompts-2.4.2.tgz", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
-    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
-
     "property-information": ["property-information@7.1.0", "https://npm.flatt.tech/property-information/-/property-information-7.1.0.tgz", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "https://npm.flatt.tech/proxy-addr/-/proxy-addr-2.0.7.tgz", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -2017,13 +2001,7 @@
 
     "react": ["react@19.2.5", "https://npm.flatt.tech/react/-/react-19.2.5.tgz", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-composer": ["react-composer@5.0.3", "", { "dependencies": { "prop-types": "^15.6.0" }, "peerDependencies": { "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0" } }, "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA=="],
-
     "react-dom": ["react-dom@19.2.5", "https://npm.flatt.tech/react-dom/-/react-dom-19.2.5.tgz", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
-
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "react-reconciler": ["react-reconciler@0.27.0", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.21.0" }, "peerDependencies": { "react": "^18.0.0" } }, "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA=="],
 
     "react-refresh": ["react-refresh@0.17.0", "https://npm.flatt.tech/react-refresh/-/react-refresh-0.17.0.tgz", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
@@ -2323,7 +2301,7 @@
 
     "three": ["three@0.169.0", "", {}, "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w=="],
 
-    "three-mesh-bvh": ["three-mesh-bvh@0.7.8", "", { "peerDependencies": { "three": ">= 0.151.0" } }, "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw=="],
+    "three-mesh-bvh": ["three-mesh-bvh@0.8.3", "", { "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg=="],
 
     "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
 
@@ -2583,6 +2561,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "https://npm.flatt.tech/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@mijime/madories/@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260503.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260503.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260503.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260503.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260503.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260503.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260503.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260503.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-gDro38CPFiBUGbaFGNt+ufOsEd1OrZrfrOPxsLSfBcvvoGaqAxV++ul/BHTOShoEkIYHiFsoDX2az1IPCDV2jQ=="],
+
     "@mijime/madories/oxfmt": ["oxfmt@0.46.0", "https://npm.flatt.tech/oxfmt/-/oxfmt-0.46.0.tgz", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.46.0", "@oxfmt/binding-android-arm64": "0.46.0", "@oxfmt/binding-darwin-arm64": "0.46.0", "@oxfmt/binding-darwin-x64": "0.46.0", "@oxfmt/binding-freebsd-x64": "0.46.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0", "@oxfmt/binding-linux-arm-musleabihf": "0.46.0", "@oxfmt/binding-linux-arm64-gnu": "0.46.0", "@oxfmt/binding-linux-arm64-musl": "0.46.0", "@oxfmt/binding-linux-ppc64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-musl": "0.46.0", "@oxfmt/binding-linux-s390x-gnu": "0.46.0", "@oxfmt/binding-linux-x64-gnu": "0.46.0", "@oxfmt/binding-linux-x64-musl": "0.46.0", "@oxfmt/binding-openharmony-arm64": "0.46.0", "@oxfmt/binding-win32-arm64-msvc": "0.46.0", "@oxfmt/binding-win32-ia32-msvc": "0.46.0", "@oxfmt/binding-win32-x64-msvc": "0.46.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA=="],
 
     "@mijime/main/oxfmt": ["oxfmt@0.1.0", "https://npm.flatt.tech/oxfmt/-/oxfmt-0.1.0.tgz", { "optionalDependencies": { "@oxfmt/darwin-arm64": "0.1.0", "@oxfmt/darwin-x64": "0.1.0", "@oxfmt/linux-arm64-gnu": "0.1.0", "@oxfmt/linux-arm64-musl": "0.1.0", "@oxfmt/linux-x64-gnu": "0.1.0", "@oxfmt/linux-x64-musl": "0.1.0", "@oxfmt/win32-arm64": "0.1.0", "@oxfmt/win32-x64": "0.1.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ASQpV4nvFF6vDZp5Rb/mx5KXLX0icFMOuIivH8nM0otmihvqtxzwUJgvvxf/EyGAytSruP78LBnw8U+tKB6h3g=="],
@@ -2590,10 +2570,6 @@
     "@mijime/theme/oxfmt": ["oxfmt@0.46.0", "https://npm.flatt.tech/oxfmt/-/oxfmt-0.46.0.tgz", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.46.0", "@oxfmt/binding-android-arm64": "0.46.0", "@oxfmt/binding-darwin-arm64": "0.46.0", "@oxfmt/binding-darwin-x64": "0.46.0", "@oxfmt/binding-freebsd-x64": "0.46.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0", "@oxfmt/binding-linux-arm-musleabihf": "0.46.0", "@oxfmt/binding-linux-arm64-gnu": "0.46.0", "@oxfmt/binding-linux-arm64-musl": "0.46.0", "@oxfmt/binding-linux-ppc64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-musl": "0.46.0", "@oxfmt/binding-linux-s390x-gnu": "0.46.0", "@oxfmt/binding-linux-x64-gnu": "0.46.0", "@oxfmt/binding-linux-x64-musl": "0.46.0", "@oxfmt/binding-openharmony-arm64": "0.46.0", "@oxfmt/binding-win32-arm64-msvc": "0.46.0", "@oxfmt/binding-win32-ia32-msvc": "0.46.0", "@oxfmt/binding-win32-x64-msvc": "0.46.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "https://npm.flatt.tech/zod/-/zod-4.3.6.tgz", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@react-three/fiber/scheduler": ["scheduler@0.21.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ=="],
-
-    "@react-three/fiber/zustand": ["zustand@3.7.2", "", { "peerDependencies": { "react": ">=16.8" }, "optionalPeers": ["react"] }, "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "https://npm.flatt.tech/estree-walker/-/estree-walker-2.0.2.tgz", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2689,8 +2665,6 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "https://npm.flatt.tech/is-docker/-/is-docker-3.0.0.tgz", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
-    "its-fine/@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
-
     "katex/commander": ["commander@8.3.0", "https://npm.flatt.tech/commander/-/commander-8.3.0.tgz", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "make-fetch-happen/https-proxy-agent": ["https-proxy-agent@5.0.1", "https://npm.flatt.tech/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
@@ -2738,8 +2712,6 @@
     "qified/hookified": ["hookified@2.2.0", "https://npm.flatt.tech/hookified/-/hookified-2.2.0.tgz", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "https://npm.flatt.tech/iconv-lite/-/iconv-lite-0.7.2.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "react-reconciler/scheduler": ["scheduler@0.21.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "https://npm.flatt.tech/glob/-/glob-7.2.3.tgz", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -2840,6 +2812,20 @@
     "@astrojs/react/vite/esbuild": ["esbuild@0.25.12", "https://npm.flatt.tech/esbuild/-/esbuild-0.25.12.tgz", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "https://npm.flatt.tech/yallist/-/yallist-3.1.1.tgz", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260503.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rUZQVuBcZlxADagx+pnhDHqjX2Ewh+KWave6vtilRWR5vsGyR3FaCzPFqXteiwPg6XRijEMnMaXg60t5itm8EA=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260503.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YtK8ac8RCkRh7jwoP8Wt4LaBhpGK8cOVMi3e0cvF/8Xn5XV1ewJK3/HdNBnlDhCib3j0eVRxK/Pg9GIq/hFUxQ=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260503.1", "", { "os": "linux", "cpu": "arm" }, "sha512-28vAomYeU8hpz1f0dDoWz6PYehz0ffEfkJhFq4tqXzUM/QY1I15u5y03EJQ5UcP4LRwrdJe22J5LdrYpM2Lr3w=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260503.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-c5yM3Ea2WZSLKmscMxUhEDdaR2Ugp7P9CX6osciIPgZIF9c4LDiuKQohjQAyidx9JZKCsSXnfS88QssWH/+ONQ=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260503.1", "", { "os": "linux", "cpu": "x64" }, "sha512-M64z7LwpqNfOXYCBKmD/ObwyxYOobUk4tDv0ECNLit7pDER1sswNZjJGjgRYjQsKokmydy6p3FqtJ1uUPUP/sw=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260503.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-QHy3R1VBb8MYszjpz0IyuDjKaW6JUHg8hYEqzhZIxvrydKLF3gyDeKohnmWSFTS/oII0GvUmYM3h83fbanBvcQ=="],
+
+    "@mijime/madories/@typescript/native-preview/@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260503.1", "", { "os": "win32", "cpu": "x64" }, "sha512-nrapqpVONrg0IZjKp3AzV9M+jxPwKGTQZEOxuKh6WHMhy/UElN8RnOFlfetA8ZMtKvPkmjgjqw0qoAa5QMwhPA=="],
 
     "@mijime/madories/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.46.0", "https://npm.flatt.tech/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.46.0.tgz", { "os": "android", "cpu": "arm" }, "sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -85,13 +85,17 @@
       "version": "1.0.0",
       "dependencies": {
         "@mijime/theme": "workspace:*",
+        "@react-three/drei": "^9.114.0",
+        "@react-three/fiber": "^8.17.0",
         "lucide-react": "^1.14.0",
+        "three": "^0.169.0",
         "uuid": "^14.0.0",
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.169.0",
         "@types/uuid": "^11.0.0",
         "@typescript/native-preview": "^7.0.0-dev.20260429.1",
         "bun-types": "^1.3.13",
@@ -180,6 +184,8 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "https://npm.flatt.tech/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "https://npm.flatt.tech/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "https://npm.flatt.tech/@babel/template/-/template-7.28.6.tgz", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -375,6 +381,8 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "https://npm.flatt.tech/@mdx-js/mdx/-/mdx-3.1.1.tgz", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
+    "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
+
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "https://npm.flatt.tech/@mermaid-js/parser/-/parser-1.1.0.tgz", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
     "@mijime/blog": ["@mijime/blog@workspace:packages/blog"],
@@ -388,6 +396,8 @@
     "@mijime/theme": ["@mijime/theme@workspace:packages/theme"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "https://npm.flatt.tech/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "https://npm.flatt.tech/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -490,6 +500,22 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.62.0", "https://npm.flatt.tech/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "https://npm.flatt.tech/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
+
+    "@react-spring/animated": ["@react-spring/animated@9.7.5", "", { "dependencies": { "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg=="],
+
+    "@react-spring/core": ["@react-spring/core@9.7.5", "", { "dependencies": { "@react-spring/animated": "~9.7.5", "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w=="],
+
+    "@react-spring/rafz": ["@react-spring/rafz@9.7.5", "", {}, "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw=="],
+
+    "@react-spring/shared": ["@react-spring/shared@9.7.5", "", { "dependencies": { "@react-spring/rafz": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw=="],
+
+    "@react-spring/three": ["@react-spring/three@9.7.5", "", { "dependencies": { "@react-spring/animated": "~9.7.5", "@react-spring/core": "~9.7.5", "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "@react-three/fiber": ">=6.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0", "three": ">=0.126" } }, "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA=="],
+
+    "@react-spring/types": ["@react-spring/types@9.7.5", "", {}, "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g=="],
+
+    "@react-three/drei": ["@react-three/drei@9.122.0", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@react-spring/three": "~9.7.5", "@use-gesture/react": "^10.3.1", "camera-controls": "^2.9.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "react-composer": "^5.0.3", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.7.8", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.0", "tunnel-rat": "^0.1.2", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^8", "react": "^18", "react-dom": "^18", "three": ">=0.137" }, "optionalPeers": ["react-dom"] }, "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA=="],
+
+    "@react-three/fiber": ["@react-three/fiber@8.18.0", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/react-reconciler": "^0.26.7", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^1.0.6", "react-reconciler": "^0.27.0", "react-use-measure": "^2.1.7", "scheduler": "^0.21.0", "suspend-react": "^0.1.3", "zustand": "^3.7.1" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=18 <19", "react-dom": ">=18 <19", "react-native": ">=0.64", "three": ">=0.133" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "https://npm.flatt.tech/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
 
@@ -669,6 +695,8 @@
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "https://npm.flatt.tech/@tootallnate/once/-/once-2.0.0.tgz", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "https://npm.flatt.tech/@tybys/wasm-util/-/wasm-util-0.10.1.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "https://npm.flatt.tech/@types/babel__core/-/babel__core-7.20.5.tgz", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -747,6 +775,8 @@
 
     "@types/debug": ["@types/debug@4.1.13", "https://npm.flatt.tech/@types/debug/-/debug-4.1.13.tgz", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
+    "@types/draco3d": ["@types/draco3d@1.4.10", "", {}, "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "https://npm.flatt.tech/@types/estree/-/estree-1.0.8.tgz", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "https://npm.flatt.tech/@types/estree-jsx/-/estree-jsx-1.0.5.tgz", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -767,15 +797,25 @@
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "https://npm.flatt.tech/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
+    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
+
     "@types/react": ["@types/react@19.2.14", "https://npm.flatt.tech/@types/react/-/react-19.2.14.tgz", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "https://npm.flatt.tech/@types/react-dom/-/react-dom-19.2.3.tgz", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/react-reconciler": ["@types/react-reconciler@0.26.7", "", { "dependencies": { "@types/react": "*" } }, "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.169.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "https://npm.flatt.tech/@types/trusted-types/-/trusted-types-2.0.7.tgz", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "https://npm.flatt.tech/@types/unist/-/unist-3.0.3.tgz", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "https://npm.flatt.tech/@types/uuid/-/uuid-11.0.0.tgz", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260429.1", "https://npm.flatt.tech/@typescript/native-preview/-/native-preview-7.0.0-dev.20260429.1.tgz", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260429.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260429.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260429.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260429.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260429.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260429.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260429.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-SGKnvs5EA+V1spnraYJqum/lEajE0IQ2bVVPC72hFfWjoCfQ6N7iVYxLUGreiE3VFyQWWQBPgXZrRUFnawVvpQ=="],
 
@@ -797,6 +837,10 @@
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "https://npm.flatt.tech/@upsetjs/venn.js/-/venn.js-2.0.0.tgz", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
+    "@use-gesture/core": ["@use-gesture/core@10.3.1", "", {}, "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="],
+
+    "@use-gesture/react": ["@use-gesture/react@10.3.1", "", { "dependencies": { "@use-gesture/core": "10.3.1" }, "peerDependencies": { "react": ">= 16.8.0" } }, "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "https://npm.flatt.tech/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "https://npm.flatt.tech/@volar/kit/-/kit-2.4.28.tgz", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
@@ -814,6 +858,8 @@
     "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "https://npm.flatt.tech/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "https://npm.flatt.tech/@vscode/l10n/-/l10n-0.0.18.tgz", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "abbrev": ["abbrev@3.0.1", "https://npm.flatt.tech/abbrev/-/abbrev-3.0.1.tgz", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
@@ -887,7 +933,11 @@
 
     "base-64": ["base-64@1.0.0", "https://npm.flatt.tech/base-64/-/base-64-1.0.0.tgz", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "https://npm.flatt.tech/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "body-parser": ["body-parser@2.2.2", "https://npm.flatt.tech/body-parser/-/body-parser-2.2.2.tgz", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -900,6 +950,8 @@
     "brace-expansion": ["brace-expansion@5.0.5", "https://npm.flatt.tech/brace-expansion/-/brace-expansion-5.0.5.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "browserslist": ["browserslist@4.28.2", "https://npm.flatt.tech/browserslist/-/browserslist-4.28.2.tgz", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "https://npm.flatt.tech/buffer-from/-/buffer-from-1.1.2.tgz", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -918,6 +970,8 @@
     "call-bound": ["call-bound@1.0.4", "https://npm.flatt.tech/call-bound/-/call-bound-1.0.4.tgz", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "camelcase": ["camelcase@8.0.0", "https://npm.flatt.tech/camelcase/-/camelcase-8.0.0.tgz", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
+
+    "camera-controls": ["camera-controls@2.10.1", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001790", "https://npm.flatt.tech/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
@@ -1002,6 +1056,8 @@
     "cors": ["cors@2.8.6", "https://npm.flatt.tech/cors/-/cors-2.8.6.tgz", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cose-base": ["cose-base@1.0.3", "https://npm.flatt.tech/cose-base/-/cose-base-1.0.3.tgz", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "https://npm.flatt.tech/cross-spawn/-/cross-spawn-7.0.6.tgz", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1125,6 +1181,8 @@
 
     "destr": ["destr@2.0.5", "https://npm.flatt.tech/destr/-/destr-2.0.5.tgz", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
+    "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
+
     "detect-libc": ["detect-libc@2.1.2", "https://npm.flatt.tech/detect-libc/-/detect-libc-2.1.2.tgz", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "deterministic-object-hash": ["deterministic-object-hash@2.0.2", "https://npm.flatt.tech/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz", { "dependencies": { "base-64": "^1.0.0" } }, "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ=="],
@@ -1148,6 +1206,8 @@
     "domutils": ["domutils@3.2.2", "https://npm.flatt.tech/domutils/-/domutils-3.2.2.tgz", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "doublearray": ["doublearray@0.0.2", "https://npm.flatt.tech/doublearray/-/doublearray-0.0.2.tgz", {}, "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw=="],
+
+    "draco3d": ["draco3d@1.5.7", "", {}, "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="],
 
     "dset": ["dset@3.1.4", "https://npm.flatt.tech/dset/-/dset-3.1.4.tgz", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
@@ -1257,6 +1317,8 @@
 
     "fdir": ["fdir@6.5.0", "https://npm.flatt.tech/fdir/-/fdir-6.5.0.tgz", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
     "file-entry-cache": ["file-entry-cache@10.1.4", "https://npm.flatt.tech/file-entry-cache/-/file-entry-cache-10.1.4.tgz", { "dependencies": { "flat-cache": "^6.1.13" } }, "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA=="],
 
     "finalhandler": ["finalhandler@2.1.1", "https://npm.flatt.tech/finalhandler/-/finalhandler-2.1.1.tgz", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
@@ -1323,6 +1385,8 @@
 
     "globalthis": ["globalthis@1.0.4", "https://npm.flatt.tech/globalthis/-/globalthis-1.0.4.tgz", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
+    "glsl-noise": ["glsl-noise@0.0.0", "", {}, "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="],
+
     "gopd": ["gopd@1.2.0", "https://npm.flatt.tech/gopd/-/gopd-1.2.0.tgz", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "https://npm.flatt.tech/graceful-fs/-/graceful-fs-4.2.11.tgz", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1377,6 +1441,8 @@
 
     "hastscript": ["hastscript@9.0.1", "https://npm.flatt.tech/hastscript/-/hastscript-9.0.1.tgz", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
+    "hls.js": ["hls.js@1.6.16", "", {}, "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="],
+
     "hono": ["hono@4.12.15", "https://npm.flatt.tech/hono/-/hono-4.12.15.tgz", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
 
     "hookified": ["hookified@1.15.1", "https://npm.flatt.tech/hookified/-/hookified-1.15.1.tgz", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
@@ -1398,6 +1464,10 @@
     "humanize-ms": ["humanize-ms@1.2.1", "https://npm.flatt.tech/humanize-ms/-/humanize-ms-1.2.1.tgz", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "https://npm.flatt.tech/iconv-lite/-/iconv-lite-0.6.3.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "https://npm.flatt.tech/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
@@ -1479,7 +1549,7 @@
 
     "is-plain-object": ["is-plain-object@2.0.4", "https://npm.flatt.tech/is-plain-object/-/is-plain-object-2.0.4.tgz", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
-    "is-promise": ["is-promise@4.0.0", "https://npm.flatt.tech/is-promise/-/is-promise-4.0.0.tgz", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+    "is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
 
     "is-regex": ["is-regex@1.2.1", "https://npm.flatt.tech/is-regex/-/is-regex-1.2.1.tgz", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -1508,6 +1578,8 @@
     "isexe": ["isexe@2.0.0", "https://npm.flatt.tech/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "isobject": ["isobject@3.0.1", "https://npm.flatt.tech/isobject/-/isobject-3.0.1.tgz", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
+
+    "its-fine": ["its-fine@1.2.5", "", { "dependencies": { "@types/react-reconciler": "^0.28.0" }, "peerDependencies": { "react": ">=18.0" } }, "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA=="],
 
     "jackspeak": ["jackspeak@4.2.3", "https://npm.flatt.tech/jackspeak/-/jackspeak-4.2.3.tgz", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -1551,6 +1623,8 @@
 
     "levn": ["levn@0.4.1", "https://npm.flatt.tech/levn/-/levn-0.4.1.tgz", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
     "lightningcss": ["lightningcss@1.32.0", "https://npm.flatt.tech/lightningcss/-/lightningcss-1.32.0.tgz", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "https://npm.flatt.tech/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -1593,11 +1667,15 @@
 
     "longest-streak": ["longest-streak@3.1.0", "https://npm.flatt.tech/longest-streak/-/longest-streak-3.1.0.tgz", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "lru-cache": ["lru-cache@11.3.5", "https://npm.flatt.tech/lru-cache/-/lru-cache-11.3.5.tgz", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "lru_map": ["lru_map@0.4.1", "https://npm.flatt.tech/lru_map/-/lru_map-0.4.1.tgz", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
     "lucide-react": ["lucide-react@1.14.0", "https://npm.flatt.tech/lucide-react/-/lucide-react-1.14.0.tgz", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
+
+    "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
 
     "magic-string": ["magic-string@0.30.21", "https://npm.flatt.tech/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1664,6 +1742,10 @@
     "merge-descriptors": ["merge-descriptors@2.0.0", "https://npm.flatt.tech/merge-descriptors/-/merge-descriptors-2.0.0.tgz", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "mermaid": ["mermaid@11.14.0", "https://npm.flatt.tech/mermaid/-/mermaid-11.14.0.tgz", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
+
+    "meshline": ["meshline@3.3.1", "", { "peerDependencies": { "three": ">=0.137" } }, "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ=="],
+
+    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
 
     "micromark": ["micromark@4.0.2", "https://npm.flatt.tech/micromark/-/micromark-4.0.2.tgz", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -1897,6 +1979,8 @@
 
     "postcss": ["postcss@8.5.10", "https://npm.flatt.tech/postcss/-/postcss-8.5.10.tgz", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
+    "potpack": ["potpack@1.0.2", "", {}, "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "https://npm.flatt.tech/prelude-ls/-/prelude-ls-1.2.1.tgz", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.3", "https://npm.flatt.tech/prettier/-/prettier-3.8.3.tgz", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
@@ -1909,7 +1993,11 @@
 
     "promise-retry": ["promise-retry@2.0.1", "https://npm.flatt.tech/promise-retry/-/promise-retry-2.0.1.tgz", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
+    "promise-worker-transferable": ["promise-worker-transferable@1.0.4", "", { "dependencies": { "is-promise": "^2.1.0", "lie": "^3.0.2" } }, "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw=="],
+
     "prompts": ["prompts@2.4.2", "https://npm.flatt.tech/prompts/-/prompts-2.4.2.tgz", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "https://npm.flatt.tech/property-information/-/property-information-7.1.0.tgz", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -1929,9 +2017,17 @@
 
     "react": ["react@19.2.5", "https://npm.flatt.tech/react/-/react-19.2.5.tgz", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
+    "react-composer": ["react-composer@5.0.3", "", { "dependencies": { "prop-types": "^15.6.0" }, "peerDependencies": { "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0" } }, "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA=="],
+
     "react-dom": ["react-dom@19.2.5", "https://npm.flatt.tech/react-dom/-/react-dom-19.2.5.tgz", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-reconciler": ["react-reconciler@0.27.0", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.21.0" }, "peerDependencies": { "react": "^18.0.0" } }, "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA=="],
+
     "react-refresh": ["react-refresh@0.17.0", "https://npm.flatt.tech/react-refresh/-/react-refresh-0.17.0.tgz", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
     "read-package-up": ["read-package-up@11.0.0", "https://npm.flatt.tech/read-package-up/-/read-package-up-11.0.0.tgz", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
@@ -2117,6 +2213,10 @@
 
     "ssri": ["ssri@9.0.1", "https://npm.flatt.tech/ssri/-/ssri-9.0.1.tgz", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
 
+    "stats-gl": ["stats-gl@2.4.2", "", { "dependencies": { "@types/three": "*", "three": "^0.170.0" } }, "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ=="],
+
+    "stats.js": ["stats.js@0.17.0", "", {}, "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="],
+
     "statuses": ["statuses@2.0.2", "https://npm.flatt.tech/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "https://npm.flatt.tech/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
@@ -2144,6 +2244,8 @@
     "stylis": ["stylis@4.4.0", "https://npm.flatt.tech/stylis/-/stylis-4.4.0.tgz", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-color": ["supports-color@7.2.0", "https://npm.flatt.tech/supports-color/-/supports-color-7.2.0.tgz", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
 
     "svgo": ["svgo@4.0.1", "https://npm.flatt.tech/svgo/-/svgo-4.0.1.tgz", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
@@ -2219,6 +2321,12 @@
 
     "textlint-util-to-string": ["textlint-util-to-string@3.3.4", "https://npm.flatt.tech/textlint-util-to-string/-/textlint-util-to-string-3.3.4.tgz", { "dependencies": { "@textlint/ast-node-types": "^13.4.1", "rehype-parse": "^6.0.1", "structured-source": "^4.0.0", "unified": "^8.4.0" } }, "sha512-XF4Qfw0ES+czKy03BwuvBUoXC8NAg920VuRxW0pd72fW76zMeMbPI/bRN5PHq3SbCdOm7U69/Pk+DX34xqIYqA=="],
 
+    "three": ["three@0.169.0", "", {}, "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w=="],
+
+    "three-mesh-bvh": ["three-mesh-bvh@0.7.8", "", { "peerDependencies": { "three": ">= 0.151.0" } }, "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw=="],
+
+    "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
+
     "tiny-inflate": ["tiny-inflate@1.0.3", "https://npm.flatt.tech/tiny-inflate/-/tiny-inflate-1.0.3.tgz", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyclip": ["tinyclip@0.1.12", "https://npm.flatt.tech/tinyclip/-/tinyclip-0.1.12.tgz", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
@@ -2241,6 +2349,12 @@
 
     "trim-lines": ["trim-lines@3.0.1", "https://npm.flatt.tech/trim-lines/-/trim-lines-3.0.1.tgz", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "troika-three-text": ["troika-three-text@0.52.4", "", { "dependencies": { "bidi-js": "^1.0.2", "troika-three-utils": "^0.52.4", "troika-worker-utils": "^0.52.0", "webgl-sdf-generator": "1.1.1" }, "peerDependencies": { "three": ">=0.125.0" } }, "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg=="],
+
+    "troika-three-utils": ["troika-three-utils@0.52.4", "", { "peerDependencies": { "three": ">=0.125.0" } }, "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A=="],
+
+    "troika-worker-utils": ["troika-worker-utils@0.52.0", "", {}, "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw=="],
+
     "trough": ["trough@2.2.0", "https://npm.flatt.tech/trough/-/trough-2.2.0.tgz", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-dedent": ["ts-dedent@2.2.0", "https://npm.flatt.tech/ts-dedent/-/ts-dedent-2.2.0.tgz", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
@@ -2250,6 +2364,8 @@
     "tslib": ["tslib@2.8.1", "https://npm.flatt.tech/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "https://npm.flatt.tech/tsx/-/tsx-4.21.0.tgz", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "type-check": ["type-check@0.4.0", "https://npm.flatt.tech/type-check/-/type-check-0.4.0.tgz", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -2325,7 +2441,11 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "https://npm.flatt.tech/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "https://npm.flatt.tech/util-deprecate/-/util-deprecate-1.0.2.tgz", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
 
     "uuid": ["uuid@14.0.0", "https://npm.flatt.tech/uuid/-/uuid-14.0.0.tgz", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
@@ -2378,6 +2498,10 @@
     "vscode-uri": ["vscode-uri@3.1.0", "https://npm.flatt.tech/vscode-uri/-/vscode-uri-3.1.0.tgz", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "https://npm.flatt.tech/web-namespaces/-/web-namespaces-2.0.1.tgz", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "webgl-constants": ["webgl-constants@1.1.1", "", {}, "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="],
+
+    "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "https://npm.flatt.tech/webidl-conversions/-/webidl-conversions-3.0.1.tgz", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -2439,6 +2563,8 @@
 
     "zod-to-ts": ["zod-to-ts@1.2.0", "https://npm.flatt.tech/zod-to-ts/-/zod-to-ts-1.2.0.tgz", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
+    "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
+
     "zwitch": ["zwitch@2.0.4", "https://npm.flatt.tech/zwitch/-/zwitch-2.0.4.tgz", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "https://npm.flatt.tech/@astrojs/compiler/-/compiler-2.13.1.tgz", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
@@ -2464,6 +2590,10 @@
     "@mijime/theme/oxfmt": ["oxfmt@0.46.0", "https://npm.flatt.tech/oxfmt/-/oxfmt-0.46.0.tgz", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.46.0", "@oxfmt/binding-android-arm64": "0.46.0", "@oxfmt/binding-darwin-arm64": "0.46.0", "@oxfmt/binding-darwin-x64": "0.46.0", "@oxfmt/binding-freebsd-x64": "0.46.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0", "@oxfmt/binding-linux-arm-musleabihf": "0.46.0", "@oxfmt/binding-linux-arm64-gnu": "0.46.0", "@oxfmt/binding-linux-arm64-musl": "0.46.0", "@oxfmt/binding-linux-ppc64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-musl": "0.46.0", "@oxfmt/binding-linux-s390x-gnu": "0.46.0", "@oxfmt/binding-linux-x64-gnu": "0.46.0", "@oxfmt/binding-linux-x64-musl": "0.46.0", "@oxfmt/binding-openharmony-arm64": "0.46.0", "@oxfmt/binding-win32-arm64-msvc": "0.46.0", "@oxfmt/binding-win32-ia32-msvc": "0.46.0", "@oxfmt/binding-win32-x64-msvc": "0.46.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "https://npm.flatt.tech/zod/-/zod-4.3.6.tgz", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@react-three/fiber/scheduler": ["scheduler@0.21.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ=="],
+
+    "@react-three/fiber/zustand": ["zustand@3.7.2", "", { "peerDependencies": { "react": ">=16.8" }, "optionalPeers": ["react"] }, "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "https://npm.flatt.tech/estree-walker/-/estree-walker-2.0.2.tgz", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2559,6 +2689,8 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "https://npm.flatt.tech/is-docker/-/is-docker-3.0.0.tgz", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
+    "its-fine/@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
+
     "katex/commander": ["commander@8.3.0", "https://npm.flatt.tech/commander/-/commander-8.3.0.tgz", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "make-fetch-happen/https-proxy-agent": ["https-proxy-agent@5.0.1", "https://npm.flatt.tech/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
@@ -2607,7 +2739,11 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "https://npm.flatt.tech/iconv-lite/-/iconv-lite-0.7.2.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "react-reconciler/scheduler": ["scheduler@0.21.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ=="],
+
     "rimraf/glob": ["glob@7.2.3", "https://npm.flatt.tech/glob/-/glob-7.2.3.tgz", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "router/is-promise": ["is-promise@4.0.0", "https://npm.flatt.tech/is-promise/-/is-promise-4.0.0.tgz", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "sentence-splitter/@textlint/ast-node-types": ["@textlint/ast-node-types@13.4.1", "https://npm.flatt.tech/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz", {}, "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ=="],
 
@@ -2616,6 +2752,8 @@
     "source-map-support/source-map": ["source-map@0.6.1", "https://npm.flatt.tech/source-map/-/source-map-0.6.1.tgz", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "ssri/minipass": ["minipass@3.3.6", "https://npm.flatt.tech/minipass/-/minipass-3.3.6.tgz", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "svgo/commander": ["commander@11.1.0", "https://npm.flatt.tech/commander/-/commander-11.1.0.tgz", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -2654,6 +2792,10 @@
     "textlint-util-to-string/rehype-parse": ["rehype-parse@6.0.2", "https://npm.flatt.tech/rehype-parse/-/rehype-parse-6.0.2.tgz", { "dependencies": { "hast-util-from-parse5": "^5.0.0", "parse5": "^5.0.0", "xtend": "^4.0.0" } }, "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug=="],
 
     "textlint-util-to-string/unified": ["unified@8.4.2", "https://npm.flatt.tech/unified/-/unified-8.4.2.tgz", { "dependencies": { "bail": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^2.0.0", "trough": "^1.0.0", "vfile": "^4.0.0" } }, "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA=="],
+
+    "three-stdlib/fflate": ["fflate@0.6.10", "", {}, "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="],
+
+    "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "https://npm.flatt.tech/chokidar/-/chokidar-5.0.0.tgz", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 

--- a/docs/superpowers/plans/2026-05-03-madories-3d-preview.md
+++ b/docs/superpowers/plans/2026-05-03-madories-3d-preview.md
@@ -1,0 +1,852 @@
+# madories 3Dプレビュー機能実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** madoriesにReact Three Fiberを使った3Dプレビュー機能を追加し、2D編集画面と切り替えて間取りを鳥瞰図で確認できるようにする
+
+**Architecture:** FloorPlanデータを純粋関数で3Dジオメトリに変換し、R3FのCanvas内で床タイルと壁セグメントを表示する。2D/3D切り替えはApp.tsxでReact.lazyによるコード分割で行う。
+
+**Tech Stack:** React, TypeScript, React Three Fiber, @react-three/drei, Three.js, bun
+
+---
+
+## ファイル構成
+
+| ファイル | 種別 | 責務 |
+|---|---|---|
+| `packages/madories/src/floor/geometry-3d.ts` | 新規 | FloorPlan → FloorTile[] / WallSegment[] 変換 |
+| `packages/madories/src/floor/geometry-3d.test.ts` | 新規 | 変換ロジックの単体テスト |
+| `packages/madories/src/components/preview-3d/index.tsx` | 新規 | React.lazy用ラッパー + Suspense |
+| `packages/madories/src/components/preview-3d/scene.tsx` | 新規 | R3F Canvas・背景色・子コンポーネント配置 |
+| `packages/madories/src/components/preview-3d/camera.tsx` | 新規 | PerspectiveCamera + 制限付きOrbitControls |
+| `packages/madories/src/components/preview-3d/lighting.tsx` | 新規 | ambientLight + directionalLight |
+| `packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx` | 新規 | 床タイルメッシュ（PlaneGeometry水平） |
+| `packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx` | 新規 | 壁セグメントメッシュ（PlaneGeometry垂直） |
+| `packages/madories/src/components/App.tsx` | 修正 | viewMode状態、Preview3D遅延読み込み、条件付き表示 |
+| `packages/madories/src/components/tool-sheet.tsx` | 修正 | 3D切り替えボタン追加 |
+| `packages/madories/package.json` | 修正 | @react-three/fiber, @react-three/drei, three, @types/three 追加 |
+
+---
+
+## Task 1: 依存関係追加
+
+**Files:**
+- Modify: `packages/madories/package.json`
+
+- [ ] **Step 1: package.json に3Dライブラリを追加**
+
+```json
+{
+  "dependencies": {
+    "@mijime/theme": "workspace:*",
+    "@react-three/drei": "^9.114.0",
+    "@react-three/fiber": "^8.17.0",
+    "lucide-react": "^1.14.0",
+    "three": "^0.169.0",
+    "uuid": "^14.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.169.0",
+    "@types/uuid": "^11.0.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260429.1",
+    "bun-types": "^1.3.13",
+    "oxfmt": "^0.46.0",
+    "oxlint": "^1.62.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "^6.0.3"
+  }
+}
+```
+
+- [ ] **Step 2: インストール実行**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io && bun install`
+Expected: 依存関係が正常に解決され、bun.lockが更新される
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/madories/package.json bun.lock
+git commit -m "deps: add @react-three/fiber, @react-three/drei, three"
+```
+
+---
+
+## Task 2: 3Dジオメトリ変換ロジック（TDD）
+
+**Files:**
+- Create: `packages/madories/src/floor/geometry-3d.ts`
+- Create: `packages/madories/src/floor/geometry-3d.test.ts`
+
+- [ ] **Step 1: 変換ロジックのテストを書く**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { generateFloorTiles, generateWallSegments } from "./geometry-3d";
+import type { FloorPlan } from "../types";
+
+function makeFloor(width: number, height: number, overrides?: Partial<FloorPlan>): FloorPlan {
+  return {
+    cells: Array.from({ length: width * height }, () => ({
+      floorType: null,
+      item: null,
+      wall: { left: "none", top: "none" },
+    })),
+    height,
+    id: "test",
+    name: "test",
+    width,
+    ...overrides,
+  };
+}
+
+describe("generateFloorTiles", () => {
+  it("空のフロアは空配列を返す", () => {
+    const floor = makeFloor(2, 2);
+    expect(generateFloorTiles(floor)).toEqual([]);
+  });
+
+  it("floorType が設定されたセルのみ返す", () => {
+    const floor = makeFloor(2, 2, {
+      cells: [
+        { floorType: "wood", item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+        { floorType: "water", item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+      ],
+    });
+    expect(generateFloorTiles(floor)).toEqual([
+      { cx: 0, cy: 0, floorType: "wood" },
+      { cx: 0, cy: 1, floorType: "water" },
+    ]);
+  });
+});
+
+describe("generateWallSegments", () => {
+  it("壁がない場合は空配列を返す", () => {
+    const floor = makeFloor(2, 2);
+    expect(generateWallSegments(floor)).toEqual([]);
+  });
+
+  it("top壁とleft壁を正しく抽出する", () => {
+    const floor = makeFloor(2, 2, {
+      cells: [
+        { floorType: null, item: null, wall: { left: "solid", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "solid" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+      ],
+    });
+    expect(generateWallSegments(floor)).toEqual([
+      { cx: 0, cy: 0, edge: "left", wallType: "solid" },
+      { cx: 1, cy: 0, edge: "top", wallType: "solid" },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun test src/floor/geometry-3d.test.ts`
+Expected: FAIL - "generateFloorTiles is not defined" またはファイルが見つからないエラー
+
+- [ ] **Step 3: 変換ロジックを実装**
+
+```typescript
+import type { FloorPlan, FloorType, WallType } from "../types";
+
+export interface FloorTile {
+  cx: number;
+  cy: number;
+  floorType: FloorType;
+}
+
+export interface WallSegment {
+  cx: number;
+  cy: number;
+  edge: "top" | "left";
+  wallType: WallType;
+}
+
+export function generateFloorTiles(floor: FloorPlan): FloorTile[] {
+  const tiles: FloorTile[] = [];
+  for (let y = 0; y < floor.height; y++) {
+    for (let x = 0; x < floor.width; x++) {
+      const cell = floor.cells[y * floor.width + x];
+      if (cell.floorType !== null) {
+        tiles.push({ cx: x, cy: y, floorType: cell.floorType });
+      }
+    }
+  }
+  return tiles;
+}
+
+export function generateWallSegments(floor: FloorPlan): WallSegment[] {
+  const segments: WallSegment[] = [];
+  for (let y = 0; y < floor.height; y++) {
+    for (let x = 0; x < floor.width; x++) {
+      const cell = floor.cells[y * floor.width + x];
+      if (cell.wall.top !== "none") {
+        segments.push({ cx: x, cy: y, edge: "top", wallType: cell.wall.top });
+      }
+      if (cell.wall.left !== "none") {
+        segments.push({ cx: x, cy: y, edge: "left", wallType: cell.wall.left });
+      }
+    }
+  }
+  return segments;
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun test src/floor/geometry-3d.test.ts`
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/madories/src/floor/geometry-3d.ts packages/madories/src/floor/geometry-3d.test.ts
+git commit -m "feat: add FloorPlan to 3D geometry conversion"
+```
+
+---
+
+## Task 3: マテリアル色定数
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/materials.ts`
+
+- [ ] **Step 1: マテリアル色定数を作成**
+
+```typescript
+import type { FloorType, WallType } from "../../types";
+
+export const FLOOR_COLORS: Record<
+  FloorType,
+  { light: string; dark: string }
+> = {
+  wood: { light: "#d4a373", dark: "#8b6f47" },
+  water: { light: "#a8d5e5", dark: "#5a8fa0" },
+  tatami: { light: "#c8d6af", dark: "#7a8f5c" },
+  concrete: { light: "#b0b0b0", dark: "#707070" },
+  void: { light: "#e0e0e0", dark: "#404040" },
+};
+
+export const WALL_COLORS: Record<
+  Exclude<WallType, "none">,
+  { light: string; dark: string; opacity?: number }
+> = {
+  solid: { light: "#333333", dark: "#cccccc" },
+  solid_thin: { light: "#666666", dark: "#999999" },
+  window_full: { light: "#87ceeb", dark: "#5a8fa0", opacity: 0.5 },
+  window_center: { light: "#87ceeb", dark: "#5a8fa0", opacity: 0.5 },
+};
+
+export const WALL_HEIGHT_FACTOR = 2.5;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/materials.ts
+git commit -m "feat: add 3D preview material color constants"
+```
+
+---
+
+## Task 4: 床メッシュコンポーネント
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx`
+
+- [ ] **Step 1: FloorMeshコンポーネントを実装**
+
+```tsx
+import { useMemo } from "react";
+import type { FloorType } from "../../../types";
+import { FLOOR_COLORS } from "../materials";
+
+interface Props {
+  cx: number;
+  cy: number;
+  cellSize: number;
+  floorType: FloorType;
+  darkMode: boolean;
+}
+
+export function FloorMesh({ cx, cy, cellSize, floorType, darkMode }: Props) {
+  const worldX = (cx - 0) * cellSize; // width offset handled by parent group
+  const worldZ = (cy - 0) * cellSize; // height offset handled by parent group
+  const color = FLOOR_COLORS[floorType][darkMode ? "dark" : "light"];
+
+  return (
+    <mesh
+      position={[worldX, 0, worldZ]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
+      <planeGeometry args={[cellSize, cellSize]} />
+      <meshStandardMaterial color={color} />
+    </mesh>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx
+git commit -m "feat: add FloorMesh component"
+```
+
+---
+
+## Task 5: 壁メッシュコンポーネント
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx`
+
+- [ ] **Step 1: WallMeshコンポーネントを実装**
+
+```tsx
+import type { WallType } from "../../../types";
+import { WALL_COLORS, WALL_HEIGHT_FACTOR } from "../materials";
+
+interface Props {
+  cx: number;
+  cy: number;
+  cellSize: number;
+  edge: "top" | "left";
+  wallType: WallType;
+  darkMode: boolean;
+}
+
+export function WallMesh({ cx, cy, cellSize, edge, wallType, darkMode }: Props) {
+  if (wallType === "none") return null;
+
+  const wallHeight = cellSize * WALL_HEIGHT_FACTOR;
+  const colorDef = WALL_COLORS[wallType];
+  const color = colorDef[darkMode ? "dark" : "light"];
+  const opacity = colorDef.opacity ?? 1;
+
+  const worldX = (cx - 0) * cellSize;
+  const worldZ = (cy - 0) * cellSize;
+
+  if (wallType === "window_center") {
+    // Split into upper wall and lower window
+    const halfHeight = wallHeight / 2;
+    const wallColor = WALL_COLORS.solid[darkMode ? "dark" : "light"];
+    return (
+      <group>
+        {/* Upper wall */}
+        <mesh
+          position={[
+            edge === "top" ? worldX : worldX - cellSize / 2,
+            halfHeight + halfHeight / 2,
+            edge === "top" ? worldZ - cellSize / 2 : worldZ,
+          ]}
+          rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+        >
+          <planeGeometry args={[cellSize, halfHeight]} />
+          <meshStandardMaterial color={wallColor} />
+        </mesh>
+        {/* Lower window */}
+        <mesh
+          position={[
+            edge === "top" ? worldX : worldX - cellSize / 2,
+            halfHeight / 2,
+            edge === "top" ? worldZ - cellSize / 2 : worldZ,
+          ]}
+          rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+        >
+          <planeGeometry args={[cellSize, halfHeight]} />
+          <meshStandardMaterial color={color} transparent opacity={opacity} />
+        </mesh>
+      </group>
+    );
+  }
+
+  return (
+    <mesh
+      position={[
+        edge === "top" ? worldX : worldX - cellSize / 2,
+        wallHeight / 2,
+        edge === "top" ? worldZ - cellSize / 2 : worldZ,
+      ]}
+      rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+    >
+      <planeGeometry args={[cellSize, wallHeight]} />
+      <meshStandardMaterial
+        color={color}
+        transparent={opacity < 1}
+        opacity={opacity}
+      />
+    </mesh>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
+git commit -m "feat: add WallMesh component"
+```
+
+---
+
+## Task 6: ライティングコンポーネント
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/lighting.tsx`
+
+- [ ] **Step 1: Lightingコンポーネントを実装**
+
+```tsx
+interface Props {
+  darkMode: boolean;
+}
+
+export function Lighting({ darkMode }: Props) {
+  const ambientIntensity = darkMode ? 0.4 : 0.6;
+  const dirIntensity = darkMode ? 0.6 : 0.8;
+
+  return (
+    <>
+      <ambientLight intensity={ambientIntensity} />
+      <directionalLight position={[10, 20, 10]} intensity={dirIntensity} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/lighting.tsx
+git commit -m "feat: add Lighting component for 3D preview"
+```
+
+---
+
+## Task 7: カメラ・コントロールコンポーネント
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/camera.tsx`
+
+- [ ] **Step 1: PreviewCameraコンポーネントを実装**
+
+```tsx
+import { useRef } from "react";
+import { useThree } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+
+interface Props {
+  width: number;
+  height: number;
+  cellSize: number;
+}
+
+export function PreviewCamera({ width, height, cellSize }: Props) {
+  const controlsRef = useRef<OrbitControlsImpl>(null);
+  const maxDim = Math.max(width, height);
+  const distance = maxDim * cellSize * 0.8;
+  const maxDistance = maxDim * cellSize * 2;
+  const minDistance = cellSize * 3;
+
+  return (
+    <>
+      <perspectiveCamera makeDefault position={[0, distance, distance]} fov={50} />
+      <OrbitControls
+        ref={controlsRef}
+        enablePan={false}
+        minPolarAngle={Math.PI / 4}
+        maxPolarAngle={Math.PI / 4}
+        minDistance={minDistance}
+        maxDistance={maxDistance}
+        target={[0, 0, 0]}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/camera.tsx
+git commit -m "feat: add PreviewCamera with constrained OrbitControls"
+```
+
+---
+
+## Task 8: シーンコンポーネント
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/scene.tsx`
+
+- [ ] **Step 1: FloorPlanSceneコンポーネントを実装**
+
+```tsx
+import { useMemo } from "react";
+import { Canvas } from "@react-three/fiber";
+import type { FloorPlan } from "../../types";
+import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
+import { PreviewCamera } from "./camera";
+import { Lighting } from "./lighting";
+import { FloorMesh } from "./meshes/floor-mesh";
+import { WallMesh } from "./meshes/wall-mesh";
+
+interface Props {
+  floor: FloorPlan;
+  cellSize: number;
+  darkMode: boolean;
+}
+
+export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
+  const tiles = useMemo(() => generateFloorTiles(floor), [floor]);
+  const walls = useMemo(() => generateWallSegments(floor), [floor]);
+
+  const offsetX = (floor.width * cellSize) / 2 - cellSize / 2;
+  const offsetZ = (floor.height * cellSize) / 2 - cellSize / 2;
+
+  const bg = darkMode ? "#1a1a1a" : "#f5f5f5";
+
+  return (
+    <Canvas style={{ background: bg, height: "100%", width: "100%" }}>
+      <PreviewCamera width={floor.width} height={floor.height} cellSize={cellSize} />
+      <Lighting darkMode={darkMode} />
+      <group position={[-offsetX, 0, -offsetZ]}>
+        {tiles.map((tile) => (
+          <FloorMesh
+            key={`floor-${tile.cx}-${tile.cy}`}
+            cx={tile.cx}
+            cy={tile.cy}
+            cellSize={cellSize}
+            floorType={tile.floorType}
+            darkMode={darkMode}
+          />
+        ))}
+        {walls.map((wall, i) => (
+          <WallMesh
+            key={`wall-${wall.cx}-${wall.cy}-${wall.edge}-${i}`}
+            cx={wall.cx}
+            cy={wall.cy}
+            cellSize={cellSize}
+            edge={wall.edge}
+            wallType={wall.wallType}
+            darkMode={darkMode}
+          />
+        ))}
+      </group>
+    </Canvas>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/scene.tsx
+git commit -m "feat: add FloorPlanScene component"
+```
+
+---
+
+## Task 9: エントリーポイント（lazy importラッパー）
+
+**Files:**
+- Create: `packages/madories/src/components/preview-3d/index.tsx`
+
+- [ ] **Step 1: Preview3Dエントリコンポーネントを実装**
+
+```tsx
+import { Suspense } from "react";
+import type { FloorPlan } from "../../types";
+import { FloorPlanScene } from "./scene";
+
+interface Props {
+  floor: FloorPlan;
+  cellSize: number;
+  darkMode: boolean;
+}
+
+function Loader() {
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
+      <span style={{ fontFamily: "IBM Plex Mono, monospace", fontSize: "13px" }}>
+        Loading 3D...
+      </span>
+    </div>
+  );
+}
+
+export default function Preview3D({ floor, cellSize, darkMode }: Props) {
+  return (
+    <Suspense fallback={<Loader />}>
+      <FloorPlanScene floor={floor} cellSize={cellSize} darkMode={darkMode} />
+    </Suspense>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/madories/src/components/preview-3d/index.tsx
+git commit -m "feat: add Preview3D lazy entry point with Suspense"
+```
+
+---
+
+## Task 10: ツールシートに3D切り替えボタンを追加
+
+**Files:**
+- Modify: `packages/madories/src/components/tool-sheet.tsx`
+
+- [ ] **Step 1: PropsにviewModeとonToggleViewModeを追加**
+
+```typescript
+import {
+  Armchair,
+  BrickWall,
+  Download,
+  Eraser,
+  FolderOpen,
+  Link,
+  Maximize2,
+  MousePointer2,
+  PaintRoller,
+  Pencil,
+  Redo2,
+  RotateCw,
+  Save,
+  Trash2,
+  Undo2,
+  View,
+} from "lucide-react";
+
+interface Props {
+  tool: ToolMode;
+  onToolChange: (tool: ToolMode) => void;
+  onSave: () => void;
+  onLoad: () => void;
+  onExportAll: () => void;
+  onShare: () => void;
+  onClear: () => void;
+  onRotateFloor: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onFitView: () => void;
+  darkMode: boolean;
+  viewMode?: "2d" | "3d";
+  onToggleViewMode?: () => void;
+}
+```
+
+- [ ] **Step 2: ToolPanelContentの引数を展開し、ボタン群に3D切り替えを追加**
+
+`ToolPanelContent` の引数リストに `viewMode` と `onToggleViewMode` を追加し、下部のボタン群（`div style={{ display: "flex", gap: "4px" }}`）に以下を追加：
+
+```tsx
+{
+  disabled: false,
+  icon: <View size={14} />,
+  onClick: () => {
+    onToggleViewMode?.();
+    onClose?.();
+  },
+  title: viewMode === "3d" ? "2D" : "3D",
+},
+```
+
+このエントリーを `RotateCw` の前または後ろに配置する。
+
+- [ ] **Step 3: ToolSheet関数で新しいpropsをToolPanelContentに渡す**
+
+```tsx
+export function ToolSheet(props: Props) {
+```
+
+のままで、内部の `ToolPanelContent {...props}` で自動的に渡されるため変更不要。ただし `ToolPanelContent` の型定義に `viewMode` と `onToggleViewMode` が含まれていることを確認する。
+
+- [ ] **Step 4: 型チェックとテスト**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun run check`
+Expected: 型チェックが通る
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/madories/src/components/tool-sheet.tsx
+git commit -m "feat: add 3D preview toggle button to ToolSheet"
+```
+
+---
+
+## Task 11: App.tsx に3D切り替え統合
+
+**Files:**
+- Modify: `packages/madories/src/components/App.tsx`
+
+- [ ] **Step 1: React.lazyでPreview3Dを遅延読み込み**
+
+```tsx
+import { useCallback, useEffect, useRef, useState, lazy, Suspense } from "react";
+
+const Preview3D = lazy(() => import("./preview-3d"));
+```
+
+- [ ] **Step 2: viewMode状態を追加し、ツールシートに渡す**
+
+```tsx
+export function App() {
+  const [viewMode, setViewMode] = useState<"2d" | "3d">("2d");
+  // ... existing state
+```
+
+- [ ] **Step 3: ToolSheet呼び出しにviewModeとonToggleViewModeを追加**
+
+```tsx
+<ToolSheet
+  tool={tool}
+  onToolChange={setTool}
+  darkMode={dark}
+  canUndo={canUndo}
+  canRedo={canRedo}
+  onUndo={undo}
+  onRedo={redo}
+  onFitView={() => canvasRef.current?.fitToContainer()}
+  onSave={() => saveToFile(building, activeFloorId)}
+  // ... other props
+  viewMode={viewMode}
+  onToggleViewMode={() => setViewMode((v) => (v === "2d" ? "3d" : "2d"))}
+/>
+```
+
+- [ ] **Step 4: FloorCanvas表示部分をviewModeで条件分岐**
+
+```tsx
+<div className="flex-1 overflow-hidden relative flex flex-col" style={{ background: "var(--paper)" }}>
+  <FloorStats floor={floor} />
+  <div className="flex-1 overflow-hidden relative">
+    {viewMode === "2d" ? (
+      <FloorCanvas
+        ref={canvasRef}
+        floor={floor}
+        ghostFloors={ghostFloors}
+        cellSize={building.cellSize}
+        darkMode={dark}
+        tool={tool}
+        // ... all existing handlers
+      />
+    ) : (
+      <Preview3D
+        floor={floor}
+        cellSize={building.cellSize}
+        darkMode={dark}
+      />
+    )}
+  </div>
+</div>
+```
+
+- [ ] **Step 5: 型チェックとテスト**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun run check`
+Expected: 型チェックが通る
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun test`
+Expected: 既存テスト + geometry-3d.test.ts が全て通る
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/madories/src/components/App.tsx
+git commit -m "feat: integrate 3D preview toggle into App"
+```
+
+---
+
+## Task 12: 最終検証
+
+**Files:**
+- 変更対象全体
+
+- [ ] **Step 1: ビルド確認**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io && bun run build`
+Expected: エラーなくビルド完了
+
+- [ ] **Step 2: 型チェックとリント**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun run check`
+Expected: oxlint と tsgo が共に通る
+
+- [ ] **Step 3: テスト実行**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io/packages/madories && bun test`
+Expected: 全テストがパス
+
+- [ ] **Step 4: 動作確認（手動）**
+
+Run: `cd /home/mijime/src/github.com/mijime/mijime.github.io && bun run dev`
+手動確認項目:
+1. 2D編集画面が正常に表示される
+2. ToolSheetの「3D」ボタンをクリックすると3Dプレビューに切り替わる
+3. 3Dプレビューでドラッグで水平回転、ホイールでズームができる
+4. 「2D」ボタンで2D編集画面に戻れる
+5. 床と壁が正しい色で表示される
+6. ダークモード切り替えで3Dの背景色・マテリアルが追従する
+
+- [ ] **Step 5: 最終コミット（必要に応じて）**
+
+変更があればコミット。なければ既存コミットのままで完了。
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| 設計書要件 | 実装タスク |
+|---|---|
+| 表示モード切り替え | Task 10, 11 |
+| 壁：厚みなしの板 | Task 5 |
+| 床：floorTypeに応じたタイル | Task 4 |
+| 家具：非表示 | （床・壁のみ実装、家具コンポーネント未作成）✅ |
+| 現在選択中の階のみ表示 | Task 8, 11（activeFloorIdのfloorを渡す）✅ |
+| ドラッグで水平回転 | Task 7（minPolarAngle=maxPolarAngle）✅ |
+| ホイール/ピンチでズーム | Task 7（OrbitControls標準対応）✅ |
+| 見下ろし角度45°固定 | Task 7 ✅ |
+| パン無効 | Task 7（enablePan=false）✅ |
+| スマホ対応 | Task 7（タッチ・ピンチはOrbitControls標準対応）✅ |
+| コード分割 | Task 11（React.lazy）✅ |
+| ダークモード対応 | Task 4, 5, 6, 8 ✅ |
+
+### Placeholder scan
+
+- 「TBD」「TODO」「implement later」なし ✅
+- 全ステップに実際のコードまたは正確なコマンドが含まれている ✅
+- 型・関数名に矛盾なし ✅
+
+### Type consistency
+
+- `FloorTile`, `WallSegment` の型は Task 2 で定義し、Task 4, 5, 8 で一貫して使用 ✅
+- `viewMode: "2d" | "3d"` は Task 10, 11 で一貫 ✅
+- `Preview3D` の props は Task 9 と Task 11 で一致 ✅

--- a/docs/superpowers/specs/2026-05-03-madories-3d-preview-design.md
+++ b/docs/superpowers/specs/2026-05-03-madories-3d-preview-design.md
@@ -1,0 +1,223 @@
+# madories 3Dプレビュー機能設計書
+
+**日付:** 2026-05-03
+**ステータス:** 設計承認済み
+
+## 概要
+
+madories（ブラウザベース間取りエディタ）に、React Three Fiber（R3F）を用いた3Dプレビュー機能を追加する。ユーザーは2D編集画面と3Dプレビュー画面を切り替えて、間取りを鳥瞰図で回転・拡大して確認できる。
+
+## 背景・目的
+
+- 2Dの間取り図だけでは空間のつながりや部屋の配置がイメージしにくい場面がある
+- 壁と床を3Dで確認できれば、設計段階での認識齟齬を減らせる
+- 編集は2D画面で行い、確認は3D画面で行うという分離されたワークフローを提供する
+
+## 要件
+
+### 機能要件
+
+1. **表示モード切り替え**
+   - 2D編集画面と3Dプレビュー画面をツールバーボタンで切り替える
+   - 3Dプレビューは編集不可（閲覧専用）
+
+2. **3D表示内容**
+   - 壁：厚みなしの板（PlaneGeometry）として表示
+   - 床：`floorType` に応じた色・質感のタイルを表示
+   - 家具：今回は非表示（将来拡張の余地を残す）
+   - 表示対象階：現在選択中の階のみ
+
+3. **操作**
+   - ドラッグ（1本指）で水平方向回転
+   - マウスホイール / ピンチで拡大縮小
+   - 見下ろし角度は45°固定
+   - パン（移動）は無効
+
+4. **スマホ対応**
+   - タッチ操作に対応（ピンチズーム、1本指ドラッグ回転）
+   - 小画面でも全体が見えるよう最小距離を調整
+
+### 非機能要件
+
+- バンドルサイズ：コード分割（dynamic import）により、2D編集画面の初回ロードに影響を与えない
+- パフォーマンス：20×20セル程度の間取りで60fps維持
+- ダークモード対応：3Dシーンの背景色・マテリアルがダークモードに追従する
+
+## アーキテクチャ
+
+```
+packages/madories/src/
+├── components/
+│   ├── App.tsx              # viewMode状態管理、2D/3D切り替え
+│   ├── floor-canvas.tsx     # 既存：2D編集キャンバス
+│   └── preview-3d/          # 新規：3Dプレビュー
+│       ├── index.tsx        # Preview3D（React.lazy用ラッパー）
+│       ├── scene.tsx        # FloorPlanScene（R3F Canvas内シーン）
+│       ├── camera.tsx       # PreviewCamera（制限付きOrbitControls）
+│       ├── lighting.tsx     # ライティング設定
+│       └── meshes/
+│           ├── floor-mesh.tsx   # 床タイルメッシュ
+│           └── wall-mesh.tsx    # 壁セグメントメッシュ
+├── floor/
+│   └── geometry-3d.ts     # FloorPlan → 3Dジオメトリ変換ロジック
+```
+
+## コンポーネント詳細
+
+### `App.tsx`
+
+- `viewMode: "2d" | "3d"` 状態を追加
+- `ToolSheet` に3D切り替えボタンを追加
+- `viewMode === "3d"` の場合、`FloorCanvas` の代わりに `Preview3D` を表示
+- `Preview3D` は `React.lazy(() => import("./preview-3d"))` で遅延読み込み
+
+### `preview-3d/index.tsx`
+
+- `Suspense` + `fallback`（簡易ローダー）で `Preview3DCanvas` を包む
+- props: `floor: FloorPlan`, `cellSize: number`, `darkMode: boolean`
+
+### `preview-3d/scene.tsx`
+
+- `<Canvas>` でR3Fレンダラを初期化
+- 背景色：`darkMode ? "#1a1a1a" : "#f5f5f5"`
+- 子要素：`PreviewCamera`, `Lighting`, `FloorMeshes`, `WallMeshes`
+
+### `preview-3d/camera.tsx`
+
+- `PerspectiveCamera`（fov=50）
+- `OrbitControls` を以下の制約で設定：
+  - `minPolarAngle = maxPolarAngle = Math.PI / 4`
+  - `enablePan = false`
+  - `minDistance = cellSize * 3`
+  - `maxDistance = cellSize * max(width, height) * 2`
+- 初期位置：全体が収まる自動計算
+
+### `preview-3d/lighting.tsx`
+
+- `<ambientLight intensity={0.6} />`
+- `<directionalLight position={[10, 20, 10]} intensity={0.8} />`
+- ダークモード時は intensity を調整
+
+### `meshes/floor-mesh.tsx`
+
+- props: `cx, cy, cellSize, floorType, darkMode`
+- `PlaneGeometry(cellSize, cellSize)` + `rotation.x = -Math.PI / 2`
+- `floorType` に対応した `MeshStandardMaterial`（色は2D表示と整合）
+
+### `meshes/wall-mesh.tsx`
+
+- props: `cx, cy, cellSize, edge: "top" | "left", wallType, darkMode`
+- `PlaneGeometry(cellSize, wallHeight)` を垂直に配置
+- `wallType` に応じた色・透過率
+- `wallType === "none"` の場合はレンダリングしない
+
+## データフロー・ジオメトリ変換
+
+### `floor/geometry-3d.ts`
+
+```typescript
+export interface FloorTile {
+  cx: number;
+  cy: number;
+  floorType: FloorType;
+}
+
+export interface WallSegment {
+  cx: number;
+  cy: number;
+  edge: "top" | "left";
+  wallType: WallType;
+}
+
+export function generateFloorTiles(floor: FloorPlan): FloorTile[];
+export function generateWallSegments(floor: FloorPlan): WallSegment[];
+```
+
+### 座標変換
+
+2D編集画面（左上原点）→ 3Dワールド（中心原点）:
+
+```
+worldX = (cx - width/2) * cellSize
+worldZ = (cy - height/2) * cellSize
+worldY = 0（床面）
+```
+
+### 壁セグメント配置
+
+- **top壁**: `position=[worldX, wallHeight/2, worldZ - cellSize/2]`, `rotation.y=0`
+- **left壁**: `position=[worldX - cellSize/2, wallHeight/2, worldZ]`, `rotation.y=Math.PI/2`
+
+壁高さ: `cellSize * 2.5`（十分に高く見える値）
+
+## マテリアル仕様
+
+### 床色（2D表示との整合）
+
+| floorType | ライトモード | ダークモード |
+|---|---|---|
+| wood | `#d4a373` | `#8b6f47` |
+| water | `#a8d5e5` | `#5a8fa0` |
+| tatami | `#c8d6af` | `#7a8f5c` |
+| concrete | `#b0b0b0` | `#707070` |
+| void | `#e0e0e0` | `#404040` |
+
+### 壁色
+
+| wallType | ライトモード | ダークモード |
+|---|---|---|
+| solid | `#333333` | `#cccccc` |
+| solid_thin | `#666666` | `#999999` |
+| window_full | 半透明青 `#87ceeb` @ opacity 0.5 | `#5a8fa0` @ opacity 0.5 |
+| window_center | 上部50%を壁、下部50%を窓として2枚の板に分割して表示 |
+
+## エラーハンドリング
+
+1. **3Dライブラリ読み込み失敗**
+   - `React.lazy` の `fallback` でローディング中表示
+   - dynamic import 失敗時はエラーメッセージを表示し、2D画面に戻るボタンを提供
+
+2. **WebGL非対応環境**
+   - `Canvas` コンポーネントがエラーを投げる場合をキャッチ
+   - 「お使いのブラウザは3D表示に対応していません」メッセージを表示
+
+3. **大規模間取り**
+   - 50×50セルを超える場合、インスタンスメッシュ（InstancedMesh）への移行を検討（将来対応）
+
+## パフォーマンス考慮
+
+- `React.memo` でメッシュコンポーネントをラップし、不要な再レンダリングを防止
+- `useMemo` で `generateFloorTiles` / `generateWallSegments` の結果をキャッシュ
+- 将来の拡張として `InstancedMesh` への移行を見据えた設計（型・データ構造を互換に保つ）
+
+## テスト方針
+
+- `floor/geometry-3d.ts` の変換ロジックに対して単体テストを追加
+  - 空のFloorPlan → 空の配列
+  - 1セルに壁・床があるFloorPlan → 正しい座標・向きのセグメント
+  - 窓タイプの壁 → 正しいマテリアル属性
+- 3DコンポーネントのテストはR3Fのレンダリングテスト（`@react-three/test-renderer`）で検討
+
+## 依存関係
+
+`packages/madories/package.json` に以下を追加：
+
+```json
+{
+  "dependencies": {
+    "@react-three/fiber": "^8.17.0",
+    "@react-three/drei": "^9.114.0",
+    "three": "^0.169.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.169.0"
+  }
+}
+```
+
+## 将来拡張
+
+- **家具3D表示**: `Item` 型に対応した簡易3Dモデル（Box, Cylinder など）を配置
+- **複数階表示**: 階ごとにy軸オフセットを設定し、建物全体を3D表示
+- **厚みのある壁**: 壁に厚みを持たせ、コーナー部の接続を自然にする
+- **InstancedMesh**: 大規模間取りでの描画パフォーマンス最適化

--- a/packages/madories/package.json
+++ b/packages/madories/package.json
@@ -17,13 +17,17 @@
   },
   "dependencies": {
     "@mijime/theme": "workspace:*",
+    "@react-three/drei": "^9.114.0",
+    "@react-three/fiber": "^8.17.0",
     "lucide-react": "^1.14.0",
+    "three": "^0.169.0",
     "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.169.0",
     "@types/uuid": "^11.0.0",
     "@typescript/native-preview": "^7.0.0-dev.20260429.1",
     "bun-types": "^1.3.13",

--- a/packages/madories/package.json
+++ b/packages/madories/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@mijime/theme": "workspace:*",
-    "@react-three/drei": "^9.114.0",
-    "@react-three/fiber": "^8.17.0",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "lucide-react": "^1.14.0",
     "three": "^0.169.0",
     "uuid": "^14.0.0"
@@ -29,7 +29,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.169.0",
     "@types/uuid": "^11.0.0",
-    "@typescript/native-preview": "^7.0.0-dev.20260429.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260503.1",
     "bun-types": "^1.3.13",
     "oxfmt": "^0.46.0",
     "oxlint": "^1.62.0",

--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -255,7 +255,23 @@ export function App() {
                 onUndo={undo}
               />
             ) : (
-              <Suspense fallback={null}>
+              <Suspense
+                fallback={
+                  <div
+                    style={{
+                      alignItems: "center",
+                      display: "flex",
+                      height: "100%",
+                      justifyContent: "center",
+                      width: "100%",
+                    }}
+                  >
+                    <span style={{ fontFamily: "IBM Plex Mono, monospace", fontSize: "13px" }}>
+                      Loading 3D…
+                    </span>
+                  </div>
+                }
+              >
                 <Preview3D floor={floor} cellSize={building.cellSize} darkMode={dark} />
               </Suspense>
             )}

--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, lazy, Suspense } from "react";
 import { useDarkMode } from "@mijime/theme/useDarkMode";
 import { computeFloorScores, exportAllFloorsPng } from "../draw/export";
 import { buildShareUrl, encodeFloors, mergeFloors } from "../floor/share";
@@ -16,6 +16,8 @@ import type { ToolMode } from "./tool-mode";
 import { FLOOR_TYPES, floorTypeToSwatchStyle } from "./tool-mode";
 import { ToolSheet } from "./tool-sheet";
 import type { FloorPlan } from "../types";
+
+const Preview3D = lazy(() => import("./preview-3d"));
 
 function FloorStats({ floor }: { floor: FloorPlan }) {
   const { storage, windows } = computeFloorScores(floor);
@@ -54,6 +56,7 @@ export function App() {
 
   useAppInit(push);
 
+  const [viewMode, setViewMode] = useState<"2d" | "3d">("2d");
   const [tool, setTool] = useState<ToolMode>({ kind: "select" });
   const canvasRef = useRef<FloorCanvasHandle>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -146,6 +149,8 @@ export function App() {
           onShare={handleShare}
           onClear={() => dispatch({ floorId: floor.id, type: "CLEAR_FLOOR" })}
           onRotateFloor={() => dispatch({ floorId: floor.id, type: "ROTATE_FLOOR" })}
+          viewMode={viewMode}
+          onToggleViewMode={() => setViewMode((v) => (v === "2d" ? "3d" : "2d"))}
         />
         <DslPanel
           floors={building.floors}
@@ -162,92 +167,98 @@ export function App() {
         >
           <FloorStats floor={floor} />
           <div className="flex-1 overflow-hidden relative">
-            <FloorCanvas
-              ref={canvasRef}
-              floor={floor}
-              ghostFloors={ghostFloors}
-              cellSize={building.cellSize}
-              darkMode={dark}
-              tool={tool}
-              onSetWall={(cellIndex, edge, wallType) => {
-                dispatch({
-                  cellIndex,
-                  edge,
-                  floorId: floor.id,
-                  type: "SET_WALL",
-                  wallType,
-                });
-              }}
-              onSetFloorType={(cellIndex, floorType) =>
-                dispatch({
-                  cellIndex,
-                  floorId: floor.id,
-                  floorType,
-                  type: "SET_FLOOR_TYPE",
-                })
-              }
-              onFillRoom={(cellIndex) => {
-                if (tool.kind !== "floor" || tool.floorType === null) {
-                  return;
+            {viewMode === "2d" ? (
+              <FloorCanvas
+                ref={canvasRef}
+                floor={floor}
+                ghostFloors={ghostFloors}
+                cellSize={building.cellSize}
+                darkMode={dark}
+                tool={tool}
+                onSetWall={(cellIndex, edge, wallType) => {
+                  dispatch({
+                    cellIndex,
+                    edge,
+                    floorId: floor.id,
+                    type: "SET_WALL",
+                    wallType,
+                  });
+                }}
+                onSetFloorType={(cellIndex, floorType) =>
+                  dispatch({
+                    cellIndex,
+                    floorId: floor.id,
+                    floorType,
+                    type: "SET_FLOOR_TYPE",
+                  })
                 }
-                dispatch({
-                  cellIndex,
-                  floorId: floor.id,
-                  floorType: tool.floorType,
-                  type: "FILL_ROOM",
-                });
-              }}
-              onPlaceItem={(cellIndex) => {
-                if (tool.kind !== "item") {
-                  return;
+                onFillRoom={(cellIndex) => {
+                  if (tool.kind !== "floor" || tool.floorType === null) {
+                    return;
+                  }
+                  dispatch({
+                    cellIndex,
+                    floorId: floor.id,
+                    floorType: tool.floorType,
+                    type: "FILL_ROOM",
+                  });
+                }}
+                onPlaceItem={(cellIndex) => {
+                  if (tool.kind !== "item") {
+                    return;
+                  }
+                  dispatch({
+                    cellIndex,
+                    floorId: floor.id,
+                    item: {
+                      rotation: 0,
+                      type: (tool as { kind: "item"; itemType: ItemType }).itemType,
+                    },
+                    type: "PLACE_ITEM",
+                  });
+                }}
+                onRotateItem={(cellIndex) =>
+                  dispatch({ cellIndex, floorId: floor.id, type: "ROTATE_ITEM" })
                 }
-                dispatch({
-                  cellIndex,
-                  floorId: floor.id,
-                  item: {
-                    rotation: 0,
-                    type: (tool as { kind: "item"; itemType: ItemType }).itemType,
-                  },
-                  type: "PLACE_ITEM",
-                });
-              }}
-              onRotateItem={(cellIndex) =>
-                dispatch({ cellIndex, floorId: floor.id, type: "ROTATE_ITEM" })
-              }
-              onMoveItem={(fromIndex, toIndex) =>
-                dispatch({
-                  floorId: floor.id,
-                  fromIndex,
-                  toIndex,
-                  type: "MOVE_ITEM",
-                })
-              }
-              onPasteRegion={(originIndex: number, region: CopiedRegion) =>
-                dispatch({
-                  floorId: floor.id,
-                  originIndex,
-                  region,
-                  type: "PASTE_REGION",
-                })
-              }
-              onEraseRegion={(x1, y1, x2, y2) =>
-                dispatch({
-                  floorId: floor.id,
-                  type: "ERASE_REGION",
-                  x1,
-                  x2,
-                  y1,
-                  y2,
-                })
-              }
-              onEraseCell={(cellIndex) =>
-                dispatch({ cellIndex, floorId: floor.id, type: "ERASE_CELL" })
-              }
-              onLongPressRoom={(cellIndex, clientX, clientY) =>
-                setRoomPicker({ cellIndex, x: clientX, y: clientY })
-              }
-              onUndo={undo}
-            />
+                onMoveItem={(fromIndex, toIndex) =>
+                  dispatch({
+                    floorId: floor.id,
+                    fromIndex,
+                    toIndex,
+                    type: "MOVE_ITEM",
+                  })
+                }
+                onPasteRegion={(originIndex: number, region: CopiedRegion) =>
+                  dispatch({
+                    floorId: floor.id,
+                    originIndex,
+                    region,
+                    type: "PASTE_REGION",
+                  })
+                }
+                onEraseRegion={(x1, y1, x2, y2) =>
+                  dispatch({
+                    floorId: floor.id,
+                    type: "ERASE_REGION",
+                    x1,
+                    x2,
+                    y1,
+                    y2,
+                  })
+                }
+                onEraseCell={(cellIndex) =>
+                  dispatch({ cellIndex, floorId: floor.id, type: "ERASE_CELL" })
+                }
+                onLongPressRoom={(cellIndex, clientX, clientY) =>
+                  setRoomPicker({ cellIndex, x: clientX, y: clientY })
+                }
+                onUndo={undo}
+              />
+            ) : (
+              <Suspense fallback={null}>
+                <Preview3D floor={floor} cellSize={building.cellSize} darkMode={dark} />
+              </Suspense>
+            )}
           </div>
         </div>
       </div>

--- a/packages/madories/src/components/preview-3d/camera.tsx
+++ b/packages/madories/src/components/preview-3d/camera.tsx
@@ -1,5 +1,4 @@
-import { useRef } from "react";
-import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { PerspectiveCamera } from "@react-three/drei";
 
 interface Props {
   width: number;
@@ -8,24 +7,8 @@ interface Props {
 }
 
 export function PreviewCamera({ width, height, cellSize }: Props) {
-  const controlsRef = useRef<React.ElementRef<typeof OrbitControls>>(null);
   const maxDim = Math.max(width, height);
   const distance = maxDim * cellSize * 0.8;
-  const maxDistance = maxDim * cellSize * 2;
-  const minDistance = cellSize * 3;
 
-  return (
-    <>
-      <PerspectiveCamera makeDefault position={[0, distance, distance]} fov={50} />
-      <OrbitControls
-        ref={controlsRef}
-        enablePan={false}
-        minPolarAngle={Math.PI / 4}
-        maxPolarAngle={Math.PI / 4}
-        minDistance={minDistance}
-        maxDistance={maxDistance}
-        target={[0, 0, 0]}
-      />
-    </>
-  );
+  return <PerspectiveCamera makeDefault position={[0, distance, distance]} fov={50} />;
 }

--- a/packages/madories/src/components/preview-3d/camera.tsx
+++ b/packages/madories/src/components/preview-3d/camera.tsx
@@ -1,0 +1,31 @@
+import { useRef } from "react";
+import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
+
+interface Props {
+  width: number;
+  height: number;
+  cellSize: number;
+}
+
+export function PreviewCamera({ width, height, cellSize }: Props) {
+  const controlsRef = useRef<React.ElementRef<typeof OrbitControls>>(null);
+  const maxDim = Math.max(width, height);
+  const distance = maxDim * cellSize * 0.8;
+  const maxDistance = maxDim * cellSize * 2;
+  const minDistance = cellSize * 3;
+
+  return (
+    <>
+      <PerspectiveCamera makeDefault position={[0, distance, distance]} fov={50} />
+      <OrbitControls
+        ref={controlsRef}
+        enablePan={false}
+        minPolarAngle={Math.PI / 4}
+        maxPolarAngle={Math.PI / 4}
+        minDistance={minDistance}
+        maxDistance={maxDistance}
+        target={[0, 0, 0]}
+      />
+    </>
+  );
+}

--- a/packages/madories/src/components/preview-3d/index.tsx
+++ b/packages/madories/src/components/preview-3d/index.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import type { FloorPlan } from "../../types";
 import { FloorPlanScene } from "./scene";
 
@@ -8,28 +7,6 @@ interface Props {
   darkMode: boolean;
 }
 
-function Loader() {
-  return (
-    <div
-      style={{
-        alignItems: "center",
-        display: "flex",
-        height: "100%",
-        justifyContent: "center",
-        width: "100%",
-      }}
-    >
-      <span style={{ fontFamily: "IBM Plex Mono, monospace", fontSize: "13px" }}>
-        Loading 3D...
-      </span>
-    </div>
-  );
-}
-
 export default function Preview3D({ floor, cellSize, darkMode }: Props) {
-  return (
-    <Suspense fallback={<Loader />}>
-      <FloorPlanScene floor={floor} cellSize={cellSize} darkMode={darkMode} />
-    </Suspense>
-  );
+  return <FloorPlanScene floor={floor} cellSize={cellSize} darkMode={darkMode} />;
 }

--- a/packages/madories/src/components/preview-3d/index.tsx
+++ b/packages/madories/src/components/preview-3d/index.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react";
+import type { FloorPlan } from "../../types";
+import { FloorPlanScene } from "./scene";
+
+interface Props {
+  floor: FloorPlan;
+  cellSize: number;
+  darkMode: boolean;
+}
+
+function Loader() {
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
+      <span style={{ fontFamily: "IBM Plex Mono, monospace", fontSize: "13px" }}>
+        Loading 3D...
+      </span>
+    </div>
+  );
+}
+
+export default function Preview3D({ floor, cellSize, darkMode }: Props) {
+  return (
+    <Suspense fallback={<Loader />}>
+      <FloorPlanScene floor={floor} cellSize={cellSize} darkMode={darkMode} />
+    </Suspense>
+  );
+}

--- a/packages/madories/src/components/preview-3d/lighting.tsx
+++ b/packages/madories/src/components/preview-3d/lighting.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  darkMode: boolean;
+}
+
+export function Lighting({ darkMode }: Props) {
+  const ambientIntensity = darkMode ? 0.4 : 0.6;
+  const dirIntensity = darkMode ? 0.6 : 0.8;
+
+  return (
+    <>
+      <ambientLight intensity={ambientIntensity} />
+      <directionalLight position={[10, 20, 10]} intensity={dirIntensity} />
+    </>
+  );
+}

--- a/packages/madories/src/components/preview-3d/materials.ts
+++ b/packages/madories/src/components/preview-3d/materials.ts
@@ -1,0 +1,21 @@
+import type { FloorType, WallType } from "../../types";
+
+export const FLOOR_COLORS: Record<FloorType, { light: string; dark: string }> = {
+  wood: { light: "#d4a373", dark: "#8b6f47" },
+  water: { light: "#a8d5e5", dark: "#5a8fa0" },
+  tatami: { light: "#c8d6af", dark: "#7a8f5c" },
+  concrete: { light: "#b0b0b0", dark: "#707070" },
+  void: { light: "#e0e0e0", dark: "#404040" },
+};
+
+export const WALL_COLORS: Record<
+  Exclude<WallType, "none">,
+  { light: string; dark: string; opacity?: number }
+> = {
+  solid: { light: "#333333", dark: "#cccccc" },
+  solid_thin: { light: "#666666", dark: "#999999" },
+  window_full: { light: "#87ceeb", dark: "#5a8fa0", opacity: 0.5 },
+  window_center: { light: "#87ceeb", dark: "#5a8fa0", opacity: 0.5 },
+};
+
+export const WALL_HEIGHT_FACTOR = 2.5;

--- a/packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { FloorType } from "../../../types";
 import { FLOOR_COLORS } from "../materials";
 
@@ -9,7 +10,7 @@ interface Props {
   darkMode: boolean;
 }
 
-export function FloorMesh({ cx, cy, cellSize, floorType, darkMode }: Props) {
+export const FloorMesh = memo(function FloorMesh({ cx, cy, cellSize, floorType, darkMode }: Props) {
   const worldX = cx * cellSize;
   const worldZ = cy * cellSize;
   const color = FLOOR_COLORS[floorType][darkMode ? "dark" : "light"];
@@ -20,4 +21,4 @@ export function FloorMesh({ cx, cy, cellSize, floorType, darkMode }: Props) {
       <meshStandardMaterial color={color} />
     </mesh>
   );
-}
+});

--- a/packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/floor-mesh.tsx
@@ -1,0 +1,23 @@
+import type { FloorType } from "../../../types";
+import { FLOOR_COLORS } from "../materials";
+
+interface Props {
+  cx: number;
+  cy: number;
+  cellSize: number;
+  floorType: FloorType;
+  darkMode: boolean;
+}
+
+export function FloorMesh({ cx, cy, cellSize, floorType, darkMode }: Props) {
+  const worldX = cx * cellSize;
+  const worldZ = cy * cellSize;
+  const color = FLOOR_COLORS[floorType][darkMode ? "dark" : "light"];
+
+  return (
+    <mesh position={[worldX, 0, worldZ]} rotation={[-Math.PI / 2, 0, 0]}>
+      <planeGeometry args={[cellSize, cellSize]} />
+      <meshStandardMaterial color={color} />
+    </mesh>
+  );
+}

--- a/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
@@ -64,11 +64,7 @@ export function WallMesh({ cx, cy, cellSize, edge, wallType, darkMode }: Props) 
       rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
     >
       <planeGeometry args={[cellSize, wallHeight]} />
-      <meshStandardMaterial
-        color={color}
-        transparent={opacity < 1}
-        opacity={opacity}
-      />
+      <meshStandardMaterial color={color} transparent={opacity < 1} opacity={opacity} />
     </mesh>
   );
 }

--- a/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { WallType } from "../../../types";
 import { WALL_COLORS, WALL_HEIGHT_FACTOR } from "../materials";
 
@@ -10,7 +11,14 @@ interface Props {
   darkMode: boolean;
 }
 
-export function WallMesh({ cx, cy, cellSize, edge, wallType, darkMode }: Props) {
+export const WallMesh = memo(function WallMesh({
+  cx,
+  cy,
+  cellSize,
+  edge,
+  wallType,
+  darkMode,
+}: Props) {
   if (wallType === "none") return null;
 
   const wallHeight = cellSize * WALL_HEIGHT_FACTOR;
@@ -67,4 +75,4 @@ export function WallMesh({ cx, cy, cellSize, edge, wallType, darkMode }: Props) 
       <meshStandardMaterial color={color} transparent={opacity < 1} opacity={opacity} />
     </mesh>
   );
-}
+});

--- a/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/wall-mesh.tsx
@@ -1,0 +1,74 @@
+import type { WallType } from "../../../types";
+import { WALL_COLORS, WALL_HEIGHT_FACTOR } from "../materials";
+
+interface Props {
+  cx: number;
+  cy: number;
+  cellSize: number;
+  edge: "top" | "left";
+  wallType: WallType;
+  darkMode: boolean;
+}
+
+export function WallMesh({ cx, cy, cellSize, edge, wallType, darkMode }: Props) {
+  if (wallType === "none") return null;
+
+  const wallHeight = cellSize * WALL_HEIGHT_FACTOR;
+  const colorDef = WALL_COLORS[wallType];
+  const color = colorDef[darkMode ? "dark" : "light"];
+  const opacity = colorDef.opacity ?? 1;
+
+  const worldX = cx * cellSize;
+  const worldZ = cy * cellSize;
+
+  if (wallType === "window_center") {
+    const halfHeight = wallHeight / 2;
+    const wallColor = WALL_COLORS.solid[darkMode ? "dark" : "light"];
+    return (
+      <group>
+        {/* Upper wall */}
+        <mesh
+          position={[
+            edge === "top" ? worldX : worldX - cellSize / 2,
+            halfHeight + halfHeight / 2,
+            edge === "top" ? worldZ - cellSize / 2 : worldZ,
+          ]}
+          rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+        >
+          <planeGeometry args={[cellSize, halfHeight]} />
+          <meshStandardMaterial color={wallColor} />
+        </mesh>
+        {/* Lower window */}
+        <mesh
+          position={[
+            edge === "top" ? worldX : worldX - cellSize / 2,
+            halfHeight / 2,
+            edge === "top" ? worldZ - cellSize / 2 : worldZ,
+          ]}
+          rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+        >
+          <planeGeometry args={[cellSize, halfHeight]} />
+          <meshStandardMaterial color={color} transparent opacity={opacity} />
+        </mesh>
+      </group>
+    );
+  }
+
+  return (
+    <mesh
+      position={[
+        edge === "top" ? worldX : worldX - cellSize / 2,
+        wallHeight / 2,
+        edge === "top" ? worldZ - cellSize / 2 : worldZ,
+      ]}
+      rotation={[0, edge === "left" ? Math.PI / 2 : 0, 0]}
+    >
+      <planeGeometry args={[cellSize, wallHeight]} />
+      <meshStandardMaterial
+        color={color}
+        transparent={opacity < 1}
+        opacity={opacity}
+      />
+    </mesh>
+  );
+}

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Canvas } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
 import type { FloorPlan } from "../../types";
 import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
 import { PreviewCamera } from "./camera";
@@ -14,9 +15,6 @@ interface Props {
 }
 
 export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
-  const [status, setStatus] = useState<string>("initializing");
-  const [err, setErr] = useState<string | null>(null);
-
   const tiles = useMemo(() => generateFloorTiles(floor), [floor]);
   const walls = useMemo(() => generateWallSegments(floor), [floor]);
 
@@ -25,63 +23,26 @@ export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
 
   const bg = darkMode ? "#1a1a1a" : "#f5f5f5";
 
+  const maxDim = Math.max(floor.width, floor.height);
+
   return (
     <>
-      {err && (
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            zIndex: 20,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "rgba(0,0,0,0.8)",
-            color: "#ff4444",
-            fontFamily: "IBM Plex Mono, monospace",
-            fontSize: "14px",
-            padding: "20px",
-            textAlign: "center",
-          }}
-        >
-          <div>
-            <div style={{ fontWeight: "bold", marginBottom: "8px" }}>3D Error</div>
-            <div>{err}</div>
-          </div>
-        </div>
-      )}
-      <div
-        style={{
-          position: "absolute",
-          top: 8,
-          left: 8,
-          zIndex: 10,
-          background: "rgba(0,0,0,0.6)",
-          color: "#0f0",
-          fontFamily: "IBM Plex Mono, monospace",
-          fontSize: "11px",
-          padding: "4px 8px",
-          borderRadius: "4px",
-          pointerEvents: "none",
-        }}
-      >
-        3D: {status}
-      </div>
       <Canvas
         style={{ background: bg, position: "absolute", inset: 0, touchAction: "none" }}
-        onCreated={() => setStatus("created")}
         gl={{ antialias: true, alpha: false }}
-        onError={(e) => {
-          setStatus("error");
-          setErr(String(e));
-        }}
       >
         <PreviewCamera width={floor.width} height={floor.height} cellSize={cellSize} />
         <Lighting darkMode={darkMode} />
-        <mesh position={[0, 50, 0]}>
-          <boxGeometry args={[100, 100, 100]} />
-          <meshBasicMaterial color="red" />
-        </mesh>
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          minPolarAngle={Math.PI / 4}
+          maxPolarAngle={Math.PI / 4}
+          minDistance={cellSize * 3}
+          maxDistance={cellSize * maxDim * 2}
+          enableDamping
+          dampingFactor={0.1}
+        />
         <group position={[-offsetX, 0, -offsetZ]}>
           {tiles.map((tile) => (
             <FloorMesh

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { Canvas } from "@react-three/fiber";
+import type { FloorPlan } from "../../types";
+import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
+import { PreviewCamera } from "./camera";
+import { Lighting } from "./lighting";
+import { FloorMesh } from "./meshes/floor-mesh";
+import { WallMesh } from "./meshes/wall-mesh";
+
+interface Props {
+  floor: FloorPlan;
+  cellSize: number;
+  darkMode: boolean;
+}
+
+export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
+  const tiles = useMemo(() => generateFloorTiles(floor), [floor]);
+  const walls = useMemo(() => generateWallSegments(floor), [floor]);
+
+  const offsetX = (floor.width * cellSize) / 2 - cellSize / 2;
+  const offsetZ = (floor.height * cellSize) / 2 - cellSize / 2;
+
+  const bg = darkMode ? "#1a1a1a" : "#f5f5f5";
+
+  return (
+    <Canvas style={{ background: bg, height: "100%", width: "100%" }}>
+      <PreviewCamera width={floor.width} height={floor.height} cellSize={cellSize} />
+      <Lighting darkMode={darkMode} />
+      <group position={[-offsetX, 0, -offsetZ]}>
+        {tiles.map((tile) => (
+          <FloorMesh
+            key={`floor-${tile.cx}-${tile.cy}`}
+            cx={tile.cx}
+            cy={tile.cy}
+            cellSize={cellSize}
+            floorType={tile.floorType}
+            darkMode={darkMode}
+          />
+        ))}
+        {walls.map((wall, i) => (
+          <WallMesh
+            key={`wall-${wall.cx}-${wall.cy}-${wall.edge}-${i}`}
+            cx={wall.cx}
+            cy={wall.cy}
+            cellSize={cellSize}
+            edge={wall.edge}
+            wallType={wall.wallType}
+            darkMode={darkMode}
+          />
+        ))}
+      </group>
+    </Canvas>
+  );
+}

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import type { FloorPlan } from "../../types";
 import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
@@ -14,6 +14,9 @@ interface Props {
 }
 
 export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
+  const [status, setStatus] = useState<string>("initializing");
+  const [err, setErr] = useState<string | null>(null);
+
   const tiles = useMemo(() => generateFloorTiles(floor), [floor]);
   const walls = useMemo(() => generateWallSegments(floor), [floor]);
 
@@ -23,32 +26,86 @@ export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
   const bg = darkMode ? "#1a1a1a" : "#f5f5f5";
 
   return (
-    <Canvas style={{ background: bg, height: "100%", width: "100%" }}>
-      <PreviewCamera width={floor.width} height={floor.height} cellSize={cellSize} />
-      <Lighting darkMode={darkMode} />
-      <group position={[-offsetX, 0, -offsetZ]}>
-        {tiles.map((tile) => (
-          <FloorMesh
-            key={`floor-${tile.cx}-${tile.cy}`}
-            cx={tile.cx}
-            cy={tile.cy}
-            cellSize={cellSize}
-            floorType={tile.floorType}
-            darkMode={darkMode}
-          />
-        ))}
-        {walls.map((wall, i) => (
-          <WallMesh
-            key={`wall-${wall.cx}-${wall.cy}-${wall.edge}-${i}`}
-            cx={wall.cx}
-            cy={wall.cy}
-            cellSize={cellSize}
-            edge={wall.edge}
-            wallType={wall.wallType}
-            darkMode={darkMode}
-          />
-        ))}
-      </group>
-    </Canvas>
+    <>
+      {err && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 20,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "rgba(0,0,0,0.8)",
+            color: "#ff4444",
+            fontFamily: "IBM Plex Mono, monospace",
+            fontSize: "14px",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          <div>
+            <div style={{ fontWeight: "bold", marginBottom: "8px" }}>3D Error</div>
+            <div>{err}</div>
+          </div>
+        </div>
+      )}
+      <div
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 8,
+          zIndex: 10,
+          background: "rgba(0,0,0,0.6)",
+          color: "#0f0",
+          fontFamily: "IBM Plex Mono, monospace",
+          fontSize: "11px",
+          padding: "4px 8px",
+          borderRadius: "4px",
+          pointerEvents: "none",
+        }}
+      >
+        3D: {status}
+      </div>
+      <Canvas
+        style={{ background: bg, position: "absolute", inset: 0, touchAction: "none" }}
+        onCreated={() => setStatus("created")}
+        gl={{ antialias: true, alpha: false }}
+        onError={(e) => {
+          setStatus("error");
+          setErr(String(e));
+        }}
+      >
+        <PreviewCamera width={floor.width} height={floor.height} cellSize={cellSize} />
+        <Lighting darkMode={darkMode} />
+        <mesh position={[0, 50, 0]}>
+          <boxGeometry args={[100, 100, 100]} />
+          <meshBasicMaterial color="red" />
+        </mesh>
+        <group position={[-offsetX, 0, -offsetZ]}>
+          {tiles.map((tile) => (
+            <FloorMesh
+              key={`floor-${tile.cx}-${tile.cy}`}
+              cx={tile.cx}
+              cy={tile.cy}
+              cellSize={cellSize}
+              floorType={tile.floorType}
+              darkMode={darkMode}
+            />
+          ))}
+          {walls.map((wall, i) => (
+            <WallMesh
+              key={`wall-${wall.cx}-${wall.cy}-${wall.edge}-${i}`}
+              cx={wall.cx}
+              cy={wall.cy}
+              cellSize={cellSize}
+              edge={wall.edge}
+              wallType={wall.wallType}
+              darkMode={darkMode}
+            />
+          ))}
+        </group>
+      </Canvas>
+    </>
   );
 }

--- a/packages/madories/src/components/tool-sheet.tsx
+++ b/packages/madories/src/components/tool-sheet.tsx
@@ -14,6 +14,7 @@ import {
   Save,
   Trash2,
   Undo2,
+  View,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { ItemCategory } from "../items";
@@ -66,6 +67,8 @@ interface Props {
   onRedo: () => void;
   onFitView: () => void;
   darkMode: boolean;
+  viewMode?: "2d" | "3d";
+  onToggleViewMode?: () => void;
 }
 
 function ToolPanelContent({
@@ -83,6 +86,8 @@ function ToolPanelContent({
   onRedo,
   onFitView,
   darkMode,
+  viewMode,
+  onToggleViewMode,
   onClose,
 }: Props & { onClose?: () => void }) {
   const [itemCategory, setItemCategory] = useState<ItemCategory>("建具");
@@ -319,6 +324,15 @@ function ToolPanelContent({
                 onClose?.();
               },
               title: "シェア",
+            },
+            {
+              disabled: false,
+              icon: <View size={14} />,
+              onClick: () => {
+                onToggleViewMode?.();
+                onClose?.();
+              },
+              title: viewMode === "3d" ? "2D" : "3D",
             },
             {
               disabled: false,

--- a/packages/madories/src/floor/geometry-3d.test.ts
+++ b/packages/madories/src/floor/geometry-3d.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { generateFloorTiles, generateWallSegments } from "./geometry-3d";
+import type { FloorPlan } from "../types";
+
+function makeFloor(width: number, height: number, overrides?: Partial<FloorPlan>): FloorPlan {
+  return {
+    cells: Array.from({ length: width * height }, () => ({
+      floorType: null,
+      item: null,
+      wall: { left: "none", top: "none" },
+    })),
+    height,
+    id: "test",
+    name: "test",
+    width,
+    ...overrides,
+  };
+}
+
+describe("generateFloorTiles", () => {
+  it("returns empty array for empty floor", () => {
+    const floor = makeFloor(2, 2);
+    expect(generateFloorTiles(floor)).toEqual([]);
+  });
+
+  it("returns only cells with floorType set", () => {
+    const floor = makeFloor(2, 2, {
+      cells: [
+        { floorType: "wood", item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+        { floorType: "water", item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+      ],
+    });
+    expect(generateFloorTiles(floor)).toEqual([
+      { cx: 0, cy: 0, floorType: "wood" },
+      { cx: 0, cy: 1, floorType: "water" },
+    ]);
+  });
+});
+
+describe("generateWallSegments", () => {
+  it("returns empty array when no walls", () => {
+    const floor = makeFloor(2, 2);
+    expect(generateWallSegments(floor)).toEqual([]);
+  });
+
+  it("extracts top and left walls correctly", () => {
+    const floor = makeFloor(2, 2, {
+      cells: [
+        { floorType: null, item: null, wall: { left: "solid", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "solid" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+        { floorType: null, item: null, wall: { left: "none", top: "none" } },
+      ],
+    });
+    expect(generateWallSegments(floor)).toEqual([
+      { cx: 0, cy: 0, edge: "left", wallType: "solid" },
+      { cx: 1, cy: 0, edge: "top", wallType: "solid" },
+    ]);
+  });
+});

--- a/packages/madories/src/floor/geometry-3d.ts
+++ b/packages/madories/src/floor/geometry-3d.ts
@@ -1,0 +1,43 @@
+import type { FloorPlan, FloorType, WallType } from "../types";
+
+export interface FloorTile {
+  cx: number;
+  cy: number;
+  floorType: FloorType;
+}
+
+export interface WallSegment {
+  cx: number;
+  cy: number;
+  edge: "top" | "left";
+  wallType: WallType;
+}
+
+export function generateFloorTiles(floor: FloorPlan): FloorTile[] {
+  const tiles: FloorTile[] = [];
+  for (let y = 0; y < floor.height; y++) {
+    for (let x = 0; x < floor.width; x++) {
+      const cell = floor.cells[y * floor.width + x];
+      if (cell.floorType !== null) {
+        tiles.push({ cx: x, cy: y, floorType: cell.floorType });
+      }
+    }
+  }
+  return tiles;
+}
+
+export function generateWallSegments(floor: FloorPlan): WallSegment[] {
+  const segments: WallSegment[] = [];
+  for (let y = 0; y < floor.height; y++) {
+    for (let x = 0; x < floor.width; x++) {
+      const cell = floor.cells[y * floor.width + x];
+      if (cell.wall.top !== "none") {
+        segments.push({ cx: x, cy: y, edge: "top", wallType: cell.wall.top });
+      }
+      if (cell.wall.left !== "none") {
+        segments.push({ cx: x, cy: y, edge: "left", wallType: cell.wall.left });
+      }
+    }
+  }
+  return segments;
+}

--- a/packages/madories/src/types/r3f.d.ts
+++ b/packages/madories/src/types/r3f.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type */
+import type { ReactThreeFiber } from "@react-three/fiber";
+
+declare module "react/jsx-runtime" {
+  namespace JSX {
+    interface IntrinsicElements extends ReactThreeFiber.ThreeElements {}
+  }
+}


### PR DESCRIPTION
## Summary
- Add 3D preview mode to madories using React Three Fiber
- Toggle between 2D editor and 3D bird's-eye view via ToolSheet button
- Generate 3D geometry (floor tiles + wall segments) from FloorPlan data
- Add dependencies: `@react-three/fiber` v9, `@react-three/drei` v10, `three`
- Ensure React 19 compatibility with R3F v9

## Test Plan
- [x] All tests pass (58 pass, 0 fail)
- [x] Type check passes (tsgo + oxlint)
- [x] Build passes (`astro build`)
- [ ] Visual verification on mobile after dev server restart