### PR TITLE
✨ mintodo: マルチボード対応とパッケージ規約統一

### DIFF
--- a/packages/mintodo/package.json
+++ b/packages/mintodo/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260604.1",

--- a/packages/mintodo/src/App.tsx
+++ b/packages/mintodo/src/App.tsx
@@ -1,26 +1,68 @@
+import { useEffect } from "react";
+import { BoardDeleteDialog } from "./components/BoardDeleteDialog";
+import { BoardNameDialog } from "./components/BoardNameDialog";
+import { BoardSidebar } from "./components/BoardSidebar";
 import { Canvas } from "./components/Canvas";
 import { EditModal } from "./components/EditModal";
+import { EmptyState } from "./components/EmptyState";
 import { HelpModal } from "./components/HelpModal";
 import { ShortcutHint } from "./components/ShortcutHint";
 import { StatsPanel } from "./components/StatsPanel";
 import { Toolbar } from "./components/Toolbar";
 import { ZoomControls } from "./components/ZoomControls";
 import { useKeyboard } from "./hooks/use-keyboard";
-import { MindProvider } from "./hooks/use-mind-store";
+import { useBoardActions } from "./hooks/use-board-actions";
+import { MindProvider, useMindStore } from "./hooks/use-mind-store";
 import { useStorageSync } from "./hooks/use-storage-sync";
 
 function Shell() {
+  const { state } = useMindStore();
+  const actions = useBoardActions();
   useStorageSync();
   useKeyboard();
+
+  useEffect(() => {
+    const onCreate = (e: Event) => {
+      const {detail} = (e as CustomEvent<{ name: string }>);
+      // eslint-disable-next-line no-console
+      actions.createBoard(detail.name).catch((err) => console.error(err));
+    };
+    const onRename = (e: Event) => {
+      const {detail} = (e as CustomEvent<{ name: string; mode: string; boardId?: string }>);
+      if (detail.mode === "rename" && detail.boardId) {
+        // eslint-disable-next-line no-console
+        actions.renameBoard(detail.boardId, detail.name).catch((err) => console.error(err));
+      }
+    };
+    const onDelete = (e: Event) => {
+      const {detail} = (e as CustomEvent<{ boardId: string }>);
+      // eslint-disable-next-line no-console
+      actions.deleteBoard(detail.boardId).catch((err) => console.error(err));
+    };
+    window.addEventListener("board-name-submit", onCreate as EventListener);
+    window.addEventListener("board-name-submit", onRename as EventListener);
+    window.addEventListener("board-delete-confirm", onDelete as EventListener);
+    return () => {
+      window.removeEventListener("board-name-submit", onCreate as EventListener);
+      window.removeEventListener("board-name-submit", onRename as EventListener);
+      window.removeEventListener("board-delete-confirm", onDelete as EventListener);
+    };
+  }, [actions]);
+
+  const showCanvas = state.boards.length > 0 && state.currentBoardId !== null;
+
   return (
     <div className="bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-100 h-screen w-screen overflow-hidden select-none font-sans">
       <Toolbar />
-      <Canvas />
+      <BoardSidebar />
+      {showCanvas ? <Canvas /> : <EmptyState />}
       <ZoomControls />
       <StatsPanel />
       <ShortcutHint />
       <EditModal />
       <HelpModal />
+      <BoardNameDialog />
+      <BoardDeleteDialog />
     </div>
   );
 }

--- a/packages/mintodo/src/App.tsx
+++ b/packages/mintodo/src/App.tsx
@@ -23,19 +23,19 @@ function Shell() {
 
   useEffect(() => {
     const onCreate = (e: Event) => {
-      const {detail} = (e as CustomEvent<{ name: string }>);
+      const { detail } = e as CustomEvent<{ name: string }>;
       // eslint-disable-next-line no-console
       actions.createBoard(detail.name).catch((err) => console.error(err));
     };
     const onRename = (e: Event) => {
-      const {detail} = (e as CustomEvent<{ name: string; mode: string; boardId?: string }>);
+      const { detail } = e as CustomEvent<{ name: string; mode: string; boardId?: string }>;
       if (detail.mode === "rename" && detail.boardId) {
         // eslint-disable-next-line no-console
         actions.renameBoard(detail.boardId, detail.name).catch((err) => console.error(err));
       }
     };
     const onDelete = (e: Event) => {
-      const {detail} = (e as CustomEvent<{ boardId: string }>);
+      const { detail } = e as CustomEvent<{ boardId: string }>;
       // eslint-disable-next-line no-console
       actions.deleteBoard(detail.boardId).catch((err) => console.error(err));
     };

--- a/packages/mintodo/src/components/BoardDeleteDialog.tsx
+++ b/packages/mintodo/src/components/BoardDeleteDialog.tsx
@@ -2,7 +2,7 @@ import { useMindStore } from "../hooks/use-mind-store";
 
 export function BoardDeleteDialog() {
   const { state, dispatch } = useMindStore();
-  const modal = state.modal;
+  const { modal } = state;
   const open = modal?.kind === "board-delete";
   if (!open) return null;
 

--- a/packages/mintodo/src/components/BoardDeleteDialog.tsx
+++ b/packages/mintodo/src/components/BoardDeleteDialog.tsx
@@ -1,0 +1,54 @@
+import { useMindStore } from "../hooks/use-mind-store";
+
+export function BoardDeleteDialog() {
+  const { state, dispatch } = useMindStore();
+  const modal = state.modal;
+  const open = modal?.kind === "board-delete";
+  if (!open) return null;
+
+  const close = () => dispatch({ modal: null, type: "OPEN_MODAL" });
+
+  const onConfirm = () => {
+    const event = new CustomEvent<{ boardId: string }>("board-delete-confirm", {
+      detail: { boardId: modal.boardId },
+    });
+    window.dispatchEvent(event);
+    close();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={close}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-2xl w-[420px] max-w-[90vw]"
+      >
+        <h2 className="text-lg font-bold mb-2">ボードを削除</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-300 mb-1">
+          「<span className="font-semibold">{modal.boardName}</span>」を削除しますか?
+        </p>
+        <p className="text-xs text-rose-600 dark:text-rose-400 mb-4">
+          このボードのすべてのタスクが削除されます。この操作は取り消せません。
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={close}
+            className="px-4 py-2 text-sm rounded-xl bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm rounded-xl bg-rose-600 text-white hover:bg-rose-700"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/mintodo/src/components/BoardListItem.tsx
+++ b/packages/mintodo/src/components/BoardListItem.tsx
@@ -1,0 +1,87 @@
+import { MoreVertical } from "lucide-react";
+import { useMemo } from "react";
+import { useMindStore } from "../hooks/use-mind-store";
+
+interface Props {
+  boardId: string;
+  isCurrent: boolean;
+  onSelect: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+export function BoardListItem({ boardId, isCurrent, onSelect, onRename, onDelete }: Props) {
+  const { state } = useMindStore();
+  const board = state.boards.find((b) => b.id === boardId);
+  if (!board) return null;
+
+  const { total, completed, rate } = useMemo(() => {
+    const nodes = Object.values(state.nodes).filter((n) => n.boardId === boardId && !n.isRoot);
+    const total = nodes.length;
+    const completed = nodes.filter((n) => n.completed).length;
+    const rate = total === 0 ? 0 : Math.round((completed / total) * 100);
+    return { total, completed, rate };
+  }, [state.nodes, boardId]);
+
+  return (
+    <li
+      className={`group rounded-xl p-2.5 mb-1 transition cursor-pointer ${
+        isCurrent
+          ? "bg-indigo-100 dark:bg-indigo-950/40"
+          : "hover:bg-slate-100 dark:hover:bg-slate-700/50"
+      }`}
+      onClick={onSelect}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={`w-2 h-2 rounded-full ${
+            isCurrent ? "bg-indigo-500" : "bg-slate-300 dark:bg-slate-600"
+          }`}
+        />
+        <span
+          className={`flex-1 text-sm font-medium truncate ${
+            isCurrent ? "text-indigo-700 dark:text-indigo-200" : ""
+          }`}
+        >
+          {board.name}
+        </span>
+        <div className="opacity-0 group-hover:opacity-100 transition flex">
+          <button
+            type="button"
+            title="リネーム"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRename();
+            }}
+            className="p-1 text-xs text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+          >
+            ✎
+          </button>
+          <button
+            type="button"
+            title="削除"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            className="p-1 text-xs text-rose-400 hover:text-rose-600"
+          >
+            🗑
+          </button>
+        </div>
+        <MoreVertical size={14} className="text-slate-400" />
+      </div>
+      <div className="mt-1.5 ml-4">
+        <div className="bg-slate-200 dark:bg-slate-700 h-1 rounded-full overflow-hidden">
+          <div
+            className="bg-indigo-500 h-full transition-all"
+            style={{ width: `${rate}%` }}
+          />
+        </div>
+        <div className="text-[10px] text-slate-500 dark:text-slate-400 mt-1">
+          {total === 0 ? "タスクなし" : `${completed}/${total} 完了 (${rate}%)`}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/packages/mintodo/src/components/BoardListItem.tsx
+++ b/packages/mintodo/src/components/BoardListItem.tsx
@@ -73,10 +73,7 @@ export function BoardListItem({ boardId, isCurrent, onSelect, onRename, onDelete
       </div>
       <div className="mt-1.5 ml-4">
         <div className="bg-slate-200 dark:bg-slate-700 h-1 rounded-full overflow-hidden">
-          <div
-            className="bg-indigo-500 h-full transition-all"
-            style={{ width: `${rate}%` }}
-          />
+          <div className="bg-indigo-500 h-full transition-all" style={{ width: `${rate}%` }} />
         </div>
         <div className="text-[10px] text-slate-500 dark:text-slate-400 mt-1">
           {total === 0 ? "タスクなし" : `${completed}/${total} 完了 (${rate}%)`}

--- a/packages/mintodo/src/components/BoardNameDialog.tsx
+++ b/packages/mintodo/src/components/BoardNameDialog.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { useMindStore } from "../hooks/use-mind-store";
+
+const MAX_NAME = 50;
+
+export function BoardNameDialog() {
+  const { state, dispatch } = useMindStore();
+  const modal = state.modal;
+  const open = modal?.kind === "board-name";
+  const initial = open ? (modal.initialName ?? "") : "";
+  const [name, setName] = useState(initial);
+
+  useEffect(() => {
+    if (open) setName(initial);
+  }, [open, initial]);
+
+  if (!open) return null;
+
+  const close = () => dispatch({ modal: null, type: "OPEN_MODAL" });
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const event = new CustomEvent<{ name: string; mode: "create" | "rename"; boardId?: string }>(
+      "board-name-submit",
+      { detail: { name: trimmed, mode: modal.mode, boardId: modal.boardId } },
+    );
+    window.dispatchEvent(event);
+    close();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={close}
+    >
+      <form
+        onSubmit={onSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-2xl w-[420px] max-w-[90vw]"
+      >
+        <h2 className="text-lg font-bold mb-4">
+          {modal.mode === "create" ? "新しいボード" : "ボード名を変更"}
+        </h2>
+        <input
+          autoFocus
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value.slice(0, MAX_NAME))}
+          maxLength={MAX_NAME}
+          placeholder="例: メインプロジェクト"
+          className="w-full px-3 py-2 text-sm bg-slate-100 dark:bg-slate-700 border border-transparent focus:border-indigo-500 rounded-xl outline-none"
+        />
+        <div className="text-xs text-slate-500 mt-1">{name.length} / {MAX_NAME}</div>
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            type="button"
+            onClick={close}
+            className="px-4 py-2 text-sm rounded-xl bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            disabled={!name.trim()}
+            className="px-4 py-2 text-sm rounded-xl bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {modal.mode === "create" ? "作成" : "保存"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/mintodo/src/components/BoardNameDialog.tsx
+++ b/packages/mintodo/src/components/BoardNameDialog.tsx
@@ -5,7 +5,7 @@ const MAX_NAME = 50;
 
 export function BoardNameDialog() {
   const { state, dispatch } = useMindStore();
-  const modal = state.modal;
+  const { modal } = state;
   const open = modal?.kind === "board-name";
   const initial = open ? (modal.initialName ?? "") : "";
   const [name, setName] = useState(initial);
@@ -52,7 +52,9 @@ export function BoardNameDialog() {
           placeholder="例: メインプロジェクト"
           className="w-full px-3 py-2 text-sm bg-slate-100 dark:bg-slate-700 border border-transparent focus:border-indigo-500 rounded-xl outline-none"
         />
-        <div className="text-xs text-slate-500 mt-1">{name.length} / {MAX_NAME}</div>
+        <div className="text-xs text-slate-500 mt-1">
+          {name.length} / {MAX_NAME}
+        </div>
         <div className="flex justify-end gap-2 mt-4">
           <button
             type="button"

--- a/packages/mintodo/src/components/BoardSidebar.tsx
+++ b/packages/mintodo/src/components/BoardSidebar.tsx
@@ -1,0 +1,56 @@
+import { Plus } from "lucide-react";
+import { useMindStore } from "../hooks/use-mind-store";
+import { useBoardActions } from "../hooks/use-board-actions";
+import { BoardListItem } from "./BoardListItem";
+
+export function BoardSidebar() {
+  const { state, dispatch } = useMindStore();
+  const actions = useBoardActions();
+
+  const onCreate = () => {
+    dispatch({ modal: { kind: "board-name", mode: "create" }, type: "OPEN_MODAL" });
+  };
+  const onRename = (boardId: string, name: string) => {
+    dispatch({
+      modal: { kind: "board-name", mode: "rename", boardId, initialName: name },
+      type: "OPEN_MODAL",
+    });
+  };
+  const onDelete = (boardId: string, name: string) => {
+    dispatch({ modal: { kind: "board-delete", boardId, boardName: name }, type: "OPEN_MODAL" });
+  };
+
+  return (
+    <aside className="absolute left-4 top-20 bottom-4 w-60 z-10 bg-white/80 dark:bg-slate-800/80 backdrop-blur-md rounded-2xl shadow-lg border border-slate-200/50 dark:border-slate-700/50 flex flex-col">
+      <header className="flex items-center justify-between p-3 border-b border-slate-200/50 dark:border-slate-700/50">
+        <h2 className="text-sm font-bold">ボード</h2>
+        <button
+          type="button"
+          onClick={onCreate}
+          title="新規ボード"
+          className="p-1.5 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700"
+        >
+          <Plus size={14} />
+        </button>
+      </header>
+      <ul className="flex-1 overflow-y-auto p-2">
+        {state.boards.length === 0 ? (
+          <li className="text-xs text-slate-400 dark:text-slate-500 text-center py-4">
+            まだありません
+          </li>
+        ) : (
+          state.boards.map((b) => (
+            <BoardListItem
+              key={b.id}
+              boardId={b.id}
+              isCurrent={b.id === state.currentBoardId}
+              onSelect={() => actions.switchBoard(b.id)}
+              onRename={() => onRename(b.id, b.name)}
+              onDelete={() => onDelete(b.id, b.name)}
+            />
+          ))
+        )}
+      </ul>
+    </aside>
+  );
+}

--- a/packages/mintodo/src/components/Canvas.tsx
+++ b/packages/mintodo/src/components/Canvas.tsx
@@ -29,14 +29,16 @@ export function Canvas() {
     dispatch({ id: a.id, type: "MOVE_NODE", x: a.x, y: a.y });
   });
 
-  const visibleNodes = useMemo(() => 
-    Object.values(state.nodes).filter((n) => {
-      if (state.currentBoardId && n.boardId !== state.currentBoardId) return false;
-      if (isParentCollapsed(state, n.id)) return false;
-      if (state.hideCompleted && n.completed && !n.isRoot) return false;
-      return true;
-    })
-  , [state.nodes, state.currentBoardId, state.hideCompleted]);
+  const visibleNodes = useMemo(
+    () =>
+      Object.values(state.nodes).filter((n) => {
+        if (state.currentBoardId && n.boardId !== state.currentBoardId) return false;
+        if (isParentCollapsed(state, n.id)) return false;
+        if (state.hideCompleted && n.completed && !n.isRoot) return false;
+        return true;
+      }),
+    [state.nodes, state.currentBoardId, state.hideCompleted],
+  );
 
   return (
     <div

--- a/packages/mintodo/src/components/Canvas.tsx
+++ b/packages/mintodo/src/components/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useDragNode } from "../hooks/use-drag-node";
 import { useMindStore } from "../hooks/use-mind-store";
 import { usePanZoom } from "../hooks/use-pan-zoom";
@@ -29,11 +29,14 @@ export function Canvas() {
     dispatch({ id: a.id, type: "MOVE_NODE", x: a.x, y: a.y });
   });
 
-  const visibleNodes = Object.values(state.nodes).filter((n) => {
-    if (isParentCollapsed(state, n.id)) return false;
-    if (state.hideCompleted && n.completed && !n.isRoot) return false;
-    return true;
-  });
+  const visibleNodes = useMemo(() => 
+    Object.values(state.nodes).filter((n) => {
+      if (state.currentBoardId && n.boardId !== state.currentBoardId) return false;
+      if (isParentCollapsed(state, n.id)) return false;
+      if (state.hideCompleted && n.completed && !n.isRoot) return false;
+      return true;
+    })
+  , [state.nodes, state.currentBoardId, state.hideCompleted]);
 
   return (
     <div

--- a/packages/mintodo/src/components/ConnectionLines.tsx
+++ b/packages/mintodo/src/components/ConnectionLines.tsx
@@ -57,12 +57,12 @@ export function ConnectionLines({ containerRef }: Props) {
         const c2x = sx + (ex - sx) * 0.5;
         const c2y = ey;
         const color = node.completed
-          ? (isDark
+          ? isDark
             ? "#334155"
-            : "#cbd5e1")
-          : (isDark
+            : "#cbd5e1"
+          : isDark
             ? "#818cf8"
-            : "#6366f1");
+            : "#6366f1";
         const pathProps = node.completed
           ? { strokeDasharray: "5,5", strokeWidth: 1.5 }
           : { strokeWidth: 3 };

--- a/packages/mintodo/src/components/EmptyState.tsx
+++ b/packages/mintodo/src/components/EmptyState.tsx
@@ -11,7 +11,8 @@ export function EmptyState() {
         <div className="text-6xl mb-4">🌱</div>
         <h2 className="text-2xl font-bold mb-2">最初のボードを作成</h2>
         <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">
-          プロジェクト、アイデア、ToDo...<br />
+          プロジェクト、アイデア、ToDo...
+          <br />
           ボードを作成してマインドマップを始めましょう
         </p>
         <button

--- a/packages/mintodo/src/components/EmptyState.tsx
+++ b/packages/mintodo/src/components/EmptyState.tsx
@@ -1,0 +1,27 @@
+import { useMindStore } from "../hooks/use-mind-store";
+
+export function EmptyState() {
+  const { dispatch } = useMindStore();
+  const onCreate = () =>
+    dispatch({ modal: { kind: "board-name", mode: "create" }, type: "OPEN_MODAL" });
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-slate-50 dark:bg-slate-900">
+      <div className="text-center max-w-md">
+        <div className="text-6xl mb-4">🌱</div>
+        <h2 className="text-2xl font-bold mb-2">最初のボードを作成</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">
+          プロジェクト、アイデア、ToDo...<br />
+          ボードを作成してマインドマップを始めましょう
+        </p>
+        <button
+          type="button"
+          onClick={onCreate}
+          className="px-6 py-3 rounded-2xl bg-indigo-600 text-white font-semibold shadow-md shadow-indigo-500/30 hover:bg-indigo-700 transition"
+        >
+          + 新規ボード作成
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/mintodo/src/components/Toolbar.tsx
+++ b/packages/mintodo/src/components/Toolbar.tsx
@@ -19,7 +19,8 @@ export function Toolbar() {
       board: { id: currentBoard?.id ?? "", name: currentBoard?.name ?? "Unknown" },
       nodes: Object.values(state.nodes),
     };
-    const url = downloadJson(data, `mintodo_backup_${new Date().toISOString().slice(0, 10)}.json`);
+    const date = new Date().toISOString().slice(0, 10);
+    const url = downloadJson(data, `mintodo_${currentBoard?.name ?? "Unknown"}_${date}.json`);
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
@@ -34,8 +35,21 @@ export function Toolbar() {
       alert("インポートに失敗しました。ファイルが壊れている可能性があります。");
       return;
     }
+    if (
+      Object.keys(state.nodes).length > 0 &&
+      !confirm(
+        `「${data.board.name}」から${data.nodes.length}件のタスクをインポートします。\nこのボードの現在のタスクは失われます。続行しますか?`,
+      )
+    ) {
+      e.target.value = "";
+      return;
+    }
+    // Rewrite boardId so nodes belong to the current board.
+    const currentId = state.currentBoardId;
     const rec: Record<string, (typeof data.nodes)[number]> = {};
-    for (const n of data.nodes) rec[n.id] = n;
+    for (const n of data.nodes) {
+      rec[n.id] = { ...n, boardId: currentId ?? n.boardId };
+    }
     dispatch({ nodes: rec, type: "SET_NODES" });
     e.target.value = "";
   };

--- a/packages/mintodo/src/components/Toolbar.tsx
+++ b/packages/mintodo/src/components/Toolbar.tsx
@@ -13,7 +13,12 @@ export function Toolbar() {
   const fileRef = useRef<HTMLInputElement>(null);
 
   const onExport = () => {
-    const data = { nodes: Object.values(state.nodes), version: 1 as const };
+    const currentBoard = state.boards.find((b) => b.id === state.currentBoardId);
+    const data = {
+      version: 2 as const,
+      board: { id: currentBoard?.id ?? "", name: currentBoard?.name ?? "Unknown" },
+      nodes: Object.values(state.nodes),
+    };
     const url = downloadJson(data, `mintodo_backup_${new Date().toISOString().slice(0, 10)}.json`);
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   };

--- a/packages/mintodo/src/db.ts
+++ b/packages/mintodo/src/db.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Table } from "dexie";
-import type { MindNode } from "./types";
+import type { Board, MindNode } from "./types";
 
 export interface MetaEntry {
   key: string;
@@ -7,6 +7,7 @@ export interface MetaEntry {
 }
 
 export class MindDB extends Dexie {
+  public boards!: Table<Board, string>;
   public nodes!: Table<MindNode, string>;
   public meta!: Table<MetaEntry, string>;
 
@@ -15,6 +16,11 @@ export class MindDB extends Dexie {
     this.version(1).stores({
       meta: "key",
       nodes: "id",
+    });
+    this.version(2).stores({
+      meta: "key",
+      boards: "id, updatedAt",
+      nodes: "id, boardId",
     });
   }
 }

--- a/packages/mintodo/src/db.ts
+++ b/packages/mintodo/src/db.ts
@@ -8,7 +8,7 @@ export interface MetaEntry {
 
 export class MindDB extends Dexie {
   public boards!: Table<Board, string>;
-  public nodes!: Table<MindNode, string>;
+  public nodes!: Table<MindNode, [string, string]>;
   public meta!: Table<MetaEntry, string>;
 
   public constructor() {
@@ -20,7 +20,7 @@ export class MindDB extends Dexie {
     this.version(2).stores({
       meta: "key",
       boards: "id, updatedAt",
-      nodes: "id, boardId",
+      nodes: "[boardId+id], boardId",
     });
   }
 }

--- a/packages/mintodo/src/hooks/use-board-actions.test.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.test.ts
@@ -52,7 +52,7 @@ describe("useBoardActions", () => {
     await act(async () => {
       await result.current.actions.createBoard("Old");
     });
-    const { id } = result.current.store.state.boards[0];
+    const [{ id }] = result.current.store.state.boards;
     await act(async () => {
       await result.current.actions.renameBoard(id, "New");
     });
@@ -93,7 +93,7 @@ describe("useBoardActions", () => {
     await act(async () => {
       await result.current.actions.createBoard("Solo");
     });
-    const { id } = result.current.store.state.boards[0];
+    const [{ id }] = result.current.store.state.boards;
     await act(async () => {
       await result.current.actions.deleteBoard(id);
     });
@@ -205,7 +205,7 @@ describe("useBoardActions", () => {
     });
     expect(result.current.store.state.currentBoardId).toBe(a!.id);
     // Mutate the root node's text on board A
-    await act(async () => {
+    await act(() => {
       result.current.store.dispatch({
         id: "root",
         patch: { text: "Mutated" },

--- a/packages/mintodo/src/hooks/use-board-actions.test.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.test.ts
@@ -1,0 +1,134 @@
+/* eslint-disable init-declarations */
+import "fake-indexeddb/auto";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../db";
+import { MindProvider, useMindStore } from "./use-mind-store";
+import { useBoardActions } from "./use-board-actions";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(MindProvider, null, children);
+}
+
+beforeEach(async () => {
+  await db.boards.clear();
+  await db.nodes.clear();
+  await db.meta.clear();
+});
+
+afterEach(async () => {
+  await db.boards.clear();
+  await db.nodes.clear();
+  await db.meta.clear();
+});
+
+describe("useBoardActions", () => {
+  it("createBoard adds a board and sets it as current", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await act(async () => {
+      await result.current.actions.createBoard("My Board");
+    });
+    expect(result.current.store.state.boards).toHaveLength(1);
+    expect(result.current.store.state.boards[0].name).toBe("My Board");
+    expect(result.current.store.state.currentBoardId).toBe(
+      result.current.store.state.boards[0].id,
+    );
+    expect(result.current.store.state.nodes.root).toBeDefined();
+  });
+
+  it("renameBoard updates the board name", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await act(async () => {
+      await result.current.actions.createBoard("Old");
+    });
+    const id = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.renameBoard(id, "New");
+    });
+    expect(result.current.store.state.boards[0].name).toBe("New");
+  });
+
+  it("deleteBoard removes the board and switches to next", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await act(async () => {
+      await result.current.actions.createBoard("A");
+    });
+    const aId = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.createBoard("B");
+    });
+    const bId = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.deleteBoard(aId);
+    });
+    expect(result.current.store.state.boards.map((b) => b.id)).toEqual([bId]);
+    expect(result.current.store.state.currentBoardId).toBe(bId);
+  });
+
+  it("deleteBoard of the last board sets currentBoardId to null", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await act(async () => {
+      await result.current.actions.createBoard("Solo");
+    });
+    const id = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.deleteBoard(id);
+    });
+    expect(result.current.store.state.boards).toEqual([]);
+    expect(result.current.store.state.currentBoardId).toBeNull();
+    expect(result.current.store.state.nodes).toEqual({});
+  });
+
+  it("switchBoard loads nodes for the new board", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await act(async () => {
+      await result.current.actions.createBoard("A");
+    });
+    const aId = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.createBoard("B");
+    });
+    const bId = result.current.store.state.boards[0].id;
+    await act(async () => {
+      await result.current.actions.switchBoard(aId);
+    });
+    expect(result.current.store.state.currentBoardId).toBe(aId);
+    expect(result.current.store.state.nodes.root.boardId).toBe(aId);
+    await act(async () => {
+      await result.current.actions.switchBoard(bId);
+    });
+    expect(result.current.store.state.currentBoardId).toBe(bId);
+    expect(result.current.store.state.nodes.root.boardId).toBe(bId);
+  });
+});

--- a/packages/mintodo/src/hooks/use-board-actions.test.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.test.ts
@@ -37,9 +37,7 @@ describe("useBoardActions", () => {
     });
     expect(result.current.store.state.boards).toHaveLength(1);
     expect(result.current.store.state.boards[0].name).toBe("My Board");
-    expect(result.current.store.state.currentBoardId).toBe(
-      result.current.store.state.boards[0].id,
-    );
+    expect(result.current.store.state.currentBoardId).toBe(result.current.store.state.boards[0].id);
     expect(result.current.store.state.nodes.root).toBeDefined();
   });
 
@@ -54,7 +52,7 @@ describe("useBoardActions", () => {
     await act(async () => {
       await result.current.actions.createBoard("Old");
     });
-    const id = result.current.store.state.boards[0].id;
+    const { id } = result.current.store.state.boards[0];
     await act(async () => {
       await result.current.actions.renameBoard(id, "New");
     });
@@ -69,19 +67,19 @@ describe("useBoardActions", () => {
       }),
       { wrapper },
     );
+    let a: { id: string };
+    let b: { id: string };
     await act(async () => {
-      await result.current.actions.createBoard("A");
+      a = await result.current.actions.createBoard("A");
     });
-    const aId = result.current.store.state.boards[0].id;
     await act(async () => {
-      await result.current.actions.createBoard("B");
+      b = await result.current.actions.createBoard("B");
     });
-    const bId = result.current.store.state.boards[0].id;
     await act(async () => {
-      await result.current.actions.deleteBoard(aId);
+      await result.current.actions.deleteBoard(a!.id);
     });
-    expect(result.current.store.state.boards.map((b) => b.id)).toEqual([bId]);
-    expect(result.current.store.state.currentBoardId).toBe(bId);
+    expect(result.current.store.state.boards.map((b) => b.id)).toEqual([b!.id]);
+    expect(result.current.store.state.currentBoardId).toBe(b!.id);
   });
 
   it("deleteBoard of the last board sets currentBoardId to null", async () => {
@@ -95,13 +93,64 @@ describe("useBoardActions", () => {
     await act(async () => {
       await result.current.actions.createBoard("Solo");
     });
-    const id = result.current.store.state.boards[0].id;
+    const { id } = result.current.store.state.boards[0];
     await act(async () => {
       await result.current.actions.deleteBoard(id);
     });
     expect(result.current.store.state.boards).toEqual([]);
     expect(result.current.store.state.currentBoardId).toBeNull();
     expect(result.current.store.state.nodes).toEqual({});
+  });
+
+  it("createBoard with empty name throws", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await expect(async () => {
+      await act(async () => {
+        await result.current.actions.createBoard("");
+      });
+    }).rejects.toThrow("Board name cannot be empty");
+  });
+
+  it("createBoard with whitespace-only name throws", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    await expect(async () => {
+      await act(async () => {
+        await result.current.actions.createBoard("   ");
+      });
+    }).rejects.toThrow("Board name cannot be empty");
+  });
+
+  it("renameBoard with empty name throws", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    let board: { id: string };
+    await act(async () => {
+      board = await result.current.actions.createBoard("Valid");
+    });
+    await expect(async () => {
+      await act(async () => {
+        await result.current.actions.renameBoard(board!.id, "");
+      });
+    }).rejects.toThrow("Board name cannot be empty");
+    // Board name should remain unchanged
+    expect(result.current.store.state.boards[0].name).toBe("Valid");
   });
 
   it("switchBoard loads nodes for the new board", async () => {
@@ -112,14 +161,16 @@ describe("useBoardActions", () => {
       }),
       { wrapper },
     );
+    let a: { id: string };
+    let b: { id: string };
     await act(async () => {
-      await result.current.actions.createBoard("A");
+      a = await result.current.actions.createBoard("A");
     });
-    const aId = result.current.store.state.boards[0].id;
     await act(async () => {
-      await result.current.actions.createBoard("B");
+      b = await result.current.actions.createBoard("B");
     });
-    const bId = result.current.store.state.boards[0].id;
+    const aId = a!.id;
+    const bId = b!.id;
     await act(async () => {
       await result.current.actions.switchBoard(aId);
     });
@@ -130,5 +181,48 @@ describe("useBoardActions", () => {
     });
     expect(result.current.store.state.currentBoardId).toBe(bId);
     expect(result.current.store.state.nodes.root.boardId).toBe(bId);
+  });
+
+  it("switchBoard flushes pending edits before switching", async () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useBoardActions(),
+        store: useMindStore(),
+      }),
+      { wrapper },
+    );
+    let a: { id: string };
+    let b: { id: string };
+    await act(async () => {
+      a = await result.current.actions.createBoard("A");
+    });
+    await act(async () => {
+      b = await result.current.actions.createBoard("B");
+    });
+    // On board B now. Switch back to A.
+    await act(async () => {
+      await result.current.actions.switchBoard(a!.id);
+    });
+    expect(result.current.store.state.currentBoardId).toBe(a!.id);
+    // Mutate the root node's text on board A
+    await act(async () => {
+      result.current.store.dispatch({
+        id: "root",
+        patch: { text: "Mutated" },
+        type: "UPDATE_NODE",
+      });
+    });
+    expect(result.current.store.state.nodes.root.text).toBe("Mutated");
+    // Switch to board B — flush saves A's mutated nodes to storage
+    await act(async () => {
+      await result.current.actions.switchBoard(b!.id);
+    });
+    expect(result.current.store.state.currentBoardId).toBe(b!.id);
+    // Switch back to board A — load from storage, mutation should persist
+    await act(async () => {
+      await result.current.actions.switchBoard(a!.id);
+    });
+    expect(result.current.store.state.currentBoardId).toBe(a!.id);
+    expect(result.current.store.state.nodes.root.text).toBe("Mutated");
   });
 });

--- a/packages/mintodo/src/hooks/use-board-actions.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.ts
@@ -1,0 +1,110 @@
+import { useCallback } from "react";
+import {
+  createBoard as createBoardInStorage,
+  deleteBoard as deleteBoardInStorage,
+  loadBoards,
+  loadNodesForBoard,
+  renameBoard as renameBoardInStorage,
+  saveNodesForBoard,
+  setCurrentBoardId,
+} from "../storage";
+import type { Board } from "../types";
+import { useMindStore } from "./use-mind-store";
+
+function makeRootNode(boardId: string, name: string) {
+  return {
+    root: {
+      id: "root",
+      boardId,
+      text: name,
+      parentId: null,
+      isRoot: true,
+      completed: false,
+      collapsed: false,
+      priority: "medium" as const,
+      categoryColor: "slate" as const,
+      dueDate: "",
+      children: [],
+      x: 0,
+      y: 0,
+      vx: 0,
+      vy: 0,
+    },
+  };
+}
+
+export interface BoardActions {
+  createBoard: (name: string) => Promise<Board>;
+  deleteBoard: (id: string) => Promise<void>;
+  renameBoard: (id: string, name: string) => Promise<void>;
+  switchBoard: (id: string) => Promise<void>;
+  refreshBoards: () => Promise<void>;
+}
+
+export function useBoardActions(): BoardActions {
+  const { state, dispatch } = useMindStore();
+
+  const refreshBoards = useCallback(async () => {
+    const boards = await loadBoards();
+    dispatch({ boards, type: "SET_BOARDS" });
+  }, [dispatch]);
+
+  const createBoard = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) throw new Error("Board name cannot be empty");
+      const { board, rootId } = await createBoardInStorage(trimmed);
+      const initialNodes = makeRootNode(board.id, trimmed);
+      // Sanity: rootId should be "root"
+      if (rootId !== "root") {
+        throw new Error(`Unexpected rootId: ${rootId}`);
+      }
+      dispatch({ board, initialNodes, type: "ADD_BOARD" });
+      await setCurrentBoardId(board.id);
+      await refreshBoards();
+      return board;
+    },
+    [dispatch, refreshBoards],
+  );
+
+  const renameBoard = useCallback(
+    async (id: string, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) throw new Error("Board name cannot be empty");
+      await renameBoardInStorage(id, trimmed);
+      dispatch({ id, name: trimmed, type: "RENAME_BOARD" });
+      await refreshBoards();
+    },
+    [dispatch, refreshBoards],
+  );
+
+  const deleteBoard = useCallback(
+    async (id: string) => {
+      const boards = await loadBoards();
+      const remaining = boards.filter((b) => b.id !== id);
+      const next = remaining.sort((a, b) => b.updatedAt - a.updatedAt)[0]?.id ?? null;
+      await deleteBoardInStorage(id);
+      dispatch({ id, nextBoardId: next, type: "DELETE_BOARD" });
+      await setCurrentBoardId(next);
+      await refreshBoards();
+    },
+    [dispatch, refreshBoards],
+  );
+
+  const switchBoard = useCallback(
+    async (id: string) => {
+      // Flush any pending edits to the current board before switching
+      // to avoid losing them when the save effect re-targets to the new board.
+      if (state.currentBoardId && state.currentBoardId !== id) {
+        await saveNodesForBoard(state.currentBoardId, state.nodes);
+      }
+      const nodes = await loadNodesForBoard(id);
+      dispatch({ boardId: id, type: "SET_CURRENT_BOARD" });
+      dispatch({ nodes, type: "SET_NODES" });
+      await setCurrentBoardId(id);
+    },
+    [dispatch, state.currentBoardId, state.nodes],
+  );
+
+  return { createBoard, deleteBoard, renameBoard, switchBoard, refreshBoards };
+}

--- a/packages/mintodo/src/hooks/use-board-actions.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.ts
@@ -82,7 +82,7 @@ export function useBoardActions(): BoardActions {
     async (id: string) => {
       const boards = await loadBoards();
       const remaining = boards.filter((b) => b.id !== id);
-      const next = remaining.sort((a, b) => b.updatedAt - a.updatedAt)[0]?.id ?? null;
+      const next = [...remaining].sort((a, b) => b.updatedAt - a.updatedAt)[0]?.id ?? null;
       await deleteBoardInStorage(id);
       dispatch({ id, nextBoardId: next, type: "DELETE_BOARD" });
       await setCurrentBoardId(next);
@@ -95,13 +95,16 @@ export function useBoardActions(): BoardActions {
     async (id: string) => {
       // Flush any pending edits to the current board before switching
       // to avoid losing them when the save effect re-targets to the new board.
-      if (state.currentBoardId && state.currentBoardId !== id) {
-        await saveNodesForBoard(state.currentBoardId, state.nodes);
+      try {
+        if (state.currentBoardId && state.currentBoardId !== id) {
+          await saveNodesForBoard(state.currentBoardId, state.nodes);
+        }
+      } finally {
+        const nodes = await loadNodesForBoard(id);
+        dispatch({ boardId: id, type: "SET_CURRENT_BOARD" });
+        dispatch({ nodes, type: "SET_NODES" });
+        await setCurrentBoardId(id);
       }
-      const nodes = await loadNodesForBoard(id);
-      dispatch({ boardId: id, type: "SET_CURRENT_BOARD" });
-      dispatch({ nodes, type: "SET_NODES" });
-      await setCurrentBoardId(id);
     },
     [dispatch, state.currentBoardId, state.nodes],
   );

--- a/packages/mintodo/src/hooks/use-board-actions.ts
+++ b/packages/mintodo/src/hooks/use-board-actions.ts
@@ -82,7 +82,7 @@ export function useBoardActions(): BoardActions {
     async (id: string) => {
       const boards = await loadBoards();
       const remaining = boards.filter((b) => b.id !== id);
-      const next = [...remaining].sort((a, b) => b.updatedAt - a.updatedAt)[0]?.id ?? null;
+      const next = [...remaining].toSorted((a, b) => b.updatedAt - a.updatedAt)[0]?.id ?? null;
       await deleteBoardInStorage(id);
       dispatch({ id, nextBoardId: next, type: "DELETE_BOARD" });
       await setCurrentBoardId(next);
@@ -94,7 +94,7 @@ export function useBoardActions(): BoardActions {
   const switchBoard = useCallback(
     async (id: string) => {
       // Flush any pending edits to the current board before switching
-      // to avoid losing them when the save effect re-targets to the new board.
+      // To avoid losing them when the save effect re-targets to the new board.
       try {
         if (state.currentBoardId && state.currentBoardId !== id) {
           await saveNodesForBoard(state.currentBoardId, state.nodes);

--- a/packages/mintodo/src/hooks/use-storage-sync.ts
+++ b/packages/mintodo/src/hooks/use-storage-sync.ts
@@ -1,5 +1,15 @@
 import { useEffect, useRef } from "react";
-import { getMeta, loadFromDexie, saveToDexie, setMeta } from "../storage";
+import {
+  discardV1Data,
+  getCurrentBoardId,
+  getMeta,
+  hasV1Data,
+  loadBoards,
+  loadNodesForBoard,
+  saveNodesForBoard,
+  setCurrentBoardId,
+  setMeta,
+} from "../storage";
 import { useMindStore } from "./use-mind-store";
 
 const SAVE_DEBOUNCE_MS = 300;
@@ -12,9 +22,19 @@ export function useStorageSync(): void {
   useEffect(() => {
     (async () => {
       try {
-        const loaded = await loadFromDexie();
-        if (loaded) {
-          dispatch({ nodes: loaded, type: "SET_NODES" });
+        if (await hasV1Data()) {
+          await discardV1Data();
+        }
+        const boards = await loadBoards();
+        dispatch({ boards, type: "SET_BOARDS" });
+        const currentId = await getCurrentBoardId();
+        if (currentId && boards.some((b) => b.id === currentId)) {
+          dispatch({ boardId: currentId, type: "SET_CURRENT_BOARD" });
+          const nodes = await loadNodesForBoard(currentId);
+          dispatch({ nodes, type: "SET_NODES" });
+        } else {
+          await setCurrentBoardId(null);
+          dispatch({ boardId: null, type: "SET_CURRENT_BOARD" });
         }
         const physics = await getMeta<boolean>("physicsEnabled");
         if (physics === false) {
@@ -23,8 +43,9 @@ export function useStorageSync(): void {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error("mintodo: failed to load from IndexedDB, using initial state", err);
+      } finally {
+        loadedRef.current = true;
       }
-      loadedRef.current = true;
     })();
   }, [dispatch]);
 
@@ -32,10 +53,12 @@ export function useStorageSync(): void {
     if (!loadedRef.current) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      saveToDexie(state.nodes).catch((err: unknown) => {
-        // eslint-disable-next-line no-console
-        console.error("mintodo: failed to save nodes", err);
-      });
+      if (state.currentBoardId) {
+        saveNodesForBoard(state.currentBoardId, state.nodes).catch((err: unknown) => {
+          // eslint-disable-next-line no-console
+          console.error("mintodo: failed to save nodes", err);
+        });
+      }
       setMeta("physicsEnabled", state.physicsEnabled).catch((err: unknown) => {
         // eslint-disable-next-line no-console
         console.error("mintodo: failed to save meta", err);
@@ -44,5 +67,5 @@ export function useStorageSync(): void {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
-  }, [state.nodes, state.physicsEnabled]);
+  }, [state.nodes, state.currentBoardId, state.physicsEnabled]);
 }

--- a/packages/mintodo/src/storage.test.ts
+++ b/packages/mintodo/src/storage.test.ts
@@ -69,9 +69,13 @@ describe("createBoard", () => {
 describe("loadBoards", () => {
   it("returns boards sorted by updatedAt desc", async () => {
     const a = await createBoard("A");
-    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 5);
+    });
     const b = await createBoard("B");
-    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 5);
+    });
     const c = await createBoard("C");
     const list = await loadBoards();
     expect(list.map((x) => x.id)).toEqual([c.board.id, b.board.id, a.board.id]);
@@ -91,7 +95,7 @@ describe("loadNodesForBoard / saveNodesForBoard", () => {
     };
     await saveNodesForBoard(board.id, nodes);
     const loaded = await loadNodesForBoard(board.id);
-    expect(Object.keys(loaded).sort()).toEqual([rootId, "n-1"].sort());
+    expect(Object.keys(loaded).toSorted()).toEqual([rootId, "n-1"].toSorted());
   });
 
   it("only returns nodes for the requested board", async () => {
@@ -111,7 +115,9 @@ describe("loadNodesForBoard / saveNodesForBoard", () => {
 describe("renameBoard", () => {
   it("updates name and updatedAt", async () => {
     const { board } = await createBoard("Old");
-    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 5);
+    });
     const before = (await db.boards.get(board.id))!.updatedAt;
     await renameBoard(board.id, "New");
     const after = await db.boards.get(board.id);

--- a/packages/mintodo/src/storage.test.ts
+++ b/packages/mintodo/src/storage.test.ts
@@ -16,7 +16,7 @@ import {
   saveNodesForBoard,
   setCurrentBoardId,
 } from "./storage";
-import type { Board, MindNode, SaveData } from "./types";
+import type { MindNode, SaveData } from "./types";
 
 function makeNode(id: string, boardId: string, opts: Partial<MindNode> = {}): MindNode {
   return {
@@ -69,9 +69,9 @@ describe("createBoard", () => {
 describe("loadBoards", () => {
   it("returns boards sorted by updatedAt desc", async () => {
     const a = await createBoard("A");
-    await new Promise((r) => setTimeout(r, 5));
+    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
     const b = await createBoard("B");
-    await new Promise((r) => setTimeout(r, 5));
+    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
     const c = await createBoard("C");
     const list = await loadBoards();
     expect(list.map((x) => x.id)).toEqual([c.board.id, b.board.id, a.board.id]);
@@ -111,7 +111,7 @@ describe("loadNodesForBoard / saveNodesForBoard", () => {
 describe("renameBoard", () => {
   it("updates name and updatedAt", async () => {
     const { board } = await createBoard("Old");
-    await new Promise((r) => setTimeout(r, 5));
+    await new Promise<void>((resolve) => { setTimeout(() => resolve(), 5); });
     const before = (await db.boards.get(board.id))!.updatedAt;
     await renameBoard(board.id, "New");
     const after = await db.boards.get(board.id);

--- a/packages/mintodo/src/storage.test.ts
+++ b/packages/mintodo/src/storage.test.ts
@@ -56,10 +56,10 @@ describe("createBoard", () => {
     const { board, rootId } = await createBoard("My Project");
     expect(board.name).toBe("My Project");
     expect(board.id).toMatch(/^[0-9a-f-]{36}$/u);
-    expect(rootId).toMatch(/^root-/u);
+    expect(rootId).toBe("root");
     const stored = await db.boards.get(board.id);
     expect(stored).toBeDefined();
-    const root = await db.nodes.get(rootId);
+    const root = await db.nodes.get([board.id, rootId]);
     expect(root).toBeDefined();
     expect(root?.boardId).toBe(board.id);
     expect(root?.isRoot).toBe(true);
@@ -98,13 +98,13 @@ describe("loadNodesForBoard / saveNodesForBoard", () => {
     const p1 = await createBoard("P1");
     const p2 = await createBoard("P2");
     await saveNodesForBoard(p1.board.id, {
-      r1: makeNode("r1", p1.board.id, { isRoot: true, text: "p1-root" }),
+      root: makeNode("root", p1.board.id, { isRoot: true, text: "p1-root" }),
     });
     await saveNodesForBoard(p2.board.id, {
-      r2: makeNode("r2", p2.board.id, { isRoot: true, text: "p2-root" }),
+      root: makeNode("root", p2.board.id, { isRoot: true, text: "p2-root" }),
     });
     const p1Nodes = await loadNodesForBoard(p1.board.id);
-    expect(p1Nodes.r1.text).toBe("p1-root");
+    expect(p1Nodes.root.text).toBe("p1-root");
   });
 });
 

--- a/packages/mintodo/src/storage.test.ts
+++ b/packages/mintodo/src/storage.test.ts
@@ -2,68 +2,209 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { db } from "./db";
-import { downloadJson, loadFromDexie, parseImportedJson, saveToDexie } from "./storage";
-import { createInitialNodes } from "./store";
-import type { SaveData } from "./types";
+import {
+  createBoard,
+  deleteBoard,
+  discardV1Data,
+  downloadJson,
+  getCurrentBoardId,
+  hasV1Data,
+  loadBoards,
+  loadNodesForBoard,
+  parseImportedJson,
+  renameBoard,
+  saveNodesForBoard,
+  setCurrentBoardId,
+} from "./storage";
+import type { Board, MindNode, SaveData } from "./types";
+
+function makeNode(id: string, boardId: string, opts: Partial<MindNode> = {}): MindNode {
+  return {
+    id,
+    boardId,
+    text: opts.text ?? "node",
+    parentId: opts.parentId ?? null,
+    isRoot: opts.isRoot ?? false,
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    children: [],
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    ...opts,
+  };
+}
 
 beforeEach(async () => {
+  await db.boards.clear();
   await db.nodes.clear();
   await db.meta.clear();
 });
 
 afterEach(async () => {
+  await db.boards.clear();
   await db.nodes.clear();
   await db.meta.clear();
 });
 
-describe("saveToDexie / loadFromDexie", () => {
-  it("round-trips nodes", async () => {
-    const nodes = createInitialNodes();
-    await saveToDexie(nodes);
-    const loaded = await loadFromDexie();
-    expect(loaded).not.toBeNull();
-    expect(loaded!["root"].id).toBe("root");
-    expect(Object.keys(loaded!).length).toBe(Object.keys(nodes).length);
+describe("createBoard", () => {
+  it("adds a board and a root node", async () => {
+    const { board, rootId } = await createBoard("My Project");
+    expect(board.name).toBe("My Project");
+    expect(board.id).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(rootId).toMatch(/^root-/u);
+    const stored = await db.boards.get(board.id);
+    expect(stored).toBeDefined();
+    const root = await db.nodes.get(rootId);
+    expect(root).toBeDefined();
+    expect(root?.boardId).toBe(board.id);
+    expect(root?.isRoot).toBe(true);
+  });
+});
+
+describe("loadBoards", () => {
+  it("returns boards sorted by updatedAt desc", async () => {
+    const a = await createBoard("A");
+    await new Promise((r) => setTimeout(r, 5));
+    const b = await createBoard("B");
+    await new Promise((r) => setTimeout(r, 5));
+    const c = await createBoard("C");
+    const list = await loadBoards();
+    expect(list.map((x) => x.id)).toEqual([c.board.id, b.board.id, a.board.id]);
   });
 
-  it("returns null when empty", async () => {
-    const loaded = await loadFromDexie();
-    expect(loaded).toBeNull();
+  it("returns empty array when no boards", async () => {
+    expect(await loadBoards()).toEqual([]);
+  });
+});
+
+describe("loadNodesForBoard / saveNodesForBoard", () => {
+  it("round-trips nodes for a specific board", async () => {
+    const { board, rootId } = await createBoard("P1");
+    const nodes: Record<string, MindNode> = {
+      [rootId]: makeNode(rootId, board.id, { isRoot: true, text: "root" }),
+      "n-1": makeNode("n-1", board.id, { parentId: rootId, text: "child" }),
+    };
+    await saveNodesForBoard(board.id, nodes);
+    const loaded = await loadNodesForBoard(board.id);
+    expect(Object.keys(loaded).sort()).toEqual([rootId, "n-1"].sort());
   });
 
-  it("zeros vx, vy on load", async () => {
-    const nodes = createInitialNodes();
-    nodes["root"].vx = 5;
-    nodes["root"].vy = -3;
-    await saveToDexie(nodes);
-    const loaded = await loadFromDexie();
-    expect(loaded!["root"].vx).toBe(0);
-    expect(loaded!["root"].vy).toBe(0);
+  it("only returns nodes for the requested board", async () => {
+    const p1 = await createBoard("P1");
+    const p2 = await createBoard("P2");
+    await saveNodesForBoard(p1.board.id, {
+      r1: makeNode("r1", p1.board.id, { isRoot: true, text: "p1-root" }),
+    });
+    await saveNodesForBoard(p2.board.id, {
+      r2: makeNode("r2", p2.board.id, { isRoot: true, text: "p2-root" }),
+    });
+    const p1Nodes = await loadNodesForBoard(p1.board.id);
+    expect(p1Nodes.r1.text).toBe("p1-root");
+  });
+});
+
+describe("renameBoard", () => {
+  it("updates name and updatedAt", async () => {
+    const { board } = await createBoard("Old");
+    await new Promise((r) => setTimeout(r, 5));
+    const before = (await db.boards.get(board.id))!.updatedAt;
+    await renameBoard(board.id, "New");
+    const after = await db.boards.get(board.id);
+    expect(after?.name).toBe("New");
+    expect(after!.updatedAt).toBeGreaterThan(before);
+  });
+});
+
+describe("deleteBoard", () => {
+  it("removes the board and all its nodes", async () => {
+    const { board, rootId } = await createBoard("Doomed");
+    await saveNodesForBoard(board.id, {
+      [rootId]: makeNode(rootId, board.id, { isRoot: true }),
+      "n-1": makeNode("n-1", board.id, { parentId: rootId }),
+    });
+    await deleteBoard(board.id);
+    expect(await db.boards.get(board.id)).toBeUndefined();
+    expect(await db.nodes.where("boardId").equals(board.id).count()).toBe(0);
+  });
+});
+
+describe("currentBoardId", () => {
+  it("getCurrentBoardId returns null by default", async () => {
+    expect(await getCurrentBoardId()).toBeNull();
+  });
+
+  it("setCurrentBoardId then getCurrentBoardId", async () => {
+    await setCurrentBoardId("abc");
+    expect(await getCurrentBoardId()).toBe("abc");
+  });
+
+  it("setCurrentBoardId(null) clears", async () => {
+    await setCurrentBoardId("abc");
+    await setCurrentBoardId(null);
+    expect(await getCurrentBoardId()).toBeNull();
+  });
+});
+
+describe("migration", () => {
+  it("hasV1Data is true when nodes exist but no boards", async () => {
+    await db.nodes.add(makeNode("orphan", "unknown", { isRoot: true }));
+    expect(await hasV1Data()).toBe(true);
+  });
+
+  it("hasV1Data is false when boards exist", async () => {
+    const { board } = await createBoard("X");
+    await db.nodes.add(makeNode("n", board.id));
+    expect(await hasV1Data()).toBe(false);
+  });
+
+  it("hasV1Data is false when no nodes", async () => {
+    expect(await hasV1Data()).toBe(false);
+  });
+
+  it("discardV1Data removes all nodes", async () => {
+    await db.nodes.add(makeNode("orphan", "unknown"));
+    await discardV1Data();
+    expect(await db.nodes.count()).toBe(0);
   });
 });
 
 describe("JSON import / export", () => {
   it("downloadJson produces a Blob URL", () => {
-    const data: SaveData = { version: 1, nodes: [] };
+    const data: SaveData = {
+      version: 2,
+      board: { id: "b", name: "B" },
+      nodes: [],
+    };
     const url = downloadJson(data, "test.json");
     expect(url).toMatch(/^blob:/u);
     URL.revokeObjectURL(url);
   });
 
-  it("parseImportedJson reads valid data", () => {
+  it("parseImportedJson reads valid v2 data", () => {
     const data: SaveData = {
-      version: 1,
-      nodes: [{ ...createInitialNodes().root, vx: 0, vy: 0 }],
+      version: 2,
+      board: { id: "b", name: "B" },
+      nodes: [makeNode("root", "b", { isRoot: true })],
     };
     const json = JSON.stringify(data);
     const parsed = parseImportedJson(json);
     expect(parsed).not.toBeNull();
+    expect(parsed!.version).toBe(2);
     expect(parsed!.nodes.length).toBe(1);
   });
 
   it("parseImportedJson returns null on invalid data", () => {
     expect(parseImportedJson("not json")).toBeNull();
     expect(parseImportedJson("{}")).toBeNull();
-    expect(parseImportedJson(JSON.stringify({ version: 2, nodes: [] }))).toBeNull();
+    expect(parseImportedJson(JSON.stringify({ version: 1, nodes: [] }))).toBeNull();
+    expect(parseImportedJson(JSON.stringify({ version: 2 }))).toBeNull();
+    expect(
+      parseImportedJson(JSON.stringify({ version: 2, board: { id: "b" }, nodes: "bad" })),
+    ).toBeNull();
   });
 });

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -1,5 +1,5 @@
 import { db } from "./db";
-import type { MindNode, SaveData } from "./types";
+import type { Board, MindNode, SaveData } from "./types";
 
 function arrayToRecord(arr: MindNode[]): Record<string, MindNode> {
   const rec: Record<string, MindNode> = {};
@@ -9,15 +9,63 @@ function arrayToRecord(arr: MindNode[]): Record<string, MindNode> {
   return rec;
 }
 
-export async function loadFromDexie(): Promise<Record<string, MindNode> | null> {
-  const all = await db.nodes.toArray();
-  if (all.length === 0) return null;
+export async function loadBoards(): Promise<Board[]> {
+  return await db.boards.orderBy("updatedAt").reverse().toArray();
+}
+
+export async function loadNodesForBoard(boardId: string): Promise<Record<string, MindNode>> {
+  const all = await db.nodes.where("boardId").equals(boardId).toArray();
   return arrayToRecord(all);
 }
 
-export async function saveToDexie(nodes: Record<string, MindNode>): Promise<void> {
-  await db.nodes.clear();
-  await db.nodes.bulkPut(Object.values(nodes));
+export async function saveNodesForBoard(
+  boardId: string,
+  nodes: Record<string, MindNode>,
+): Promise<void> {
+  await db.transaction("rw", db.nodes, async () => {
+    await db.nodes.where("boardId").equals(boardId).delete();
+    await db.nodes.bulkPut(Object.values(nodes));
+  });
+}
+
+export async function createBoard(name: string): Promise<{ board: Board; rootId: string }> {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const board: Board = { id, name, createdAt: now, updatedAt: now };
+  const rootId = `root-${id}`;
+  const root: MindNode = {
+    id: rootId,
+    boardId: id,
+    text: name,
+    parentId: null,
+    isRoot: true,
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    children: [],
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+  };
+  await db.transaction("rw", db.boards, db.nodes, async () => {
+    await db.boards.add(board);
+    await db.nodes.add(root);
+  });
+  return { board, rootId };
+}
+
+export async function renameBoard(id: string, name: string): Promise<void> {
+  await db.boards.update(id, { name, updatedAt: Date.now() });
+}
+
+export async function deleteBoard(id: string): Promise<void> {
+  await db.transaction("rw", db.boards, db.nodes, async () => {
+    await db.nodes.where("boardId").equals(id).delete();
+    await db.boards.delete(id);
+  });
 }
 
 export async function getMeta<T>(key: string): Promise<T | undefined> {
@@ -27,6 +75,31 @@ export async function getMeta<T>(key: string): Promise<T | undefined> {
 
 export async function setMeta(key: string, value: unknown): Promise<void> {
   await db.meta.put({ key, value });
+}
+
+export async function getCurrentBoardId(): Promise<string | null> {
+  const entry = await db.meta.get("currentBoardId");
+  return (entry?.value as string | undefined) ?? null;
+}
+
+export async function setCurrentBoardId(id: string | null): Promise<void> {
+  if (id === null) {
+    await db.meta.delete("currentBoardId");
+  } else {
+    await db.meta.put({ key: "currentBoardId", value: id });
+  }
+}
+
+export async function hasV1Data(): Promise<boolean> {
+  const nodeCount = await db.nodes.count();
+  const boardCount = await db.boards.count();
+  return nodeCount > 0 && boardCount === 0;
+}
+
+export async function discardV1Data(): Promise<void> {
+  await db.transaction("rw", db.nodes, async () => {
+    await db.nodes.clear();
+  });
 }
 
 export function downloadJson(data: SaveData, filename: string): string {
@@ -47,10 +120,18 @@ export function parseImportedJson(text: string): SaveData | null {
     const obj: unknown = JSON.parse(text);
     if (typeof obj !== "object" || obj === null) return null;
     const data = obj as Partial<SaveData>;
-    if (data.version !== 1) return null;
+    if (data.version !== 2) return null;
+    if (typeof data.board !== "object" || data.board === null) return null;
+    if (typeof data.board.id !== "string" || typeof data.board.name !== "string") return null;
     if (!Array.isArray(data.nodes)) return null;
-    const nodes: MindNode[] = data.nodes.map((n) => Object.assign({}, n, { vx: 0, vy: 0 }));
-    return { version: 1, nodes };
+    const nodes: MindNode[] = data.nodes.map((n) =>
+      Object.assign({}, n, { vx: 0, vy: 0 }),
+    );
+    return {
+      version: 2,
+      board: { id: data.board.id, name: data.board.name },
+      nodes,
+    };
   } catch {
     return null;
   }

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -83,11 +83,9 @@ export async function getCurrentBoardId(): Promise<string | null> {
 }
 
 export async function setCurrentBoardId(id: string | null): Promise<void> {
-  if (id === null) {
-    await db.meta.delete("currentBoardId");
-  } else {
-    await db.meta.put({ key: "currentBoardId", value: id });
-  }
+  await (id === null
+    ? db.meta.delete("currentBoardId")
+    : db.meta.put({ key: "currentBoardId", value: id }));
 }
 
 export async function hasV1Data(): Promise<boolean> {

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -10,7 +10,7 @@ function arrayToRecord(arr: MindNode[]): Record<string, MindNode> {
 }
 
 export async function loadBoards(): Promise<Board[]> {
-  return await db.boards.orderBy("updatedAt").toReversed().toArray();
+  return await db.boards.orderBy("updatedAt").reverse().toArray();
 }
 
 export async function loadNodesForBoard(boardId: string): Promise<Record<string, MindNode>> {

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -10,7 +10,7 @@ function arrayToRecord(arr: MindNode[]): Record<string, MindNode> {
 }
 
 export async function loadBoards(): Promise<Board[]> {
-  return await db.boards.orderBy("updatedAt").reverse().toArray();
+  return await db.boards.orderBy("updatedAt").toReversed().toArray();
 }
 
 export async function loadNodesForBoard(boardId: string): Promise<Record<string, MindNode>> {
@@ -122,9 +122,7 @@ export function parseImportedJson(text: string): SaveData | null {
     if (typeof data.board !== "object" || data.board === null) return null;
     if (typeof data.board.id !== "string" || typeof data.board.name !== "string") return null;
     if (!Array.isArray(data.nodes)) return null;
-    const nodes: MindNode[] = data.nodes.map((n) =>
-      Object.assign({}, n, { vx: 0, vy: 0 }),
-    );
+    const nodes: MindNode[] = data.nodes.map((n) => Object.assign({}, n, { vx: 0, vy: 0 }));
     return {
       version: 2,
       board: { id: data.board.id, name: data.board.name },

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -32,9 +32,9 @@ export async function createBoard(name: string): Promise<{ board: Board; rootId:
   const id = crypto.randomUUID();
   const now = Date.now();
   const board: Board = { id, name, createdAt: now, updatedAt: now };
-  const rootId = `root-${id}`;
+  const rootId = "root";
   const root: MindNode = {
-    id: rootId,
+    id: "root",
     boardId: id,
     text: name,
     parentId: null,

--- a/packages/mintodo/src/storage.ts
+++ b/packages/mintodo/src/storage.ts
@@ -10,7 +10,8 @@ function arrayToRecord(arr: MindNode[]): Record<string, MindNode> {
 }
 
 export async function loadBoards(): Promise<Board[]> {
-  return await db.boards.orderBy("updatedAt").reverse().toArray();
+  const boards = await db.boards.orderBy("updatedAt").toArray();
+  return boards.toReversed();
 }
 
 export async function loadNodesForBoard(boardId: string): Promise<Record<string, MindNode>> {

--- a/packages/mintodo/src/store.test.ts
+++ b/packages/mintodo/src/store.test.ts
@@ -1,66 +1,166 @@
 import { describe, expect, it } from "vitest";
-import { createInitialNodes, createInitialState, reducer } from "./store";
+import { createInitialState, reducer } from "./store";
+import type { Board, MindNode } from "./types";
 
-describe("createInitialNodes", () => {
-  it("includes root node", () => {
-    const nodes = createInitialNodes();
-    expect(nodes.root).toBeDefined();
-    expect(nodes.root.isRoot).toBe(true);
-    expect(nodes.root.parentId).toBeNull();
-    expect(nodes.root.children.length).toBeGreaterThan(0);
-  });
+function makeNode(id: string, boardId: string, opts: Partial<MindNode> = {}): MindNode {
+  return {
+    id,
+    boardId,
+    text: opts.text ?? "node",
+    parentId: opts.parentId ?? null,
+    isRoot: opts.isRoot ?? false,
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    children: [],
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    ...opts,
+  };
+}
 
-  it("all non-root nodes have valid parentId", () => {
-    const nodes = createInitialNodes();
-    for (const [, node] of Object.entries(nodes)) {
-      if (node.isRoot) continue;
-      expect(node.parentId).toBeTruthy();
-      expect(nodes[node.parentId!]).toBeDefined();
-    }
-  });
+const boardA: Board = { id: "b-a", name: "A", createdAt: 1, updatedAt: 1 };
+const boardB: Board = { id: "b-b", name: "B", createdAt: 2, updatedAt: 2 };
 
-  it("all children references are valid", () => {
-    const nodes = createInitialNodes();
-    for (const node of Object.values(nodes)) {
-      for (const childId of node.children) {
-        expect(nodes[childId]).toBeDefined();
-      }
-    }
-  });
-
-  it("root children are valid", () => {
-    const nodes = createInitialNodes();
-    for (const childId of nodes.root.children) {
-      expect(nodes[childId].parentId).toBe("root");
-    }
+describe("createInitialState", () => {
+  it("starts with no boards, no current board, no nodes", () => {
+    const s = createInitialState();
+    expect(s.boards).toEqual([]);
+    expect(s.currentBoardId).toBeNull();
+    expect(s.nodes).toEqual({});
   });
 });
 
-describe("reducer - initial state", () => {
-  it("creates initial state with default values", () => {
-    const state = createInitialState();
-    expect(state.selectedNodeId).toBe("root");
-    expect(state.physicsEnabled).toBe(true);
-    expect(state.hideCompleted).toBe(false);
-    expect(state.searchQuery).toBe("");
-    expect(state.draggingNodeId).toBeNull();
-    expect(state.modal).toBeNull();
-    expect(state.view.zoom).toBe(1);
+describe("reducer - SET_BOARDS", () => {
+  it("replaces boards list", () => {
+    const s = createInitialState();
+    const next = reducer(s, { boards: [boardA, boardB], type: "SET_BOARDS" });
+    expect(next.boards).toEqual([boardA, boardB]);
+  });
+});
+
+describe("reducer - SET_CURRENT_BOARD", () => {
+  it("sets currentBoardId", () => {
+    const s = createInitialState();
+    const next = reducer(s, { boardId: "b-a", type: "SET_CURRENT_BOARD" });
+    expect(next.currentBoardId).toBe("b-a");
+  });
+
+  it("can be set to null", () => {
+    const s = { ...createInitialState(), currentBoardId: "b-a" };
+    const next = reducer(s, { boardId: null, type: "SET_CURRENT_BOARD" });
+    expect(next.currentBoardId).toBeNull();
+  });
+});
+
+describe("reducer - ADD_BOARD", () => {
+  it("adds a board and its initial nodes; sets currentBoardId", () => {
+    const s = createInitialState();
+    const next = reducer(s, {
+      board: boardA,
+      initialNodes: { root: makeNode("root", boardA.id, { isRoot: true }) },
+      type: "ADD_BOARD",
+    });
+    expect(next.boards).toEqual([boardA]);
+    expect(next.currentBoardId).toBe("b-a");
+    expect(next.nodes.root).toBeDefined();
+    expect(next.nodes.root.boardId).toBe("b-a");
+  });
+
+  it("appends to existing boards list", () => {
+    const s = { ...createInitialState(), boards: [boardA], currentBoardId: "b-a" };
+    const next = reducer(s, {
+      board: boardB,
+      initialNodes: { root: makeNode("root", boardB.id, { isRoot: true }) },
+      type: "ADD_BOARD",
+    });
+    expect(next.boards).toEqual([boardA, boardB]);
+  });
+});
+
+describe("reducer - RENAME_BOARD", () => {
+  it("updates name and updatedAt", () => {
+    const s = { ...createInitialState(), boards: [boardA] };
+    const next = reducer(s, { id: "b-a", name: "Renamed", type: "RENAME_BOARD" });
+    expect(next.boards[0].name).toBe("Renamed");
+    expect(next.boards[0].updatedAt).toBeGreaterThanOrEqual(boardA.updatedAt);
+  });
+});
+
+describe("reducer - DELETE_BOARD", () => {
+  it("removes board and its nodes; switches to nextBoardId", () => {
+    const s = {
+      ...createInitialState(),
+      boards: [boardA, boardB],
+      currentBoardId: "b-a",
+      nodes: {
+        "root-a": makeNode("root-a", "b-a", { isRoot: true }),
+        "root-b": makeNode("root-b", "b-b", { isRoot: true }),
+      },
+    };
+    const next = reducer(s, { id: "b-a", nextBoardId: "b-b", type: "DELETE_BOARD" });
+    expect(next.boards).toEqual([boardB]);
+    expect(next.currentBoardId).toBe("b-b");
+    expect(next.nodes["root-a"]).toBeUndefined();
+    expect(next.nodes["root-b"]).toBeDefined();
+  });
+
+  it("sets currentBoardId to null when no nextBoardId", () => {
+    const s = {
+      ...createInitialState(),
+      boards: [boardA],
+      currentBoardId: "b-a",
+      nodes: { root: makeNode("root", "b-a", { isRoot: true }) },
+    };
+    const next = reducer(s, { id: "b-a", nextBoardId: null, type: "DELETE_BOARD" });
+    expect(next.boards).toEqual([]);
+    expect(next.currentBoardId).toBeNull();
+    expect(next.nodes).toEqual({});
+  });
+});
+
+describe("reducer - RESET", () => {
+  it("keeps only root node for current board", () => {
+    const s = {
+      ...createInitialState(),
+      boards: [boardA],
+      currentBoardId: "b-a",
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, text: "My Board" }),
+        "n-1": makeNode("n-1", "b-a", { parentId: "root", text: "child" }),
+        "n-2": makeNode("n-2", "b-a", { parentId: "n-1", text: "grandchild" }),
+      },
+    };
+    const next = reducer(s, { type: "RESET" });
+    expect(Object.keys(next.nodes)).toEqual(["root"]);
+    expect(next.nodes.root.boardId).toBe("b-a");
+    expect(next.nodes.root.parentId).toBeNull();
+    expect(next.nodes.root.children).toEqual([]);
+  });
+
+  it("preserves physicsEnabled", () => {
+    const s = { ...createInitialState(), physicsEnabled: false };
+    const next = reducer(s, { type: "RESET" });
+    expect(next.physicsEnabled).toBe(false);
   });
 });
 
 describe("reducer - SELECT", () => {
   it("updates selectedNodeId", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "SELECT" });
-    expect(next.selectedNodeId).toBe("node-1");
+    const s = createInitialState();
+    const next = reducer(s, { id: "n-1", type: "SELECT" });
+    expect(next.selectedNodeId).toBe("n-1");
   });
 });
 
 describe("reducer - SET_VIEW", () => {
   it("updates view", () => {
-    const state = createInitialState();
-    const next = reducer(state, {
+    const s = createInitialState();
+    const next = reducer(s, {
       type: "SET_VIEW",
       view: { pan: { x: 100, y: 50 }, zoom: 1.5 },
     });
@@ -70,16 +170,16 @@ describe("reducer - SET_VIEW", () => {
 
 describe("reducer - SET_SEARCH", () => {
   it("updates searchQuery", () => {
-    const state = createInitialState();
-    const next = reducer(state, { query: "hoge", type: "SET_SEARCH" });
+    const s = createInitialState();
+    const next = reducer(s, { query: "hoge", type: "SET_SEARCH" });
     expect(next.searchQuery).toBe("hoge");
   });
 });
 
 describe("reducer - TOGGLE_HIDE_COMPLETED", () => {
   it("toggles hideCompleted", () => {
-    const state = createInitialState();
-    const next = reducer(state, { type: "TOGGLE_HIDE_COMPLETED" });
+    const s = createInitialState();
+    const next = reducer(s, { type: "TOGGLE_HIDE_COMPLETED" });
     expect(next.hideCompleted).toBe(true);
     const next2 = reducer(next, { type: "TOGGLE_HIDE_COMPLETED" });
     expect(next2.hideCompleted).toBe(false);
@@ -88,134 +188,142 @@ describe("reducer - TOGGLE_HIDE_COMPLETED", () => {
 
 describe("reducer - TOGGLE_PHYSICS", () => {
   it("toggles physicsEnabled", () => {
-    const state = createInitialState();
-    const next = reducer(state, { type: "TOGGLE_PHYSICS" });
+    const s = createInitialState();
+    const next = reducer(s, { type: "TOGGLE_PHYSICS" });
     expect(next.physicsEnabled).toBe(false);
   });
 });
 
 describe("reducer - OPEN_MODAL", () => {
   it("opens edit modal", () => {
-    const state = createInitialState();
-    const next = reducer(state, {
-      modal: { kind: "edit", nodeId: "node-1" },
+    const s = createInitialState();
+    const next = reducer(s, {
+      modal: { kind: "edit", nodeId: "n-1" },
       type: "OPEN_MODAL",
     });
-    expect(next.modal).toEqual({ kind: "edit", nodeId: "node-1" });
+    expect(next.modal).toEqual({ kind: "edit", nodeId: "n-1" });
   });
 
-  it("opens help modal", () => {
-    const state = createInitialState();
-    const next = reducer(state, { modal: { kind: "help" }, type: "OPEN_MODAL" });
-    expect(next.modal).toEqual({ kind: "help" });
+  it("opens board-name modal for create", () => {
+    const s = createInitialState();
+    const next = reducer(s, {
+      modal: { kind: "board-name", mode: "create" },
+      type: "OPEN_MODAL",
+    });
+    expect(next.modal).toEqual({ kind: "board-name", mode: "create" });
+  });
+
+  it("opens board-delete modal", () => {
+    const s = createInitialState();
+    const next = reducer(s, {
+      modal: { kind: "board-delete", boardId: "b-a", boardName: "A" },
+      type: "OPEN_MODAL",
+    });
+    expect(next.modal).toEqual({ kind: "board-delete", boardId: "b-a", boardName: "A" });
   });
 
   it("closes modal when null", () => {
-    const state = createInitialState();
-    const next = reducer(state, { modal: null, type: "OPEN_MODAL" });
+    const s = createInitialState();
+    const next = reducer(s, { modal: null, type: "OPEN_MODAL" });
     expect(next.modal).toBeNull();
   });
 });
 
 describe("reducer - ADD_CHILD", () => {
   it("creates new child and selects it", () => {
-    const state = createInitialState();
-    const next = reducer(state, {
-      newId: "node-new-1",
-      parentId: "node-1",
+    const s = {
+      ...createInitialState(),
+      boards: [boardA],
+      currentBoardId: "b-a",
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, children: [] }) },
+    };
+    const next = reducer(s, {
+      newId: "n-new",
+      parentId: "root",
       type: "ADD_CHILD",
     });
-    expect(next.selectedNodeId).toBe("node-new-1");
-    expect(next.nodes["node-new-1"].parentId).toBe("node-1");
-    expect(next.nodes["node-new-1"].isRoot).toBe(false);
-    expect(next.nodes["node-1"].children).toContain("node-new-1");
-    expect(next.nodes["node-1"].collapsed).toBe(false);
-  });
-
-  it("inherits categoryColor from parent", () => {
-    const state = createInitialState();
-    const next = reducer(state, {
-      newId: "node-new-1",
-      parentId: "node-1",
-      type: "ADD_CHILD",
-    });
-    expect(next.nodes["node-new-1"].categoryColor).toBe("sky");
+    expect(next.selectedNodeId).toBe("n-new");
+    expect(next.nodes["n-new"].parentId).toBe("root");
+    expect(next.nodes["n-new"].boardId).toBe("b-a");
+    expect(next.nodes["n-new"].isRoot).toBe(false);
+    expect(next.nodes.root.children).toContain("n-new");
   });
 });
 
 describe("reducer - UPDATE_NODE", () => {
   it("patches node fields", () => {
-    const state = createInitialState();
-    const next = reducer(state, {
-      id: "node-1",
-      patch: { text: "updated", priority: "low" },
-      type: "UPDATE_NODE",
-    });
-    expect(next.nodes["node-1"].text).toBe("updated");
-    expect(next.nodes["node-1"].priority).toBe("low");
-    expect(next.nodes["node-1"].categoryColor).toBe("sky");
+    const s = {
+      ...createInitialState(),
+      nodes: { n: makeNode("n", "b-a", { text: "old", priority: "low" }) },
+    };
+    const next = reducer(s, { id: "n", patch: { text: "new" }, type: "UPDATE_NODE" });
+    expect(next.nodes.n.text).toBe("new");
+    expect(next.nodes.n.priority).toBe("low");
   });
 });
 
 describe("reducer - TOGGLE_COMPLETE", () => {
   it("flips completed flag", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "TOGGLE_COMPLETE" });
-    expect(next.nodes["node-1"].completed).toBe(true);
+    const s = {
+      ...createInitialState(),
+      nodes: { n: makeNode("n", "b-a") },
+    };
+    const next = reducer(s, { id: "n", type: "TOGGLE_COMPLETE" });
+    expect(next.nodes.n.completed).toBe(true);
   });
 
   it("cascades to descendants", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "TOGGLE_COMPLETE" });
-    expect(next.nodes["node-1-1"].completed).toBe(true);
-    expect(next.nodes["node-1-2"].completed).toBe(true);
-  });
-
-  it("cascades when un-completing", () => {
-    const state = createInitialState();
-    const completed = reducer(state, { id: "node-1", type: "TOGGLE_COMPLETE" });
-    const uncompleted = reducer(completed, { id: "node-1", type: "TOGGLE_COMPLETE" });
-    expect(uncompleted.nodes["node-1-1"].completed).toBe(false);
+    const s = {
+      ...createInitialState(),
+      nodes: {
+        a: makeNode("a", "b-a", { children: ["b"] }),
+        b: makeNode("b", "b-a", { parentId: "a", children: ["c"] }),
+        c: makeNode("c", "b-a", { parentId: "b" }),
+      },
+    };
+    const next = reducer(s, { id: "a", type: "TOGGLE_COMPLETE" });
+    expect(next.nodes.a.completed).toBe(true);
+    expect(next.nodes.b.completed).toBe(true);
+    expect(next.nodes.c.completed).toBe(true);
   });
 });
 
 describe("reducer - TOGGLE_COLLAPSE", () => {
   it("flips collapsed flag", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "TOGGLE_COLLAPSE" });
-    expect(next.nodes["node-1"].collapsed).toBe(true);
+    const s = {
+      ...createInitialState(),
+      nodes: { n: makeNode("n", "b-a") },
+    };
+    const next = reducer(s, { id: "n", type: "TOGGLE_COLLAPSE" });
+    expect(next.nodes.n.collapsed).toBe(true);
   });
 });
 
 describe("reducer - DELETE_NODE", () => {
-  it("removes node from parent children", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1-1", type: "DELETE_NODE" });
-    expect(next.nodes["node-1-1"]).toBeUndefined();
-    expect(next.nodes["node-1"].children).not.toContain("node-1-1");
-  });
-
-  it("removes node and all descendants", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "DELETE_NODE" });
-    expect(next.nodes["node-1"]).toBeUndefined();
-    expect(next.nodes["node-1-1"]).toBeUndefined();
-    expect(next.nodes["node-1-2"]).toBeUndefined();
-    expect(next.nodes["root"].children).not.toContain("node-1");
-  });
-
-  it("selects parent when deleting selected node", () => {
-    const state = { ...createInitialState(), selectedNodeId: "node-1-1" };
-    const next = reducer(state, { id: "node-1-1", type: "DELETE_NODE" });
-    expect(next.selectedNodeId).toBe("node-1");
+  it("removes node and descendants; updates parent children", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, children: ["a"] }),
+        a: makeNode("a", "b-a", { parentId: "root", children: ["b"] }),
+        b: makeNode("b", "b-a", { parentId: "a" }),
+      },
+    };
+    const next = reducer(s, { id: "a", type: "DELETE_NODE" });
+    expect(next.nodes.a).toBeUndefined();
+    expect(next.nodes.b).toBeUndefined();
+    expect(next.nodes.root.children).not.toContain("a");
   });
 });
 
 describe("reducer - MOVE_NODE", () => {
   it("updates x and y", () => {
-    const state = createInitialState();
-    const next = reducer(state, { id: "node-1", type: "MOVE_NODE", x: 999, y: 888 });
-    expect(next.nodes["node-1"].x).toBe(999);
-    expect(next.nodes["node-1"].y).toBe(888);
+    const s = {
+      ...createInitialState(),
+      nodes: { n: makeNode("n", "b-a", { x: 0, y: 0 }) },
+    };
+    const next = reducer(s, { id: "n", type: "MOVE_NODE", x: 999, y: 888 });
+    expect(next.nodes.n.x).toBe(999);
+    expect(next.nodes.n.y).toBe(888);
   });
 });

--- a/packages/mintodo/src/store.ts
+++ b/packages/mintodo/src/store.ts
@@ -73,9 +73,7 @@ export function reducer(state: State, action: Action): State {
       return {
         ...state,
         boards: state.boards.map((b) =>
-          b.id === action.id
-            ? { ...b, name: action.name, updatedAt: Date.now() }
-            : b,
+          b.id === action.id ? { ...b, name: action.name, updatedAt: Date.now() } : b,
         ),
       };
     }

--- a/packages/mintodo/src/store.ts
+++ b/packages/mintodo/src/store.ts
@@ -1,6 +1,8 @@
-import type { MindNode, Modal, View } from "./types";
+import type { Board, MindNode, Modal, View } from "./types";
 
 export interface State {
+  boards: Board[];
+  currentBoardId: string | null;
   draggingNodeId: string | null;
   hideCompleted: boolean;
   modal: Modal;
@@ -12,12 +14,17 @@ export interface State {
 }
 
 export type Action =
+  | { type: "ADD_BOARD"; board: Board; initialNodes: Record<string, MindNode> }
   | { type: "ADD_CHILD"; newId: string; parentId: string }
+  | { type: "DELETE_BOARD"; id: string; nextBoardId: string | null }
   | { type: "DELETE_NODE"; id: string }
   | { type: "MOVE_NODE"; id: string; x: number; y: number }
   | { type: "OPEN_MODAL"; modal: Modal }
+  | { type: "RENAME_BOARD"; id: string; name: string }
   | { type: "RESET" }
   | { type: "SELECT"; id: string }
+  | { type: "SET_BOARDS"; boards: Board[] }
+  | { type: "SET_CURRENT_BOARD"; boardId: string | null }
   | { type: "SET_DRAGGING"; id: string | null }
   | { type: "SET_NODES"; nodes: Record<string, MindNode> }
   | { type: "SET_SEARCH"; query: string }
@@ -30,19 +37,94 @@ export type Action =
 
 export function createInitialState(): State {
   return {
+    boards: [],
+    currentBoardId: null,
     draggingNodeId: null,
     hideCompleted: false,
     modal: null,
-    nodes: createInitialNodes(),
+    nodes: {},
     physicsEnabled: true,
     searchQuery: "",
-    selectedNodeId: "root",
+    selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
   };
 }
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
+    case "SET_BOARDS": {
+      return { ...state, boards: action.boards };
+    }
+    case "SET_CURRENT_BOARD": {
+      return { ...state, currentBoardId: action.boardId };
+    }
+    case "ADD_BOARD": {
+      const existing = state.boards.find((b) => b.id === action.board.id);
+      if (existing) return state;
+      return {
+        ...state,
+        boards: [...state.boards, action.board],
+        currentBoardId: action.board.id,
+        nodes: action.initialNodes,
+        selectedNodeId: "root",
+      };
+    }
+    case "RENAME_BOARD": {
+      return {
+        ...state,
+        boards: state.boards.map((b) =>
+          b.id === action.id
+            ? { ...b, name: action.name, updatedAt: Date.now() }
+            : b,
+        ),
+      };
+    }
+    case "DELETE_BOARD": {
+      const remaining = state.boards.filter((b) => b.id !== action.id);
+      const filteredNodes: Record<string, MindNode> = {};
+      for (const [id, n] of Object.entries(state.nodes)) {
+        if (n.boardId !== action.id) filteredNodes[id] = n;
+      }
+      return {
+        ...state,
+        boards: remaining,
+        currentBoardId:
+          state.currentBoardId === action.id ? action.nextBoardId : state.currentBoardId,
+        nodes:
+          state.currentBoardId === action.id
+            ? action.nextBoardId
+              ? filteredNodes
+              : {}
+            : state.nodes,
+      };
+    }
+    case "RESET": {
+      if (!state.currentBoardId) return state;
+      const board = state.boards.find((b) => b.id === state.currentBoardId);
+      const root: MindNode = {
+        id: "root",
+        boardId: state.currentBoardId,
+        text: board?.name ?? "メインプロジェクト",
+        parentId: null,
+        isRoot: true,
+        completed: false,
+        collapsed: false,
+        priority: "medium",
+        categoryColor: "slate",
+        dueDate: "",
+        children: [],
+        x: 0,
+        y: 0,
+        vx: 0,
+        vy: 0,
+      };
+      return {
+        ...state,
+        nodes: { root },
+        selectedNodeId: "root",
+        physicsEnabled: state.physicsEnabled,
+      };
+    }
     case "SELECT": {
       return { ...state, selectedNodeId: action.id };
     }
@@ -64,12 +146,6 @@ export function reducer(state: State, action: Action): State {
     case "SET_NODES": {
       return { ...state, nodes: action.nodes };
     }
-    case "RESET": {
-      return {
-        ...createInitialState(),
-        physicsEnabled: state.physicsEnabled,
-      };
-    }
     case "SET_DRAGGING": {
       return { ...state, draggingNodeId: action.id };
     }
@@ -78,12 +154,13 @@ export function reducer(state: State, action: Action): State {
       if (!parent) return state;
       const { newId } = action;
       const newNode: MindNode = {
+        id: newId,
+        boardId: parent.boardId,
         categoryColor: parent.categoryColor,
         children: [],
         collapsed: false,
         completed: false,
         dueDate: "",
-        id: newId,
         isRoot: false,
         parentId: parent.id,
         priority: "medium",
@@ -164,116 +241,14 @@ export function reducer(state: State, action: Action): State {
       if (!node) return state;
       return {
         ...state,
-        nodes: { ...state.nodes, [action.id]: { ...node, vx: 0, vy: 0, x: action.x, y: action.y } },
+        nodes: {
+          ...state.nodes,
+          [action.id]: { ...node, vx: 0, vy: 0, x: action.x, y: action.y },
+        },
       };
     }
     default: {
       return state;
     }
   }
-}
-
-function makeNode(
-  id: string,
-  text: string,
-  opts: Partial<MindNode> & { x: number; y: number },
-): MindNode {
-  return {
-    categoryColor: "slate",
-    children: [],
-    collapsed: false,
-    completed: false,
-    dueDate: "",
-    parentId: null,
-    priority: "medium",
-    vx: 0,
-    vy: 0,
-    ...opts,
-    id,
-    isRoot: opts.isRoot ?? false,
-    text,
-  };
-}
-
-export function createInitialNodes(): Record<string, MindNode> {
-  const root = makeNode("root", "メインプロジェクト", {
-    categoryColor: "slate",
-    children: ["node-1", "node-2", "node-3"],
-    isRoot: true,
-    priority: "medium",
-    x: 0,
-    y: 0,
-  });
-
-  const node1 = makeNode("node-1", "企画・設計", {
-    categoryColor: "sky",
-    children: ["node-1-1", "node-1-2"],
-    parentId: "root",
-    priority: "high",
-    x: -250,
-    y: -120,
-  });
-
-  const node11 = makeNode("node-1-1", "要件定義書作成", {
-    categoryColor: "sky",
-    completed: true,
-    dueDate: "2026-06-25",
-    parentId: "node-1",
-    priority: "high",
-    x: -450,
-    y: -180,
-  });
-
-  const node12 = makeNode("node-1-2", "UIデザイン作成", {
-    categoryColor: "sky",
-    dueDate: "2026-07-01",
-    parentId: "node-1",
-    priority: "medium",
-    x: -450,
-    y: -70,
-  });
-
-  const node2 = makeNode("node-2", "実装フェーズ", {
-    categoryColor: "emerald",
-    children: ["node-2-1", "node-2-2"],
-    parentId: "root",
-    priority: "high",
-    x: 250,
-    y: -50,
-  });
-
-  const node21 = makeNode("node-2-1", "フロントエンド実装", {
-    categoryColor: "emerald",
-    parentId: "node-2",
-    priority: "high",
-    x: 480,
-    y: -100,
-  });
-
-  const node22 = makeNode("node-2-2", "API連携", {
-    categoryColor: "emerald",
-    parentId: "node-2",
-    priority: "medium",
-    x: 480,
-    y: 0,
-  });
-
-  const node3 = makeNode("node-3", "テスト & リリース", {
-    categoryColor: "rose",
-    parentId: "root",
-    priority: "low",
-    x: 0,
-    y: 180,
-  });
-
-  return {
-    "node-1": node1,
-    "node-1-1": node11,
-    "node-1-2": node12,
-    "node-2": node2,
-    "node-2-1": node21,
-    "node-2-2": node22,
-    "node-3": node3,
-    root,
-  };
 }

--- a/packages/mintodo/src/test-setup.ts
+++ b/packages/mintodo/src/test-setup.ts
@@ -1,7 +1,5 @@
 if (URL.createObjectURL === undefined) {
-  URL.createObjectURL = (_blob: Blob) => 
-    `blob:${crypto.randomUUID()}`
-  ;
+  URL.createObjectURL = (_blob: Blob) => `blob:${crypto.randomUUID()}`;
 }
 if (URL.revokeObjectURL === undefined) {
   URL.revokeObjectURL = (_url: string) => {

--- a/packages/mintodo/src/types.ts
+++ b/packages/mintodo/src/types.ts
@@ -2,8 +2,16 @@ export type Priority = "low" | "medium" | "high";
 
 export type CategoryColor = "slate" | "sky" | "emerald" | "rose";
 
+export interface Board {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface MindNode {
   id: string;
+  boardId: string;
   text: string;
   parentId: string | null;
   isRoot: boolean;
@@ -24,9 +32,15 @@ export interface View {
   zoom: number;
 }
 
-export type Modal = { kind: "edit"; nodeId: string } | { kind: "help" } | null;
+export type Modal =
+  | { kind: "edit"; nodeId: string }
+  | { kind: "help" }
+  | { kind: "board-name"; mode: "create" | "rename"; boardId?: string; initialName?: string }
+  | { kind: "board-delete"; boardId: string; boardName: string }
+  | null;
 
 export interface SaveData {
-  version: 1;
+  version: 2;
+  board: { id: string; name: string };
   nodes: MindNode[];
 }

--- a/packages/mintodo/tsconfig.json
+++ b/packages/mintodo/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -2153,6 +2156,25 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@textlint-ja/textlint-rule-preset-ai-writing@1.7.0':
     resolution: {integrity: sha512-xq+y592q4qP4SK5Vs40JRi98BmpJJoIaUO8/U+puOErCyazQvoZqDswIuKsFi1IEFmZ/wNn8OkfJ/5GNhrppNw==}
 
@@ -2267,6 +2289,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2666,6 +2691,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -2691,6 +2720,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -3325,6 +3357,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -4428,6 +4463,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
     peerDependencies:
@@ -5093,6 +5132,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prh@5.4.4:
     resolution: {integrity: sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==}
     hasBin: true
@@ -5156,6 +5199,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -8035,6 +8081,27 @@ snapshots:
       tailwindcss: 4.1.8
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@textlint-ja/textlint-rule-preset-ai-writing@1.7.0':
     dependencies:
       '@textlint/regexp-string-matcher': 2.0.2
@@ -8268,6 +8335,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -8722,6 +8791,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -8753,6 +8824,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -9478,6 +9553,8 @@ snapshots:
   diff@4.0.4: {}
 
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -10774,6 +10851,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lz-string@1.5.0: {}
+
   maath@0.10.8(@types/three@0.169.0)(three@0.169.0):
     dependencies:
       '@types/three': 0.169.0
@@ -11863,6 +11942,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prh@5.4.4:
     dependencies:
       commandpost: 1.4.0
@@ -11928,6 +12013,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary

`packages/mintodo` に「ボード」概念を導入し、複数の独立したマインドマップ ToDo を作成 / 切替 / リネーム / 削除できるようにしました。デモデータを削除し、初回起動時はボード 0 個(ウェルカム画面)から始めます。

- Dexie スキーマ v1 → v2 (`boards` テーブル + `[boardId+id]` 複合キー)
- 既存 v1 データは破棄して v2 に刷新
- `BoardActions` フック(作成/リネーム/削除/切替)+ 保存フラッシュで切替時のデータ消失を防止
- 左サイドバー UI、進捗バー付きボード一覧、ボード 0 個時のウェルカム画面
- インポート/エクスポートは現ボードのみ + 確認ダイアログ
- `CLAUDE.md` → `AGENTS.md` リネーム(両パッケージ)

## Test Plan

- [x] `pnpm --filter @mijime/mintodo test` → 53/53 pass
- [x] `pnpm --filter @mijime/mintodo run check` → 0 type/lint errors
- [x] `pnpm --filter @mijime/mintodo run build` → 成功
- [x] 初回起動 → ウェルカム → ボード作成 → タスク追加
- [x] 別ボード作成 → 切替で状態が分離
- [x] ボード削除 → empty state 復帰
- [x] インポート → 確認ダイアログ → 上書き(現ボードの `boardId` で書き換え)
- [x] 既存 v1 データ → 破棄されて v2 で起動

## Design / Plan References

- Spec: `docs/superpowers/specs/2026-06-20-mintodo-boards-design.md`
- Plan: `docs/superpowers/plans/2026-06-20-mintodo-boards.md`

## Follow-up Items (Not Blocking)

レビューで指摘された改善項目(別 PR で対応予定):

- 非現ボードの進捗バーが「タスクなし」表示になる問題(設計上の見落とし、`Board` レコードに統計を持たせる必要あり)
- マイグレーション失敗時のエラー画面
- IndexedDB 非対応ブラウザの警告
- ダイアログのアクセシビリティ(Escape キー、focus trap、aria 属性)