### PR TITLE
fix(madories): restore 3D view toggle in tool sheet

### DIFF
--- a/packages/madories/src/components/App.tsx
+++ b/packages/madories/src/components/App.tsx
@@ -56,7 +56,7 @@ export function App() {
 
   useAppInit(push);
 
-  const [viewMode] = useState<"2d" | "3d">("2d");
+  const [viewMode, setViewMode] = useState<"2d" | "3d">("2d");
   const [tool, setTool] = useState<ToolMode>({ kind: "select" });
   const canvasRef = useRef<FloorCanvasHandle>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -149,6 +149,8 @@ export function App() {
           onShare={handleShare}
           onClear={() => dispatch({ floorId: floor.id, type: "CLEAR_FLOOR" })}
           onRotateFloor={() => dispatch({ floorId: floor.id, type: "ROTATE_FLOOR" })}
+          viewMode={viewMode}
+          onToggleViewMode={() => setViewMode((v) => (v === "2d" ? "3d" : "2d"))}
         />
         <DslPanel
           floors={building.floors}

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -37,13 +37,17 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
 
     return Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
       const stepY = stepHeight * (i + 0.5);
-      const stepZ = (i * stepDepth) - (cellSize * effectiveH / 2) + (stepDepth / 2);
+      const stepZ = i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2;
       const stepX = 0;
 
       return (
         <mesh key={i} position={[stepX, stepY, stepZ]}>
           <boxGeometry
-            args={[stepWidth * STAIRS_MESH_SCALE, stepHeight * STAIRS_MESH_SCALE, stepDepth * STAIRS_MESH_SCALE]}
+            args={[
+              stepWidth * STAIRS_MESH_SCALE,
+              stepHeight * STAIRS_MESH_SCALE,
+              stepDepth * STAIRS_MESH_SCALE,
+            ]}
           />
           <meshStandardMaterial color={color} />
         </mesh>

--- a/packages/madories/src/components/tool-sheet.tsx
+++ b/packages/madories/src/components/tool-sheet.tsx
@@ -20,6 +20,8 @@ interface Props {
   onRedo: () => void;
   onFitView: () => void;
   darkMode: boolean;
+  viewMode: "2d" | "3d";
+  onToggleViewMode: () => void;
 }
 
 function ToolPanelContent({
@@ -37,6 +39,8 @@ function ToolPanelContent({
   onRedo,
   onFitView,
   darkMode,
+  viewMode,
+  onToggleViewMode,
   onClose,
 }: Props & { onClose?: () => void }) {
   return (
@@ -76,6 +80,8 @@ function ToolPanelContent({
           onClear={onClear}
           onRotateFloor={onRotateFloor}
           onClose={onClose}
+          viewMode={viewMode}
+          onToggleViewMode={onToggleViewMode}
         />
       </div>
     </div>
@@ -85,9 +91,8 @@ function ToolPanelContent({
 export function ToolSheet(props: Props) {
   const [open, setOpen] = useState(false);
   const currentLabel =
-    { wall: "壁", floor: "床", item: "家具", erase: "消す", select: "選択" }[
-      props.tool.kind
-    ] ?? "家具";
+    { wall: "壁", floor: "床", item: "家具", erase: "消す", select: "選択" }[props.tool.kind] ??
+    "家具";
 
   return (
     <>

--- a/packages/madories/src/components/tool-sheet/action-tabs.test.tsx
+++ b/packages/madories/src/components/tool-sheet/action-tabs.test.tsx
@@ -2,46 +2,32 @@ import { describe, expect, it } from "bun:test";
 import { renderToString } from "react-dom/server";
 import { ActionTabs } from "./action-tabs";
 
+const baseProps = {
+  canRedo: false,
+  canUndo: true,
+  onClear: () => {},
+  onExportAll: () => {},
+  onFitView: () => {},
+  onLoad: () => {},
+  onRedo: () => {},
+  onRotateFloor: () => {},
+  onSave: () => {},
+  onShare: () => {},
+  onToggleViewMode: () => {},
+  onUndo: () => {},
+  viewMode: "2d" as const,
+};
+
 describe("ActionTabs", () => {
   it("renders 3 category tabs", () => {
-    const html = renderToString(
-      <ActionTabs
-        canUndo={true}
-        canRedo={false}
-        onUndo={() => {}}
-        onRedo={() => {}}
-        onFitView={() => {}}
-        onSave={() => {}}
-        onLoad={() => {}}
-        onExportAll={() => {}}
-        onShare={() => {}}
-        onClear={() => {}}
-        onRotateFloor={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    const html = renderToString(<ActionTabs {...baseProps} onClose={() => {}} />);
     expect(html).toContain("編集");
     expect(html).toContain("ファイル");
     expect(html).toContain("操作");
   });
 
   it("renders edit actions by default", () => {
-    const html = renderToString(
-      <ActionTabs
-        canUndo={true}
-        canRedo={false}
-        onUndo={() => {}}
-        onRedo={() => {}}
-        onFitView={() => {}}
-        onSave={() => {}}
-        onLoad={() => {}}
-        onExportAll={() => {}}
-        onShare={() => {}}
-        onClear={() => {}}
-        onRotateFloor={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    const html = renderToString(<ActionTabs {...baseProps} onClose={() => {}} />);
     expect(html).toContain("戻す");
     expect(html).toContain("進む");
     expect(html).not.toContain("保存");
@@ -50,20 +36,7 @@ describe("ActionTabs", () => {
 
   it("applies disabled state when canUndo is false", () => {
     const html = renderToString(
-      <ActionTabs
-        canUndo={false}
-        canRedo={false}
-        onUndo={() => {}}
-        onRedo={() => {}}
-        onFitView={() => {}}
-        onSave={() => {}}
-        onLoad={() => {}}
-        onExportAll={() => {}}
-        onShare={() => {}}
-        onClear={() => {}}
-        onRotateFloor={() => {}}
-        onClose={() => {}}
-      />,
+      <ActionTabs {...baseProps} canUndo={false} onClose={() => {}} />,
     );
     expect(html).toContain('disabled=""');
     expect(html).toContain("opacity:0.4");

--- a/packages/madories/src/components/tool-sheet/action-tabs.tsx
+++ b/packages/madories/src/components/tool-sheet/action-tabs.tsx
@@ -9,6 +9,7 @@ import {
   Save,
   Trash2,
   Undo2,
+  View,
 } from "lucide-react";
 import { btnBase } from "./styles";
 
@@ -35,6 +36,8 @@ interface Props {
   onClear: () => void;
   onRotateFloor: () => void;
   onClose?: () => void;
+  viewMode: "2d" | "3d";
+  onToggleViewMode: () => void;
 }
 
 export function ActionTabs({
@@ -50,6 +53,8 @@ export function ActionTabs({
   onClear,
   onRotateFloor,
   onClose,
+  viewMode,
+  onToggleViewMode,
 }: Props) {
   const [activeTab, setActiveTab] = useState<ActionTab>("edit");
   const [clearPending, setClearPending] = useState(false);
@@ -66,15 +71,73 @@ export function ActionTabs({
   ];
 
   const fileActions: ActionItem[] = [
-    { disabled: false, icon: <Save size={14} />, id: "save", onClick: () => { onSave(); onClose?.(); }, title: "保存" },
-    { disabled: false, icon: <FolderOpen size={14} />, id: "load", onClick: () => { onLoad(); onClose?.(); }, title: "読込" },
-    { disabled: false, icon: <Download size={14} />, id: "export", onClick: () => { onExportAll(); onClose?.(); }, title: "書出" },
-    { disabled: false, icon: <Link size={14} />, id: "share", onClick: () => { onShare(); onClose?.(); }, title: "共有" },
+    {
+      disabled: false,
+      icon: <Save size={14} />,
+      id: "save",
+      onClick: () => {
+        onSave();
+        onClose?.();
+      },
+      title: "保存",
+    },
+    {
+      disabled: false,
+      icon: <FolderOpen size={14} />,
+      id: "load",
+      onClick: () => {
+        onLoad();
+        onClose?.();
+      },
+      title: "読込",
+    },
+    {
+      disabled: false,
+      icon: <Download size={14} />,
+      id: "export",
+      onClick: () => {
+        onExportAll();
+        onClose?.();
+      },
+      title: "書出",
+    },
+    {
+      disabled: false,
+      icon: <Link size={14} />,
+      id: "share",
+      onClick: () => {
+        onShare();
+        onClose?.();
+      },
+      title: "共有",
+    },
   ];
 
   const operationActions: ActionItem[] = [
-    { disabled: false, icon: <Maximize2 size={14} />, id: "fitView", onClick: onFitView, title: "全体表示" },
-    { disabled: false, icon: <RotateCw size={14} />, id: "rotate", onClick: () => { onRotateFloor(); onClose?.(); }, title: "回転" },
+    {
+      disabled: false,
+      icon: <View size={14} />,
+      id: "viewMode",
+      onClick: onToggleViewMode,
+      title: viewMode === "2d" ? "3D表示" : "2D表示",
+    },
+    {
+      disabled: false,
+      icon: <Maximize2 size={14} />,
+      id: "fitView",
+      onClick: onFitView,
+      title: "全体表示",
+    },
+    {
+      disabled: false,
+      icon: <RotateCw size={14} />,
+      id: "rotate",
+      onClick: () => {
+        onRotateFloor();
+        onClose?.();
+      },
+      title: "回転",
+    },
   ];
 
   const tabDefs: { key: ActionTab; label: string; actions: ActionItem[] }[] = [

--- a/packages/madories/src/components/tool-sheet/primary-tool-tabs.test.tsx
+++ b/packages/madories/src/components/tool-sheet/primary-tool-tabs.test.tsx
@@ -1,18 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { renderToString } from "react-dom/server";
-import {
-  getToolModeForKind,
-  PrimaryToolTabs,
-} from "./primary-tool-tabs";
+import { getToolModeForKind, PrimaryToolTabs } from "./primary-tool-tabs";
 import type { ToolMode } from "../tool-mode";
 
 describe("PrimaryToolTabs", () => {
   it("renders 5 tabs", () => {
     const html = renderToString(
-      <PrimaryToolTabs
-        tool={{ kind: "select" }}
-        onToolChange={() => {}}
-      />,
+      <PrimaryToolTabs tool={{ kind: "select" }} onToolChange={() => {}} />,
     );
     expect(html).toContain("壁");
     expect(html).toContain("床");
@@ -23,10 +17,7 @@ describe("PrimaryToolTabs", () => {
 
   it("validates component structure", () => {
     const html = renderToString(
-      <PrimaryToolTabs
-        tool={{ kind: "select" }}
-        onToolChange={() => {}}
-      />,
+      <PrimaryToolTabs tool={{ kind: "select" }} onToolChange={() => {}} />,
     );
 
     // Verify all 5 buttons are rendered
@@ -41,9 +32,7 @@ describe("PrimaryToolTabs", () => {
     const kinds: ToolMode["kind"][] = ["wall", "floor", "item", "erase", "select"];
     for (const kind of kinds) {
       const tool = getToolModeForKind(kind);
-      const html = renderToString(
-        <PrimaryToolTabs tool={tool} onToolChange={() => {}} />,
-      );
+      const html = renderToString(<PrimaryToolTabs tool={tool} onToolChange={() => {}} />);
       expect(html).toContain("<button");
     }
   });

--- a/packages/madories/src/components/tool-sheet/primary-tool-tabs.tsx
+++ b/packages/madories/src/components/tool-sheet/primary-tool-tabs.tsx
@@ -1,10 +1,4 @@
-import {
-  Armchair,
-  BrickWall,
-  Eraser,
-  MousePointer2,
-  PaintRoller,
-} from "lucide-react";
+import { Armchair, BrickWall, Eraser, MousePointer2, PaintRoller } from "lucide-react";
 import type { ToolMode } from "../tool-mode";
 import { btnBase } from "./styles";
 

--- a/packages/madories/src/components/tool-sheet/sub-panels.test.tsx
+++ b/packages/madories/src/components/tool-sheet/sub-panels.test.tsx
@@ -42,18 +42,10 @@ describe("SubPanels", () => {
 
   it("renders nothing for erase/select", () => {
     const eraseHtml = renderToString(
-      <SubPanels
-        tool={{ kind: "erase" }}
-        onToolChange={() => {}}
-        darkMode={false}
-      />,
+      <SubPanels tool={{ kind: "erase" }} onToolChange={() => {}} darkMode={false} />,
     );
     const selectHtml = renderToString(
-      <SubPanels
-        tool={{ kind: "select" }}
-        onToolChange={() => {}}
-        darkMode={false}
-      />,
+      <SubPanels tool={{ kind: "select" }} onToolChange={() => {}} darkMode={false} />,
     );
     expect(eraseHtml).not.toContain("壁");
     expect(selectHtml).not.toContain("壁");

--- a/packages/madories/src/components/tool-sheet/sub-panels.tsx
+++ b/packages/madories/src/components/tool-sheet/sub-panels.tsx
@@ -23,7 +23,13 @@ interface Props {
   darkMode: boolean;
 }
 
-function WallSubPanel({ tool, onToolChange }: { tool: Extract<ToolMode, { kind: "wall" }>; onToolChange: (tool: ToolMode) => void }) {
+function WallSubPanel({
+  tool,
+  onToolChange,
+}: {
+  tool: Extract<ToolMode, { kind: "wall" }>;
+  onToolChange: (tool: ToolMode) => void;
+}) {
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
       {WALL_TYPES.map(({ type, label }) => (
@@ -45,7 +51,15 @@ function WallSubPanel({ tool, onToolChange }: { tool: Extract<ToolMode, { kind: 
   );
 }
 
-function FloorSubPanel({ tool, onToolChange, darkMode }: { tool: Extract<ToolMode, { kind: "floor" }>; onToolChange: (tool: ToolMode) => void; darkMode: boolean }) {
+function FloorSubPanel({
+  tool,
+  onToolChange,
+  darkMode,
+}: {
+  tool: Extract<ToolMode, { kind: "floor" }>;
+  onToolChange: (tool: ToolMode) => void;
+  darkMode: boolean;
+}) {
   return (
     <div style={{ display: "grid", gap: "3px", gridTemplateColumns: "1fr 1fr" }}>
       {FLOOR_TYPES.map((entry) => {
@@ -84,7 +98,13 @@ function FloorSubPanel({ tool, onToolChange, darkMode }: { tool: Extract<ToolMod
   );
 }
 
-function ItemSubPanel({ tool, onToolChange }: { tool: Extract<ToolMode, { kind: "item" }>; onToolChange: (tool: ToolMode) => void }) {
+function ItemSubPanel({
+  tool,
+  onToolChange,
+}: {
+  tool: Extract<ToolMode, { kind: "item" }>;
+  onToolChange: (tool: ToolMode) => void;
+}) {
   const [itemCategory, setItemCategory] = useState<ItemCategory>(ITEM_CATEGORIES[0]);
   const items = ITEMS_BY_CATEGORY[itemCategory];
 


### PR DESCRIPTION
## Summary
PR #128 のツールシートリファクタリング時に削除されていた3D表示切り替えを復元。

## Changes
- `ToolSheet` / `ActionTabs` に `viewMode` / `onToggleViewMode` props を追加
- 「操作」タブに 3D/2D 切り替えボタンを追加
- `App.tsx` で `setViewMode` と props 渡しを復元
- `ActionTabs` テストを `baseProps` ヘルパーで整理

## Test Plan
- [x] 88 tests pass
- [x] bun run check (all packages)
- [x] bun run format