### PR TITLE
fix(madories): refine 3D preview with per-item heights, 3D stairs, and type safety

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "lts"
+node = "22"
 lefthook = "latest"
 bun = "latest"
 

--- a/packages/madories/src/components/preview-3d/materials.test.ts
+++ b/packages/madories/src/components/preview-3d/materials.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { getItemHeightFactor, ITEM_HEIGHT_FACTOR_DEFAULT } from "./materials";
+
+describe("getItemHeightFactor", () => {
+  it("returns 0.5 for chair", () => {
+    expect(getItemHeightFactor("chair")).toBe(0.5);
+  });
+
+  it("returns 0.5 for bed_single", () => {
+    expect(getItemHeightFactor("bed_single")).toBe(0.5);
+  });
+
+  it("returns 0.5 for bed_double", () => {
+    expect(getItemHeightFactor("bed_double")).toBe(0.5);
+  });
+
+  it("returns 1.5 for washer", () => {
+    expect(getItemHeightFactor("washer")).toBe(1.5);
+  });
+
+  it("returns 1.5 for fridge", () => {
+    expect(getItemHeightFactor("fridge")).toBe(1.5);
+  });
+
+  it("returns 1.5 for shelf1", () => {
+    expect(getItemHeightFactor("shelf1")).toBe(1.5);
+  });
+
+  it("returns 1.5 for shelf2", () => {
+    expect(getItemHeightFactor("shelf2")).toBe(1.5);
+  });
+
+  it("returns default 0.8 for items without explicit factor", () => {
+    expect(getItemHeightFactor("desk")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
+    expect(getItemHeightFactor("toilet")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
+    expect(getItemHeightFactor("stairs")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
+  });
+});

--- a/packages/madories/src/components/preview-3d/materials.ts
+++ b/packages/madories/src/components/preview-3d/materials.ts
@@ -1,4 +1,4 @@
-import type { FloorType, WallType } from "../../types";
+import type { FloorType, ItemType, WallType } from "../../types";
 
 export const FLOOR_COLORS: Record<FloorType, { light: string; dark: string }> = {
   wood: { light: "#d4a373", dark: "#8b6f47" },
@@ -22,7 +22,7 @@ export const WALL_HEIGHT_FACTOR = 2.5;
 
 export const WALL_THICKNESS_FACTOR = 0.1;
 
-export const ITEM_COLORS: Record<string, { light: string; dark: string }> = {
+export const ITEM_COLORS: Record<ItemType, { light: string; dark: string }> = {
   chair: { light: "#8b5a2b", dark: "#5c3a1e" },
   desk: { light: "#a0522d", dark: "#6b3a1e" },
   desk_small: { light: "#a0522d", dark: "#6b3a1e" },
@@ -46,4 +46,18 @@ export const ITEM_COLORS: Record<string, { light: string; dark: string }> = {
   bed_double: { light: "#4682b4", dark: "#2f5a7a" },
 };
 
-export const ITEM_HEIGHT_FACTOR = 1.0;
+export const ITEM_HEIGHT_FACTORS: Partial<Record<ItemType, number>> = {
+  chair: 0.5,
+  bed_single: 0.5,
+  bed_double: 0.5,
+  washer: 1.5,
+  fridge: 1.5,
+  shelf1: 1.5,
+  shelf2: 1.5,
+};
+
+export const ITEM_HEIGHT_FACTOR_DEFAULT = 0.8;
+
+export function getItemHeightFactor(type: ItemType): number {
+  return ITEM_HEIGHT_FACTORS[type] ?? ITEM_HEIGHT_FACTOR_DEFAULT;
+}

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { getItemDrawOffset } from "./furniture-mesh";
+
+describe("getItemDrawOffset", () => {
+  it("returns no offset for 0° rotation", () => {
+    const result = getItemDrawOffset(1, 2, 0);
+    expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: 0 });
+  });
+
+  it("swaps dimensions and offsets X for 90° rotation on asymmetric item", () => {
+    const result = getItemDrawOffset(1, 2, 90);
+    expect(result).toEqual({ effectiveW: 2, effectiveH: 1, offX: -1, offY: 0 });
+  });
+
+  it("offsets Y for 180° rotation on asymmetric item", () => {
+    const result = getItemDrawOffset(1, 2, 180);
+    expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: -1 });
+  });
+
+  it("swaps dimensions and offsets both X and Y for 270° on larger asymmetric item", () => {
+    const result = getItemDrawOffset(2, 3, 270);
+    expect(result).toEqual({ effectiveW: 3, effectiveH: 2, offX: -2, offY: -1 });
+  });
+
+  it("returns no offset for symmetric items regardless of rotation", () => {
+    for (const rotation of [0, 90, 180, 270] as const) {
+      const result = getItemDrawOffset(1, 1, rotation);
+      expect(result).toEqual({ effectiveW: 1, effectiveH: 1, offX: 0, offY: 0 });
+    }
+  });
+
+  it("handles wider items correctly at 90°", () => {
+    const result = getItemDrawOffset(2, 1, 90);
+    expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: 0 });
+  });
+});

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -1,7 +1,9 @@
 import { memo } from "react";
 import type { Item, ItemType } from "../../../types";
 import { ITEM_DEF_MAP } from "../../../items";
-import { ITEM_COLORS, ITEM_HEIGHT_FACTOR } from "../materials";
+import { ITEM_COLORS, getItemHeightFactor } from "../materials";
+
+const ITEM_MESH_SCALE = 0.9;
 
 interface Props {
   x: number;
@@ -11,7 +13,7 @@ interface Props {
   darkMode: boolean;
 }
 
-function getItemDrawOffset(
+export function getItemDrawOffset(
   w: number,
   h: number,
   rotation: 0 | 90 | 180 | 270,
@@ -20,8 +22,8 @@ function getItemDrawOffset(
   const effectiveW = isRotated ? h : w;
   const effectiveH = isRotated ? w : h;
   const asymmetric = w !== h;
-  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) : 0;
-  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) : 0;
+  const offX = asymmetric && (rotation === 90 || rotation === 270) ? -(effectiveW - 1) || 0 : 0;
+  const offY = asymmetric && (rotation === 180 || rotation === 270) ? -(effectiveH - 1) || 0 : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 
@@ -50,7 +52,7 @@ export const FurnitureMesh = memo(function FurnitureMesh({
 
   const width = effectiveW * cellSize;
   const depth = effectiveH * cellSize;
-  const height = cellSize * ITEM_HEIGHT_FACTOR;
+  const height = cellSize * getItemHeightFactor(item.type);
 
   const posX = drawX * cellSize + width / 2 - cellSize / 2;
   const posZ = drawY * cellSize + depth / 2 - cellSize / 2;
@@ -59,7 +61,7 @@ export const FurnitureMesh = memo(function FurnitureMesh({
 
   return (
     <mesh position={[posX, height / 2, posZ]}>
-      <boxGeometry args={[width * 0.9, height, depth * 0.9]} />
+      <boxGeometry args={[width * ITEM_MESH_SCALE, height, depth * ITEM_MESH_SCALE]} />
       <meshStandardMaterial color={color} />
     </mesh>
   );

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -1,0 +1,58 @@
+import { memo, useMemo } from "react";
+import type { Item } from "../../../types";
+import { ITEM_DEF_MAP } from "../../../items";
+import { ITEM_COLORS } from "../materials";
+
+interface Props {
+  x: number;
+  y: number;
+  cellSize: number;
+  item: Item;
+  darkMode: boolean;
+}
+
+const STAIRS_STEP_COUNT = 6;
+const STAIRS_TOTAL_HEIGHT = 1.5;
+const STAIRS_MESH_SCALE = 0.95;
+
+function getItemColor(darkMode: boolean): string {
+  const entry = ITEM_COLORS.stairs;
+  return entry ? (darkMode ? entry.dark : entry.light) : (darkMode ? "#666666" : "#999999");
+}
+
+export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkMode }: Props) {
+  const steps = useMemo(() => {
+    const def = ITEM_DEF_MAP.get(item.type);
+    if (!def) return null;
+
+    const isRotated = item.rotation === 90 || item.rotation === 270;
+    const effectiveW = isRotated ? def.h : def.w;
+    const effectiveH = isRotated ? def.w : def.h;
+
+    const stepHeight = (cellSize * STAIRS_TOTAL_HEIGHT) / STAIRS_STEP_COUNT;
+    const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
+    const stepWidth = cellSize * effectiveW;
+
+    const color = getItemColor(darkMode);
+
+    return Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
+      const stepY = stepHeight * (i + 0.5);
+      const stepZ = (i * stepDepth) - (cellSize * effectiveH / 2) + (stepDepth / 2);
+      const stepX = 0;
+
+      return (
+        <mesh key={i} position={[stepX, stepY, stepZ]}>
+          <boxGeometry
+            args={[stepWidth * STAIRS_MESH_SCALE, stepHeight * STAIRS_MESH_SCALE, stepDepth * STAIRS_MESH_SCALE]}
+          />
+          <meshStandardMaterial color={color} />
+        </mesh>
+      );
+    });
+  }, [x, y, cellSize, item.rotation, darkMode]);
+
+  const posX = x * cellSize;
+  const posZ = y * cellSize;
+
+  return <group position={[posX, 0, posZ]}>{steps}</group>;
+});

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -8,6 +8,7 @@ import { Lighting } from "./lighting";
 import { FloorMesh } from "./meshes/floor-mesh";
 import { WallMesh } from "./meshes/wall-mesh";
 import { FurnitureMesh } from "./meshes/furniture-mesh";
+import { StairsMesh } from "./meshes/stairs-mesh";
 
 interface Props {
   floor: FloorPlan;
@@ -78,16 +79,28 @@ export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
               darkMode={darkMode}
             />
           ))}
-          {items.map((it, i) => (
-            <FurnitureMesh
-              key={`item-${it.x}-${it.y}-${i}`}
-              x={it.x}
-              y={it.y}
-              cellSize={cellSize}
-              item={it.item!}
-              darkMode={darkMode}
-            />
-          ))}
+          {items.map((it, i) => {
+            if (!it.item) return null;
+            return it.item.type === "stairs" ? (
+              <StairsMesh
+                key={`item-${it.x}-${it.y}-${i}`}
+                x={it.x}
+                y={it.y}
+                cellSize={cellSize}
+                item={it.item}
+                darkMode={darkMode}
+              />
+            ) : (
+              <FurnitureMesh
+                key={`item-${it.x}-${it.y}-${i}`}
+                x={it.x}
+                y={it.y}
+                cellSize={cellSize}
+                item={it.item}
+                darkMode={darkMode}
+              />
+            );
+          })}
         </group>
       </Canvas>
     </>


### PR DESCRIPTION
## Summary
- アイテムごとに高さを設定（椅子・ベッド: 0.5、洗濯機・冷蔵庫・棚: 1.5、デフォルト: 0.8）
- 階段を3Dの昇るステップとして描画
- 非対称アイテムの270°回転オフセットを修正
- `ITEM_COLORS` と `ITEM_HEIGHT_FACTORS` の型を `Record<ItemType>` に強化
- 階段の寸法をハードコードから `ITEM_DEF_MAP` 参照に変更
- マジックナンバー（0.9, 0.95）を名前付き定数化

## Tests
- [x] 72 tests pass
- [x] bun run check (all packages)
- [x] bun run format