### PR TITLE
fix(madories): align 3D item rotation with 2D view

### DIFF
--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
@@ -17,9 +17,9 @@ describe("getItemDrawOffset", () => {
     expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: -1 });
   });
 
-  it("swaps dimensions and offsets both X and Y for 270° on larger asymmetric item", () => {
+  it("swaps dimensions but no offsets for 270° on larger asymmetric item", () => {
     const result = getItemDrawOffset(2, 3, 270);
-    expect(result).toEqual({ effectiveW: 3, effectiveH: 2, offX: -2, offY: -1 });
+    expect(result).toEqual({ effectiveW: 3, effectiveH: 2, offX: 0, offY: 0 });
   });
 
   it("returns no offset for symmetric items regardless of rotation", () => {

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -22,8 +22,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? h : w;
   const effectiveH = isRotated ? w : h;
   const asymmetric = w !== h;
-  const offX = asymmetric && (rotation === 90 || rotation === 270) ? -(effectiveW - 1) || 0 : 0;
-  const offY = asymmetric && (rotation === 180 || rotation === 270) ? -(effectiveH - 1) || 0 : 0;
+  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
+  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 
@@ -60,7 +60,7 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   const color = getItemColor(item.type, darkMode);
 
   return (
-    <mesh position={[posX, height / 2, posZ]}>
+    <mesh position={[posX, height / 2, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
       <boxGeometry args={[width * ITEM_MESH_SCALE, height, depth * ITEM_MESH_SCALE]} />
       <meshStandardMaterial color={color} />
     </mesh>

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -29,15 +29,21 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
     const effectiveW = isRotated ? def.h : def.w;
     const effectiveH = isRotated ? def.w : def.h;
 
+    const asymmetric = def.w !== def.h;
+    const offX = asymmetric && item.rotation === 90 ? -(effectiveW - 1) : 0;
+    const offY = asymmetric && item.rotation === 180 ? -(effectiveH - 1) : 0;
+    const drawX = x + offX;
+    const drawY = y + offY;
+
     const stepHeight = (cellSize * STAIRS_TOTAL_HEIGHT) / STAIRS_STEP_COUNT;
     const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
     const stepWidth = cellSize * effectiveW;
 
     const color = getItemColor(darkMode);
 
-    return Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
+    const stepElements = Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
       const stepY = stepHeight * (i + 0.5);
-      const stepZ = i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2;
+      const stepZ = -(i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2);
       const stepX = 0;
 
       return (
@@ -53,10 +59,18 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
         </mesh>
       );
     });
+
+    return { drawX, drawY, stepElements };
   }, [x, y, cellSize, item.rotation, darkMode]);
 
-  const posX = x * cellSize;
-  const posZ = y * cellSize;
+  if (!steps) return null;
 
-  return <group position={[posX, 0, posZ]}>{steps}</group>;
+  const posX = steps.drawX * cellSize;
+  const posZ = steps.drawY * cellSize;
+
+  return (
+    <group position={[posX, 0, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
+      {steps.stepElements}
+    </group>
+  );
 });

--- a/packages/madories/src/draw/draw-items.ts
+++ b/packages/madories/src/draw/draw-items.ts
@@ -29,8 +29,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? def.h : def.w;
   const effectiveH = isRotated ? def.w : def.h;
   const asymmetric = def.w !== def.h;
-  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) : 0;
-  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) : 0;
+  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
+  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 


### PR DESCRIPTION
## Summary
- Fixed 3D preview so item rotation matches the 2D top-down view.
- Applied mesh rotation to `FurnitureMesh` and `StairsMesh`.
- Unified `getItemDrawOffset` logic between 2D (`draw-items.ts`) and 3D (`furniture-mesh.tsx`).
- Fixed default stairs direction (now ascends toward the top of the screen like the 2D arrow).
- Updated tests to match the corrected 270° offset behavior.

## Verification
- `bun test`: 88 pass / 0 fail
- `oxlint`: 0 warnings, 0 errors
- `tsgo --noEmit`: clean