### PR TITLE
fix(madories): fix 3D item positioning, orientation, and multi-tile rendering

### DIFF
--- a/packages/madories/src/components/preview-3d/dedup-items.test.ts
+++ b/packages/madories/src/components/preview-3d/dedup-items.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { dedupFloorItems } from "./dedup-items";
+import type { FloorPlan } from "../../types";
+
+function makeFloor(w: number, h: number, cells: FloorPlan["cells"]): FloorPlan {
+  return { id: "test", width: w, height: h, cells, name: "" };
+}
+
+describe("dedupFloorItems", () => {
+  it("renders each single-tile item once", () => {
+    const floor = makeFloor(2, 1, [
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "chair", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "toilet", rotation: 0 } },
+    ]);
+    const result = dedupFloorItems(floor);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ x: 0, y: 0, item: { type: "chair", rotation: 0 } });
+    expect(result[1]).toEqual({ x: 1, y: 0, item: { type: "toilet", rotation: 0 } });
+  });
+
+  it("deduplicates a 1x2 item at rotation 0", () => {
+    const floor = makeFloor(2, 2, [
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+    ]);
+    const result = dedupFloorItems(floor);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ x: 0, y: 0, item: { type: "sofa", rotation: 0 } });
+  });
+
+  it("deduplicates a 1x2 item at rotation 90", () => {
+    const floor = makeFloor(2, 2, [
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 90 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 90 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+    ]);
+    const result = dedupFloorItems(floor);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ x: 0, y: 0, item: { type: "sofa", rotation: 90 } });
+  });
+
+  it("handles multiple multi-tile items", () => {
+    const floor = makeFloor(2, 4, [
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "tv", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "tv", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "stairs", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "stairs", rotation: 0 } },
+      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
+    ]);
+    const result = dedupFloorItems(floor);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ x: 0, y: 0, item: { type: "tv", rotation: 0 } });
+    expect(result[1]).toEqual({ x: 0, y: 2, item: { type: "stairs", rotation: 0 } });
+  });
+});

--- a/packages/madories/src/components/preview-3d/dedup-items.test.ts
+++ b/packages/madories/src/components/preview-3d/dedup-items.test.ts
@@ -9,8 +9,16 @@ function makeFloor(w: number, h: number, cells: FloorPlan["cells"]): FloorPlan {
 describe("dedupFloorItems", () => {
   it("renders each single-tile item once", () => {
     const floor = makeFloor(2, 1, [
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "chair", rotation: 0 } },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "toilet", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "chair", rotation: 0 },
+      },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "toilet", rotation: 0 },
+      },
     ]);
     const result = dedupFloorItems(floor);
     expect(result).toHaveLength(2);
@@ -20,9 +28,17 @@ describe("dedupFloorItems", () => {
 
   it("deduplicates a 1x2 item at rotation 0", () => {
     const floor = makeFloor(2, 2, [
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "sofa", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "sofa", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
     ]);
     const result = dedupFloorItems(floor);
@@ -32,8 +48,16 @@ describe("dedupFloorItems", () => {
 
   it("deduplicates a 1x2 item at rotation 90", () => {
     const floor = makeFloor(2, 2, [
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 90 } },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "sofa", rotation: 90 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "sofa", rotation: 90 },
+      },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "sofa", rotation: 90 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
     ]);
@@ -44,13 +68,29 @@ describe("dedupFloorItems", () => {
 
   it("handles multiple multi-tile items", () => {
     const floor = makeFloor(2, 4, [
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "tv", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "tv", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "tv", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "tv", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "stairs", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "stairs", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
-      { floorType: "wood", wall: { top: "solid", left: "solid" }, item: { type: "stairs", rotation: 0 } },
+      {
+        floorType: "wood",
+        wall: { top: "solid", left: "solid" },
+        item: { type: "stairs", rotation: 0 },
+      },
       { floorType: "wood", wall: { top: "solid", left: "solid" }, item: null },
     ]);
     const result = dedupFloorItems(floor);

--- a/packages/madories/src/components/preview-3d/dedup-items.ts
+++ b/packages/madories/src/components/preview-3d/dedup-items.ts
@@ -1,0 +1,32 @@
+import type { FloorPlan } from "../../types";
+import { ITEM_DEF_MAP } from "../../items";
+import { getItemDrawOffset } from "./meshes/furniture-mesh";
+
+export function dedupFloorItems(
+  floor: FloorPlan,
+): { x: number; y: number; item: FloorPlan["cells"][number]["item"] }[] {
+  const result: { x: number; y: number; item: FloorPlan["cells"][number]["item"] }[] = [];
+  const visited = new Set<number>();
+  for (let y = 0; y < floor.height; y++) {
+    for (let x = 0; x < floor.width; x++) {
+      const idx = y * floor.width + x;
+      if (visited.has(idx)) continue;
+      const cell = floor.cells[idx];
+      if (!cell.item) continue;
+      const def = ITEM_DEF_MAP.get(cell.item.type);
+      if (!def) continue;
+      result.push({ x, y, item: cell.item });
+      const { effectiveW, effectiveH } = getItemDrawOffset(def.w, def.h, cell.item.rotation);
+      for (let dy = 0; dy < effectiveH; dy++) {
+        for (let dx = 0; dx < effectiveW; dx++) {
+          const cx = x + dx;
+          const cy = y + dy;
+          if (cx < floor.width && cy < floor.height) {
+            visited.add(cy * floor.width + cx);
+          }
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/packages/madories/src/components/preview-3d/materials.test.ts
+++ b/packages/madories/src/components/preview-3d/materials.test.ts
@@ -30,10 +30,15 @@ describe("getItemHeightFactor", () => {
     expect(getItemHeightFactor("shelf2")).toBe(1.5);
   });
 
+  it("returns 0.5 for desk", () => {
+    expect(getItemHeightFactor("desk")).toBe(0.5);
+    expect(getItemHeightFactor("desk_small")).toBe(0.5);
+  });
+
   it("returns default 0.8 for items without explicit factor", () => {
-    expect(getItemHeightFactor("desk")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
     expect(getItemHeightFactor("toilet")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
     expect(getItemHeightFactor("stairs")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
+    expect(getItemHeightFactor("kitchen")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
   });
 });
 

--- a/packages/madories/src/components/preview-3d/materials.test.ts
+++ b/packages/madories/src/components/preview-3d/materials.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getItemHeightFactor, ITEM_HEIGHT_FACTOR_DEFAULT } from "./materials";
+import { getItemDepthFactor, getItemHeightFactor, ITEM_HEIGHT_FACTOR_DEFAULT } from "./materials";
 
 describe("getItemHeightFactor", () => {
   it("returns 0.5 for chair", () => {
@@ -34,5 +34,17 @@ describe("getItemHeightFactor", () => {
     expect(getItemHeightFactor("desk")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
     expect(getItemHeightFactor("toilet")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
     expect(getItemHeightFactor("stairs")).toBe(ITEM_HEIGHT_FACTOR_DEFAULT);
+  });
+});
+
+describe("getItemDepthFactor", () => {
+  it("returns 1 for items without explicit depth factor", () => {
+    expect(getItemDepthFactor("sofa")).toBe(1);
+    expect(getItemDepthFactor("desk")).toBe(1);
+    expect(getItemDepthFactor("fridge")).toBe(1);
+  });
+
+  it("returns thinner factor for flat-screen items", () => {
+    expect(getItemDepthFactor("tv")).toBe(0.15);
   });
 });

--- a/packages/madories/src/components/preview-3d/materials.ts
+++ b/packages/madories/src/components/preview-3d/materials.ts
@@ -61,3 +61,11 @@ export const ITEM_HEIGHT_FACTOR_DEFAULT = 0.8;
 export function getItemHeightFactor(type: ItemType): number {
   return ITEM_HEIGHT_FACTORS[type] ?? ITEM_HEIGHT_FACTOR_DEFAULT;
 }
+
+export const ITEM_DEPTH_FACTORS: Partial<Record<ItemType, number>> = {
+  tv: 0.15,
+};
+
+export function getItemDepthFactor(type: ItemType): number {
+  return ITEM_DEPTH_FACTORS[type] ?? 1;
+}

--- a/packages/madories/src/components/preview-3d/materials.ts
+++ b/packages/madories/src/components/preview-3d/materials.ts
@@ -50,6 +50,8 @@ export const ITEM_HEIGHT_FACTORS: Partial<Record<ItemType, number>> = {
   chair: 0.5,
   bed_single: 0.5,
   bed_double: 0.5,
+  desk: 0.5,
+  desk_small: 0.5,
   washer: 1.5,
   fridge: 1.5,
   shelf1: 1.5,
@@ -68,4 +70,27 @@ export const ITEM_DEPTH_FACTORS: Partial<Record<ItemType, number>> = {
 
 export function getItemDepthFactor(type: ItemType): number {
   return ITEM_DEPTH_FACTORS[type] ?? 1;
+}
+
+export const ITEM_PART_COLORS: Partial<
+  Record<ItemType, Record<string, { light: string; dark: string }>>
+> = {
+  sofa: {
+    back: { light: "#8B7D6B", dark: "#7a6e5e" },
+    seat: { light: "#A0907D", dark: "#8c7d6a" },
+  },
+  desk: {
+    leg: { light: "#6B5030", dark: "#7a5830" },
+    top: { light: "#D4B896", dark: "#b08a60" },
+  },
+  washbasin_large: {
+    mirror: { light: "#E8F4F8", dark: "#1a3a4a" },
+    counter: { light: "#EAD8C0", dark: "#6a5a40" },
+  },
+};
+
+export function getItemPartColor(type: ItemType, part: string, darkMode: boolean): string {
+  const entry = ITEM_PART_COLORS[type]?.[part];
+  if (entry) return darkMode ? entry.dark : entry.light;
+  return darkMode ? "#666666" : "#999999";
 }

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getItemDrawOffset } from "./furniture-mesh";
+import { getItemDrawOffset, getItemCenterPosition } from "./furniture-mesh";
 
 describe("getItemDrawOffset", () => {
   it("returns no offset for 0° rotation", () => {
@@ -32,5 +32,34 @@ describe("getItemDrawOffset", () => {
   it("handles wider items correctly at 90°", () => {
     const result = getItemDrawOffset(2, 1, 90);
     expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: 0 });
+  });
+});
+
+describe("getItemCenterPosition", () => {
+  const c = 10;
+
+  it("centers a single-tile item on its cell", () => {
+    const result = getItemCenterPosition(0, 0, 1, 1, c);
+    expect(result).toEqual({ posX: 5, posZ: 5 });
+  });
+
+  it("centers a 1x2 item across its 2-cell span", () => {
+    const result = getItemCenterPosition(0, 0, 1, 2, c);
+    expect(result).toEqual({ posX: 5, posZ: 10 });
+  });
+
+  it("centers a 2x1 item across its 2-cell width", () => {
+    const result = getItemCenterPosition(0, 0, 2, 1, c);
+    expect(result).toEqual({ posX: 10, posZ: 5 });
+  });
+
+  it("accounts for draw offset in position", () => {
+    const result = getItemCenterPosition(-1, 0, 2, 1, c);
+    expect(result).toEqual({ posX: 0, posZ: 5 });
+  });
+
+  it("works for non-zero origin cells", () => {
+    const result = getItemCenterPosition(2, 3, 1, 1, c);
+    expect(result).toEqual({ posX: 25, posZ: 35 });
   });
 });

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
@@ -17,9 +17,9 @@ describe("getItemDrawOffset", () => {
     expect(result).toEqual({ effectiveW: 1, effectiveH: 2, offX: 0, offY: -1 });
   });
 
-  it("swaps dimensions and offsets both X and Y for 270° on larger asymmetric item", () => {
+  it("swaps dimensions but no offsets for 270° on larger asymmetric item", () => {
     const result = getItemDrawOffset(2, 3, 270);
-    expect(result).toEqual({ effectiveW: 3, effectiveH: 2, offX: -2, offY: -1 });
+    expect(result).toEqual({ effectiveW: 3, effectiveH: 2, offX: 0, offY: 0 });
   });
 
   it("returns no offset for symmetric items regardless of rotation", () => {

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import type { Item, ItemType } from "../../../types";
 import { ITEM_DEF_MAP } from "../../../items";
-import { ITEM_COLORS, getItemHeightFactor } from "../materials";
+import { ITEM_COLORS, getItemDepthFactor, getItemHeightFactor } from "../materials";
 
 const ITEM_MESH_SCALE = 0.9;
 
@@ -11,6 +11,18 @@ interface Props {
   cellSize: number;
   item: Item;
   darkMode: boolean;
+}
+
+export function getItemCenterPosition(
+  drawX: number,
+  drawY: number,
+  effectiveW: number,
+  effectiveH: number,
+  cellSize: number,
+): { posX: number; posZ: number } {
+  const posX = (drawX + effectiveW / 2) * cellSize;
+  const posZ = (drawY + effectiveH / 2) * cellSize;
+  return { posX, posZ };
 }
 
 export function getItemDrawOffset(
@@ -50,18 +62,89 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   const drawX = x + offX;
   const drawY = y + offY;
 
-  const width = effectiveW * cellSize;
-  const depth = effectiveH * cellSize;
+  const width = effectiveW * cellSize * ITEM_MESH_SCALE;
+  const depth = effectiveH * cellSize * ITEM_MESH_SCALE * getItemDepthFactor(item.type);
   const height = cellSize * getItemHeightFactor(item.type);
 
-  const posX = drawX * cellSize + width / 2 - cellSize / 2;
-  const posZ = drawY * cellSize + depth / 2 - cellSize / 2;
+  const { posX, posZ } = getItemCenterPosition(drawX, drawY, effectiveW, effectiveH, cellSize);
 
   const color = getItemColor(item.type, darkMode);
+  const rotation: [number, number, number] = [0, -item.rotation * (Math.PI / 180), 0];
+
+  if (item.type === "sofa") {
+    const backColor = darkMode ? "#7a6e5e" : "#8B7D6B";
+    const seatColor = darkMode ? "#8c7d6a" : "#A0907D";
+    const backrestW = width * 0.25;
+    const seatW = width * 0.45;
+    const backrestX = -width / 2 + backrestW / 2;
+    const seatX = width / 2 - seatW / 2;
+    return (
+      <group position={[posX, 0, posZ]} rotation={rotation}>
+        <mesh position={[backrestX, height * 0.6, 0]}>
+          <boxGeometry args={[backrestW, height * 0.8, depth]} />
+          <meshStandardMaterial color={backColor} />
+        </mesh>
+        <mesh position={[seatX, height * 0.2, 0]}>
+          <boxGeometry args={[seatW, height * 0.4, depth]} />
+          <meshStandardMaterial color={seatColor} />
+        </mesh>
+      </group>
+    );
+  }
+
+  if (item.type === "desk") {
+    const legColor = darkMode ? "#7a5830" : "#6B5030";
+    const topColor = darkMode ? "#b08a60" : "#D4B896";
+    const legR = Math.min(width, depth) * 0.07;
+    const legH = height * 0.75;
+    const topH = height * 0.15;
+    const inset = Math.min(width, depth) * 0.1;
+    const legs = [
+      [-width / 2 + inset, -depth / 2 + inset],
+      [width / 2 - inset, -depth / 2 + inset],
+      [-width / 2 + inset, depth / 2 - inset],
+      [width / 2 - inset, depth / 2 - inset],
+    ];
+    return (
+      <group position={[posX, 0, posZ]} rotation={rotation}>
+        {legs.map(([lx, lz], i) => (
+          <mesh key={i} position={[lx, legH / 2, lz]}>
+            <boxGeometry args={[legR * 2, legH, legR * 2]} />
+            <meshStandardMaterial color={legColor} />
+          </mesh>
+        ))}
+        <mesh position={[0, legH + topH / 2, 0]}>
+          <boxGeometry args={[width, topH, depth]} />
+          <meshStandardMaterial color={topColor} />
+        </mesh>
+      </group>
+    );
+  }
+
+  if (item.type === "washbasin_large") {
+    const mirrorColor = darkMode ? "#1a3a4a" : "#E8F4F8";
+    const counterColor = darkMode ? "#6a5a40" : "#EAD8C0";
+    const mirrorW = width * 0.28;
+    const counterW = width * 0.65;
+    const mirrorX = -width / 2 + mirrorW / 2;
+    const counterX = width / 2 - counterW / 2;
+    return (
+      <group position={[posX, 0, posZ]} rotation={rotation}>
+        <mesh position={[mirrorX, height * 0.4, 0]}>
+          <boxGeometry args={[mirrorW, height * 0.8, depth]} />
+          <meshStandardMaterial color={mirrorColor} />
+        </mesh>
+        <mesh position={[counterX, height * 0.5, 0]}>
+          <boxGeometry args={[counterW, height, depth]} />
+          <meshStandardMaterial color={counterColor} />
+        </mesh>
+      </group>
+    );
+  }
 
   return (
-    <mesh position={[posX, height / 2, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
-      <boxGeometry args={[width * ITEM_MESH_SCALE, height, depth * ITEM_MESH_SCALE]} />
+    <mesh position={[posX, height / 2, posZ]} rotation={rotation}>
+      <boxGeometry args={[width, height, depth]} />
       <meshStandardMaterial color={color} />
     </mesh>
   );

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -22,8 +22,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? h : w;
   const effectiveH = isRotated ? w : h;
   const asymmetric = w !== h;
-  const offX = asymmetric && (rotation === 90 || rotation === 270) ? -(effectiveW - 1) || 0 : 0;
-  const offY = asymmetric && (rotation === 180 || rotation === 270) ? -(effectiveH - 1) || 0 : 0;
+  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
+  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 
@@ -60,7 +60,7 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   const color = getItemColor(item.type, darkMode);
 
   return (
-    <mesh position={[posX, height / 2, posZ]}>
+    <mesh position={[posX, height / 2, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
       <boxGeometry args={[width * ITEM_MESH_SCALE, height, depth * ITEM_MESH_SCALE]} />
       <meshStandardMaterial color={color} />
     </mesh>

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -34,8 +34,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? h : w;
   const effectiveH = isRotated ? w : h;
   const asymmetric = w !== h;
-  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
-  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
+  const offX = asymmetric && rotation === 90 && effectiveW > 1 ? -(effectiveW - 1) : 0;
+  const offY = asymmetric && rotation === 180 && effectiveH > 1 ? -(effectiveH - 1) : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -1,7 +1,12 @@
 import { memo } from "react";
 import type { Item, ItemType } from "../../../types";
 import { ITEM_DEF_MAP } from "../../../items";
-import { ITEM_COLORS, getItemDepthFactor, getItemHeightFactor, getItemPartColor } from "../materials";
+import {
+  ITEM_COLORS,
+  getItemDepthFactor,
+  getItemHeightFactor,
+  getItemPartColor,
+} from "../materials";
 
 const ITEM_MESH_SCALE = 0.9;
 

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import type { Item, ItemType } from "../../../types";
 import { ITEM_DEF_MAP } from "../../../items";
-import { ITEM_COLORS, getItemDepthFactor, getItemHeightFactor } from "../materials";
+import { ITEM_COLORS, getItemDepthFactor, getItemHeightFactor, getItemPartColor } from "../materials";
 
 const ITEM_MESH_SCALE = 0.9;
 
@@ -72,8 +72,8 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   const rotation: [number, number, number] = [0, -item.rotation * (Math.PI / 180), 0];
 
   if (item.type === "sofa") {
-    const backColor = darkMode ? "#7a6e5e" : "#8B7D6B";
-    const seatColor = darkMode ? "#8c7d6a" : "#A0907D";
+    const backColor = getItemPartColor("sofa", "back", darkMode);
+    const seatColor = getItemPartColor("sofa", "seat", darkMode);
     const backrestW = width * 0.25;
     const seatW = width * 0.45;
     const backrestX = -width / 2 + backrestW / 2;
@@ -93,9 +93,9 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   }
 
   if (item.type === "desk") {
-    const legColor = darkMode ? "#7a5830" : "#6B5030";
-    const topColor = darkMode ? "#b08a60" : "#D4B896";
-    const legR = Math.min(width, depth) * 0.07;
+    const legColor = getItemPartColor("desk", "leg", darkMode);
+    const topColor = getItemPartColor("desk", "top", darkMode);
+    const legS = Math.min(width, depth) * 0.07;
     const legH = height * 0.75;
     const topH = height * 0.15;
     const inset = Math.min(width, depth) * 0.1;
@@ -109,7 +109,7 @@ export const FurnitureMesh = memo(function FurnitureMesh({
       <group position={[posX, 0, posZ]} rotation={rotation}>
         {legs.map(([lx, lz], i) => (
           <mesh key={i} position={[lx, legH / 2, lz]}>
-            <boxGeometry args={[legR * 2, legH, legR * 2]} />
+            <boxGeometry args={[legS * 2, legH, legS * 2]} />
             <meshStandardMaterial color={legColor} />
           </mesh>
         ))}
@@ -122,8 +122,8 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   }
 
   if (item.type === "washbasin_large") {
-    const mirrorColor = darkMode ? "#1a3a4a" : "#E8F4F8";
-    const counterColor = darkMode ? "#6a5a40" : "#EAD8C0";
+    const mirrorColor = getItemPartColor("washbasin_large", "mirror", darkMode);
+    const counterColor = getItemPartColor("washbasin_large", "counter", darkMode);
     const mirrorW = width * 0.28;
     const counterW = width * 0.65;
     const mirrorX = -width / 2 + mirrorW / 2;

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -29,15 +29,21 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
     const effectiveW = isRotated ? def.h : def.w;
     const effectiveH = isRotated ? def.w : def.h;
 
+    const asymmetric = def.w !== def.h;
+    const offX = asymmetric && item.rotation === 90 ? -(effectiveW - 1) : 0;
+    const offY = asymmetric && item.rotation === 180 ? -(effectiveH - 1) : 0;
+    const drawX = x + offX;
+    const drawY = y + offY;
+
     const stepHeight = (cellSize * STAIRS_TOTAL_HEIGHT) / STAIRS_STEP_COUNT;
     const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
     const stepWidth = cellSize * effectiveW;
 
     const color = getItemColor(darkMode);
 
-    return Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
+    const stepElements = Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
       const stepY = stepHeight * (i + 0.5);
-      const stepZ = i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2;
+      const stepZ = -(i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2);
       const stepX = 0;
 
       return (
@@ -53,10 +59,18 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
         </mesh>
       );
     });
+
+    return { drawX, drawY, stepElements };
   }, [x, y, cellSize, item.rotation, darkMode]);
 
-  const posX = x * cellSize;
-  const posZ = y * cellSize;
+  if (!steps) return null;
 
-  return <group position={[posX, 0, posZ]}>{steps}</group>;
+  const posX = steps.drawX * cellSize;
+  const posZ = steps.drawY * cellSize;
+
+  return (
+    <group position={[posX, 0, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
+      {steps.stepElements}
+    </group>
+  );
 });

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -63,7 +63,10 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
   if (!steps) return null;
 
   return (
-    <group position={[steps.posX, 0, steps.posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
+    <group
+      position={[steps.posX, 0, steps.posZ]}
+      rotation={[0, -item.rotation * (Math.PI / 180), 0]}
+    >
       {steps.stepElements}
     </group>
   );

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from "react";
 import type { Item } from "../../../types";
 import { ITEM_DEF_MAP } from "../../../items";
 import { ITEM_COLORS } from "../materials";
+import { getItemCenterPosition, getItemDrawOffset } from "./furniture-mesh";
 
 interface Props {
   x: number;
@@ -25,29 +26,23 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
     const def = ITEM_DEF_MAP.get(item.type);
     if (!def) return null;
 
-    const isRotated = item.rotation === 90 || item.rotation === 270;
-    const effectiveW = isRotated ? def.h : def.w;
-    const effectiveH = isRotated ? def.w : def.h;
-
-    const asymmetric = def.w !== def.h;
-    const offX = asymmetric && item.rotation === 90 ? -(effectiveW - 1) : 0;
-    const offY = asymmetric && item.rotation === 180 ? -(effectiveH - 1) : 0;
+    const { effectiveW, effectiveH, offX, offY } = getItemDrawOffset(def.w, def.h, item.rotation);
     const drawX = x + offX;
     const drawY = y + offY;
 
     const stepHeight = (cellSize * STAIRS_TOTAL_HEIGHT) / STAIRS_STEP_COUNT;
-    const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
     const stepWidth = cellSize * effectiveW;
+    const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
+    const halfSpan = (cellSize * effectiveH) / 2;
 
     const color = getItemColor(darkMode);
 
     const stepElements = Array.from({ length: STAIRS_STEP_COUNT }, (_, i) => {
       const stepY = stepHeight * (i + 0.5);
-      const stepZ = -(i * stepDepth - (cellSize * effectiveH) / 2 + stepDepth / 2);
-      const stepX = 0;
+      const stepZ = -halfSpan + stepDepth / 2 + i * stepDepth;
 
       return (
-        <mesh key={i} position={[stepX, stepY, stepZ]}>
+        <mesh key={i} position={[0, stepY, stepZ]}>
           <boxGeometry
             args={[
               stepWidth * STAIRS_MESH_SCALE,
@@ -60,16 +55,15 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
       );
     });
 
-    return { drawX, drawY, stepElements };
-  }, [x, y, cellSize, item.rotation, darkMode]);
+    const { posX, posZ } = getItemCenterPosition(drawX, drawY, effectiveW, effectiveH, cellSize);
+
+    return { posX, posZ, stepElements };
+  }, [x, y, cellSize, item.rotation, item.type, darkMode]);
 
   if (!steps) return null;
 
-  const posX = steps.drawX * cellSize;
-  const posZ = steps.drawY * cellSize;
-
   return (
-    <group position={[posX, 0, posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
+    <group position={[steps.posX, 0, steps.posZ]} rotation={[0, -item.rotation * (Math.PI / 180), 0]}>
       {steps.stepElements}
     </group>
   );

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -3,13 +3,13 @@ import { Canvas } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import type { FloorPlan } from "../../types";
 import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
-import { ITEM_DEF_MAP } from "../../items";
 import { PreviewCamera } from "./camera";
 import { Lighting } from "./lighting";
 import { FloorMesh } from "./meshes/floor-mesh";
 import { WallMesh } from "./meshes/wall-mesh";
-import { FurnitureMesh, getItemDrawOffset } from "./meshes/furniture-mesh";
+import { FurnitureMesh } from "./meshes/furniture-mesh";
 import { StairsMesh } from "./meshes/stairs-mesh";
+import { dedupFloorItems } from "./dedup-items";
 
 interface Props {
   floor: FloorPlan;
@@ -20,26 +20,7 @@ interface Props {
 export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
   const tiles = useMemo(() => generateFloorTiles(floor), [floor]);
   const walls = useMemo(() => generateWallSegments(floor), [floor]);
-  const items = useMemo(() => {
-    const result: { x: number; y: number; item: FloorPlan["cells"][number]["item"] }[] = [];
-    const seen = new Set<string>();
-    for (let y = 0; y < floor.height; y++) {
-      for (let x = 0; x < floor.width; x++) {
-        const cell = floor.cells[y * floor.width + x];
-        if (!cell.item) continue;
-        const def = ITEM_DEF_MAP.get(cell.item.type);
-        if (!def) continue;
-        const { offX, offY } = getItemDrawOffset(def.w, def.h, cell.item.rotation);
-        const drawX = x + offX;
-        const drawY = y + offY;
-        const key = `${drawX},${drawY}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        result.push({ x, y, item: cell.item });
-      }
-    }
-    return result;
-  }, [floor]);
+  const items = useMemo(() => dedupFloorItems(floor), [floor]);
 
   const offsetX = (floor.width * cellSize) / 2 - cellSize / 2;
   const offsetZ = (floor.height * cellSize) / 2 - cellSize / 2;

--- a/packages/madories/src/components/preview-3d/scene.tsx
+++ b/packages/madories/src/components/preview-3d/scene.tsx
@@ -3,11 +3,12 @@ import { Canvas } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import type { FloorPlan } from "../../types";
 import { generateFloorTiles, generateWallSegments } from "../../floor/geometry-3d";
+import { ITEM_DEF_MAP } from "../../items";
 import { PreviewCamera } from "./camera";
 import { Lighting } from "./lighting";
 import { FloorMesh } from "./meshes/floor-mesh";
 import { WallMesh } from "./meshes/wall-mesh";
-import { FurnitureMesh } from "./meshes/furniture-mesh";
+import { FurnitureMesh, getItemDrawOffset } from "./meshes/furniture-mesh";
 import { StairsMesh } from "./meshes/stairs-mesh";
 
 interface Props {
@@ -21,12 +22,20 @@ export function FloorPlanScene({ floor, cellSize, darkMode }: Props) {
   const walls = useMemo(() => generateWallSegments(floor), [floor]);
   const items = useMemo(() => {
     const result: { x: number; y: number; item: FloorPlan["cells"][number]["item"] }[] = [];
+    const seen = new Set<string>();
     for (let y = 0; y < floor.height; y++) {
       for (let x = 0; x < floor.width; x++) {
         const cell = floor.cells[y * floor.width + x];
-        if (cell.item) {
-          result.push({ x, y, item: cell.item });
-        }
+        if (!cell.item) continue;
+        const def = ITEM_DEF_MAP.get(cell.item.type);
+        if (!def) continue;
+        const { offX, offY } = getItemDrawOffset(def.w, def.h, cell.item.rotation);
+        const drawX = x + offX;
+        const drawY = y + offY;
+        const key = `${drawX},${drawY}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        result.push({ x, y, item: cell.item });
       }
     }
     return result;

--- a/packages/madories/src/components/tool-sheet/action-tabs.test.tsx
+++ b/packages/madories/src/components/tool-sheet/action-tabs.test.tsx
@@ -35,9 +35,7 @@ describe("ActionTabs", () => {
   });
 
   it("applies disabled state when canUndo is false", () => {
-    const html = renderToString(
-      <ActionTabs {...baseProps} canUndo={false} onClose={() => {}} />,
-    );
+    const html = renderToString(<ActionTabs {...baseProps} canUndo={false} onClose={() => {}} />);
     expect(html).toContain('disabled=""');
     expect(html).toContain("opacity:0.4");
   });

--- a/packages/madories/src/draw/draw-items.ts
+++ b/packages/madories/src/draw/draw-items.ts
@@ -29,8 +29,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? def.h : def.w;
   const effectiveH = isRotated ? def.w : def.h;
   const asymmetric = def.w !== def.h;
-  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
-  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
+  const offX = asymmetric && rotation === 90 && effectiveW > 1 ? -(effectiveW - 1) : 0;
+  const offY = asymmetric && rotation === 180 && effectiveH > 1 ? -(effectiveH - 1) : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 

--- a/packages/madories/src/draw/draw-items.ts
+++ b/packages/madories/src/draw/draw-items.ts
@@ -29,8 +29,8 @@ export function getItemDrawOffset(
   const effectiveW = isRotated ? def.h : def.w;
   const effectiveH = isRotated ? def.w : def.h;
   const asymmetric = def.w !== def.h;
-  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) : 0;
-  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) : 0;
+  const offX = asymmetric && rotation === 90 ? -(effectiveW - 1) || 0 : 0;
+  const offY = asymmetric && rotation === 180 ? -(effectiveH - 1) || 0 : 0;
   return { effectiveH, effectiveW, offX, offY };
 }
 


### PR DESCRIPTION
## Summary
- Fixed multi-tile item centering (`getItemCenterPosition`) so 2-cell items span both cells.
- Added TV depth factor (0.15x) for thin flat-screen appearance.
- Added directional sub-meshes: sofa (backrest + seat), desk (tabletop + legs), washbasin_large (mirror + counter).
- Fixed stairs step span to fill the full 2-tile height.
- Deduplicated multi-tile items in 3D scene to prevent double rendering.
- Unified stairs mesh to use shared `getItemDrawOffset` / `getItemCenterPosition`.

## Verification
- `bun test`: 95 pass / 0 fail
- `tsgo --noEmit`: clean
- `oxlint`: 0 warnings, 0 errors