### PR TITLE
fix(madories): fix 3D item positioning regressions

### DIFF
--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.test.ts
@@ -40,26 +40,26 @@ describe("getItemCenterPosition", () => {
 
   it("centers a single-tile item on its cell", () => {
     const result = getItemCenterPosition(0, 0, 1, 1, c);
-    expect(result).toEqual({ posX: 5, posZ: 5 });
+    expect(result).toEqual({ posX: 0, posZ: 0 });
   });
 
   it("centers a 1x2 item across its 2-cell span", () => {
     const result = getItemCenterPosition(0, 0, 1, 2, c);
-    expect(result).toEqual({ posX: 5, posZ: 10 });
+    expect(result).toEqual({ posX: 0, posZ: 5 });
   });
 
   it("centers a 2x1 item across its 2-cell width", () => {
     const result = getItemCenterPosition(0, 0, 2, 1, c);
-    expect(result).toEqual({ posX: 10, posZ: 5 });
+    expect(result).toEqual({ posX: 5, posZ: 0 });
   });
 
   it("accounts for draw offset in position", () => {
     const result = getItemCenterPosition(-1, 0, 2, 1, c);
-    expect(result).toEqual({ posX: 0, posZ: 5 });
+    expect(result).toEqual({ posX: -5, posZ: 0 });
   });
 
   it("works for non-zero origin cells", () => {
     const result = getItemCenterPosition(2, 3, 1, 1, c);
-    expect(result).toEqual({ posX: 25, posZ: 35 });
+    expect(result).toEqual({ posX: 20, posZ: 30 });
   });
 });

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -25,8 +25,8 @@ export function getItemCenterPosition(
   effectiveH: number,
   cellSize: number,
 ): { posX: number; posZ: number } {
-  const posX = (drawX + effectiveW / 2) * cellSize;
-  const posZ = (drawY + effectiveH / 2) * cellSize;
+  const posX = (drawX + effectiveW / 2 - 0.5) * cellSize;
+  const posZ = (drawY + effectiveH / 2 - 0.5) * cellSize;
   return { posX, posZ };
 }
 

--- a/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/furniture-mesh.tsx
@@ -67,8 +67,8 @@ export const FurnitureMesh = memo(function FurnitureMesh({
   const drawX = x + offX;
   const drawY = y + offY;
 
-  const width = effectiveW * cellSize * ITEM_MESH_SCALE;
-  const depth = effectiveH * cellSize * ITEM_MESH_SCALE * getItemDepthFactor(item.type);
+  const width = def.w * cellSize * ITEM_MESH_SCALE;
+  const depth = def.h * cellSize * ITEM_MESH_SCALE * getItemDepthFactor(item.type);
   const height = cellSize * getItemHeightFactor(item.type);
 
   const { posX, posZ } = getItemCenterPosition(drawX, drawY, effectiveW, effectiveH, cellSize);

--- a/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
+++ b/packages/madories/src/components/preview-3d/meshes/stairs-mesh.tsx
@@ -31,9 +31,9 @@ export const StairsMesh = memo(function StairsMesh({ x, y, cellSize, item, darkM
     const drawY = y + offY;
 
     const stepHeight = (cellSize * STAIRS_TOTAL_HEIGHT) / STAIRS_STEP_COUNT;
-    const stepWidth = cellSize * effectiveW;
-    const stepDepth = (cellSize * effectiveH) / STAIRS_STEP_COUNT;
-    const halfSpan = (cellSize * effectiveH) / 2;
+    const stepWidth = cellSize * def.w;
+    const stepDepth = (cellSize * def.h) / STAIRS_STEP_COUNT;
+    const halfSpan = (cellSize * def.h) / 2;
 
     const color = getItemColor(darkMode);
 


### PR DESCRIPTION
## Summary
Fixes two positioning regressions introduced in #131:

1. **Restore `-0.5` offset in `getItemCenterPosition`** — the `-cellSize/2` adjustment is required to center items on cell centers rather than grid intersections. Removing it shifted every item by half a cell in both directions.

2. **Use pre-rotation dimensions for 3D box geometry** — `effectiveW/effectiveH` were being used for both positioning (correct) and box sizing (incorrect). This caused a double rotation: the geometry was already swapped by `effectiveW/H`, then rotated again by the `rotation` prop, visually canceling out.

## Changes
- `furniture-mesh.tsx`: restore `- 0.5` in `getItemCenterPosition`; use `def.w/def.h` for box geometry
- `stairs-mesh.tsx`: use `def.w/def.h` for step dimensions

## Verification
- `bun test`: 100 pass / 0 fail
- `tsgo --noEmit`: clean
- `oxlint`: 0 warnings, 0 errors