### PR TITLE
feat(mintodo): TaskCard editorial redesign

### DIFF
--- a/docs/superpowers/plans/2026-06-25-mintodo-taskcard-redesign.md
+++ b/docs/superpowers/plans/2026-06-25-mintodo-taskcard-redesign.md
@@ -1,0 +1,1034 @@
+# mintodo TaskCard Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh the TaskCard visual treatment to an editorial / sophisticated style, eliminate `dangerouslySetInnerHTML` from the badge pipeline, and split the component into focused subcomponents (`StatusDot`, `DueBadge`, `TaskCheckbox`, `priorityClass`).
+
+**Architecture:** Pure data layer first (`formatBadges` returns a `DueBadgeInfo` and a `statusLabel`, no HTML strings), then a pure helper (`priorityClass`), then three presentational subcomponents that consume that data, then a TaskCard rewrite that composes them. Every task follows TDD: failing test → minimal implementation → green test → commit. No new dependencies, no store changes, no changes to `NodeCard.tsx` or `KanbanCard.tsx`.
+
+**Tech Stack:** React 19, TypeScript 6, Tailwind v4, vitest + @testing-library/react, oxfmt/oxlint, pnpm.
+
+## Global Constraints
+
+- All `pnpm` commands run with `workdir: /Users/kojima.takashi/src/github.com/mijime/mijime.github.io/packages/mintodo` unless noted.
+- Git commands run with `git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io ...` from the monorepo root.
+- Test command: `pnpm test` (vitest run; expect all existing tests passing).
+- Typecheck + lint: `pnpm run check`.
+- Format: pre-commit hook (lefthook) runs `pnpm run format`. Do not run manually.
+- Commit messages: `type(mintodo): ...` Conventional Commits with the `mintodo` scope. No body unless required.
+- Branch: `feat/mintodo-taskcard-redesign`.
+- No changes to `apps/main`, `@mijime/theme`, `NodeCard.tsx`, or `KanbanCard.tsx`. No new dependencies.
+- All existing TaskCard test IDs (`task-card-*`, `task-check-*`, `add-child-*`, `status-dot-*`) are preserved. Tests must pass without renaming them.
+- Theme colors come from CSS variables (`var(--paper)`, `var(--ink)`, `var(--mid)`, `var(--terra)`); no `dark:` Tailwind variants inside TaskCard or its subcomponents.
+- `categoryBorderColor` and `statusDotClass` exports in `lib/badges.ts` are preserved; `categoryDotClass` is removed.
+- Status indicator cycling click (`DONE → REVIEW → WIP → INBOX`) is OUT OF SCOPE. `StatusDot` is a presentational `<span>`, not a `<button>`.
+- Each task ends with: full `pnpm test` green, `pnpm run check` clean, one commit.
+
+---
+
+## File Structure
+
+Files created or modified across this plan:
+
+| File | Responsibility |
+|---|---|
+| `packages/mintodo/src/components/priority.ts` (new) | Pure `priorityClass` helper |
+| `packages/mintodo/src/components/priority.test.ts` (new) | Tests for `priorityClass` |
+| `packages/mintodo/src/lib/badges.ts` (modify) | `formatBadges` returns pure data; add `statusLabel`; drop `categoryDotClass` |
+| `packages/mintodo/src/lib/badges.test.ts` (modify) | Tests for new `formatBadges` shape and `statusLabel` |
+| `packages/mintodo/src/components/StatusDot.tsx` (new) | Colored dot with paper/mid ring |
+| `packages/mintodo/src/components/StatusDot.test.tsx` (new) | Tests for `StatusDot` |
+| `packages/mintodo/src/components/DueBadge.tsx` (new) | Renders overdue / today / future / none pill |
+| `packages/mintodo/src/components/DueBadge.test.tsx` (new) | Tests for `DueBadge` |
+| `packages/mintodo/src/components/TaskCheckbox.tsx` (new) | 14px square checkbox button |
+| `packages/mintodo/src/components/TaskCheckbox.test.tsx` (new) | Tests for `TaskCheckbox` |
+| `packages/mintodo/src/components/TaskCard.tsx` (modify) | Rewrite using the new subcomponents |
+| `packages/mintodo/src/components/TaskCard.test.tsx` (modify) | Update the rose+done child-index assertion |
+
+No other files change. `NodeCard.tsx` and `KanbanCard.tsx` continue to import `TaskCard` from the same path.
+
+---
+
+## Task 1: `priorityClass` helper
+
+**Files:**
+- Create: `packages/mintodo/src/components/priority.ts`
+- Create: `packages/mintodo/src/components/priority.test.ts`
+
+**Interfaces:**
+- Consumes: `Priority` type from `../types`
+- Produces: `export function priorityClass(priority: Priority): string` — `""` for medium, `"font-bold tracking-wide uppercase"` for high, `"italic"` for low. Returns Tailwind class fragments; consumers concatenate.
+
+- [ ] **Step 1: Create the failing test**
+
+Create `packages/mintodo/src/components/priority.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { priorityClass } from "./priority";
+
+describe("priorityClass", () => {
+  it("returns empty string for medium", () => {
+    expect(priorityClass("medium")).toBe("");
+  });
+
+  it("returns bold + uppercase classes for high", () => {
+    const out = priorityClass("high");
+    expect(out).toContain("font-bold");
+    expect(out).toContain("uppercase");
+  });
+
+  it("returns italic for low", () => {
+    expect(priorityClass("low")).toBe("italic");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- priority.test
+```
+
+Expected: FAIL — `Cannot find module './priority'` (or similar "module not found" error).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `packages/mintodo/src/components/priority.ts`:
+
+```ts
+import type { Priority } from "../types";
+
+export function priorityClass(priority: Priority): string {
+  switch (priority) {
+    case "high": {
+      return "font-bold tracking-wide uppercase";
+    }
+    case "low": {
+      return "italic";
+    }
+    default: {
+      return "";
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- priority.test
+```
+
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 5: Run full test + check**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: all tests pass, 0 type errors, 0 lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/components/priority.ts packages/mintodo/src/components/priority.test.ts
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "feat(mintodo): add priorityClass helper"
+```
+
+---
+
+## Task 2: Refactor `formatBadges` to pure data
+
+**Files:**
+- Modify: `packages/mintodo/src/lib/badges.ts` (replace `BadgeInfo`, add `DueBadgeInfo`, replace `formatBadges` body, drop `categoryDotClass`)
+- Modify: `packages/mintodo/src/lib/badges.test.ts` (rewrite `formatBadges` describe; delete `categoryDotClass` describe; add `statusLabel` cases)
+
+**Interfaces:**
+- Consumes: `MindNode` from `../types`
+- Produces:
+  ```ts
+  export type DueKind = "none" | "overdue" | "today" | "future";
+  export interface DueBadgeInfo { kind: DueKind; daysFromNow: number }
+  export interface BadgeInfo {
+    due: DueBadgeInfo;
+    showPriority: boolean;
+    statusLabel: "INBOX" | "WIP" | "REVIEW" | "DONE";
+  }
+  export function formatBadges(node: MindNode): BadgeInfo;
+  ```
+- `categoryBorderColor` and `statusDotClass` exports are unchanged.
+- `categoryDotClass` export is removed.
+
+- [ ] **Step 1: Rewrite `badges.test.ts` to the new contract (it will fail to import)**
+
+Replace the entire content of `packages/mintodo/src/lib/badges.test.ts` with:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { formatBadges, categoryBorderColor, statusDotClass } from "./badges";
+import type { MindNode } from "../types";
+
+function makeNode(opts: Partial<MindNode> = {}): MindNode {
+  return {
+    id: "n",
+    boardId: "b",
+    text: "t",
+    parentId: null,
+    isRoot: false,
+    completed: opts.completed ?? false,
+    collapsed: false,
+    priority: opts.priority ?? "medium",
+    categoryColor: "slate",
+    dueDate: opts.dueDate ?? "",
+    status: opts.status ?? "inbox",
+    children: [],
+    x: 0,
+    y: 0,
+    ...opts,
+  };
+}
+
+function todayString(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+describe("formatBadges", () => {
+  it("empty dueDate -> kind none, showPriority false, statusLabel INBOX", () => {
+    const r = formatBadges(makeNode());
+    expect(r.due.kind).toBe("none");
+    expect(r.due.daysFromNow).toBe(0);
+    expect(r.showPriority).toBe(false);
+    expect(r.statusLabel).toBe("INBOX");
+  });
+
+  it("past dueDate -> kind overdue, negative daysFromNow", () => {
+    const r = formatBadges(makeNode({ dueDate: "2000-01-01" }));
+    expect(r.due.kind).toBe("overdue");
+    expect(r.due.daysFromNow).toBeLessThan(0);
+  });
+
+  it("due today -> kind today, daysFromNow 0", () => {
+    const r = formatBadges(makeNode({ dueDate: todayString() }));
+    expect(r.due.kind).toBe("today");
+    expect(r.due.daysFromNow).toBe(0);
+  });
+
+  it("future dueDate -> kind future, positive daysFromNow", () => {
+    const r = formatBadges(makeNode({ dueDate: "2099-12-31" }));
+    expect(r.due.kind).toBe("future");
+    expect(r.due.daysFromNow).toBeGreaterThan(0);
+  });
+
+  it("done status suppresses due to kind none", () => {
+    const r = formatBadges(makeNode({ dueDate: "2000-01-01", status: "done", completed: true }));
+    expect(r.due.kind).toBe("none");
+  });
+
+  it("done status but not completed also suppresses due", () => {
+    const r = formatBadges(makeNode({ dueDate: "2000-01-01", status: "done", completed: false }));
+    expect(r.due.kind).toBe("none");
+  });
+
+  it("showPriority is true only for high", () => {
+    expect(formatBadges(makeNode({ priority: "low" })).showPriority).toBe(false);
+    expect(formatBadges(makeNode({ priority: "medium" })).showPriority).toBe(false);
+    expect(formatBadges(makeNode({ priority: "high" })).showPriority).toBe(true);
+  });
+
+  it("statusLabel maps each TaskStatus", () => {
+    expect(formatBadges(makeNode({ status: "inbox" })).statusLabel).toBe("INBOX");
+    expect(formatBadges(makeNode({ status: "wip" })).statusLabel).toBe("WIP");
+    expect(formatBadges(makeNode({ status: "review" })).statusLabel).toBe("REVIEW");
+    expect(formatBadges(makeNode({ status: "done" })).statusLabel).toBe("DONE");
+  });
+});
+
+describe("categoryBorderColor", () => {
+  it("maps colors to hex/var values", () => {
+    expect(categoryBorderColor("sky")).toBe("#0ea5e9");
+    expect(categoryBorderColor("emerald")).toBe("#10b981");
+    expect(categoryBorderColor("rose")).toBe("#f43f5e");
+    expect(categoryBorderColor("slate")).toBe("var(--mid)");
+  });
+});
+
+describe("statusDotClass", () => {
+  it("returns the right class per status", () => {
+    expect(statusDotClass("inbox")).toBe("bg-slate-400");
+    expect(statusDotClass("wip")).toBe("bg-sky-500");
+    expect(statusDotClass("review")).toBe("bg-amber-500");
+    expect(statusDotClass("done")).toBe("bg-emerald-500");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- badges.test
+```
+
+Expected: FAIL — `TypeError: r.dueHtml is undefined` (or similar; the new `r.due` shape does not exist yet, and `categoryDotClass` import will fail).
+
+- [ ] **Step 3: Rewrite `badges.ts`**
+
+Replace the entire content of `packages/mintodo/src/lib/badges.ts` with:
+
+```ts
+import type { MindNode, TaskStatus } from "../types";
+
+export type DueKind = "none" | "overdue" | "today" | "future";
+
+export interface DueBadgeInfo {
+  kind: DueKind;
+  daysFromNow: number;
+}
+
+export interface BadgeInfo {
+  due: DueBadgeInfo;
+  showPriority: boolean;
+  statusLabel: "INBOX" | "WIP" | "REVIEW" | "DONE";
+}
+
+const STATUS_LABEL: Record<TaskStatus, BadgeInfo["statusLabel"]> = {
+  inbox: "INBOX",
+  wip: "WIP",
+  review: "REVIEW",
+  done: "DONE",
+};
+
+function dueBadgeInfo(dueDate: string, isCompleted: boolean): DueBadgeInfo {
+  if (!dueDate || isCompleted) {
+    return { kind: "none", daysFromNow: 0 };
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+  const diff = due.getTime() - today.getTime();
+  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  if (days < 0) {
+    return { kind: "overdue", daysFromNow: days };
+  }
+  if (days === 0) {
+    return { kind: "today", daysFromNow: 0 };
+  }
+  return { kind: "future", daysFromNow: days };
+}
+
+export function formatBadges(node: MindNode): BadgeInfo {
+  const isDone = node.status === "done" || node.completed;
+  return {
+    due: dueBadgeInfo(node.dueDate, isDone),
+    showPriority: node.priority === "high",
+    statusLabel: STATUS_LABEL[node.status],
+  };
+}
+
+export function categoryBorderColor(c: MindNode["categoryColor"]): string {
+  switch (c) {
+    case "sky": {
+      return "#0ea5e9";
+    }
+    case "emerald": {
+      return "#10b981";
+    }
+    case "rose": {
+      return "#f43f5e";
+    }
+    default: {
+      return "var(--mid)";
+    }
+  }
+}
+
+export function statusDotClass(s: TaskStatus): string {
+  switch (s) {
+    case "wip": {
+      return "bg-sky-500";
+    }
+    case "review": {
+      return "bg-amber-500";
+    }
+    case "done": {
+      return "bg-emerald-500";
+    }
+    default: {
+      return "bg-slate-400";
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- badges.test
+```
+
+Expected: PASS — all 11 tests in `badges.test.ts` pass.
+
+- [ ] **Step 5: Run full test + check (expect TaskCard failures)**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: `pnpm test` reports failures in `TaskCard.test.tsx` and `integration.test.tsx` (TaskCard still imports the old `dueHtml`/`showHigh`/`showBadgeRow` shape). `pnpm run check` reports type errors in `TaskCard.tsx` and any consumer. **These failures are expected.** They will be fixed in Task 6. Do NOT fix them here. Confirm only that:
+- `badges.test.ts` passes.
+- The failures are limited to `TaskCard` consumers (not other components).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/lib/badges.ts packages/mintodo/src/lib/badges.test.ts
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "refactor(mintodo): formatBadges returns pure data, drop categoryDotClass"
+```
+
+---
+
+## Task 3: `StatusDot` component
+
+**Files:**
+- Create: `packages/mintodo/src/components/StatusDot.tsx`
+- Create: `packages/mintodo/src/components/StatusDot.test.tsx`
+
+**Interfaces:**
+- Consumes: `statusDotClass` from `../lib/badges`
+- Produces: `<StatusDot status={TaskStatus} dimmed?={boolean} testId?={string} />` — a `<span>` with the correct color, a 2px paper / 1px mid ring via `box-shadow`, and `data-testid="status-dot-…"` if `testId` is provided.
+
+- [ ] **Step 1: Create the failing test**
+
+Create `packages/mintodo/src/components/StatusDot.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatusDot } from "./StatusDot";
+
+describe("StatusDot", () => {
+  it("renders wip with bg-sky-500", () => {
+    render(<StatusDot status="wip" testId="dot" />);
+    const el = screen.getByTestId("dot");
+    expect(el.className).toContain("bg-sky-500");
+    expect(el.className).toContain("rounded-full");
+  });
+
+  it("renders review with bg-amber-500", () => {
+    render(<StatusDot status="review" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-amber-500");
+  });
+
+  it("renders done with bg-emerald-500", () => {
+    render(<StatusDot status="done" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-emerald-500");
+  });
+
+  it("renders inbox with bg-slate-400", () => {
+    render(<StatusDot status="inbox" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-slate-400");
+  });
+
+  it("uses box-shadow ring", () => {
+    const { container } = render(<StatusDot status="wip" />);
+    const el = container.querySelector("span") as HTMLElement;
+    expect(el.style.boxShadow).toContain("var(--paper)");
+    expect(el.style.boxShadow).toContain("var(--mid)");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- StatusDot.test
+```
+
+Expected: FAIL — `Cannot find module './StatusDot'`.
+
+- [ ] **Step 3: Implement `StatusDot`**
+
+Create `packages/mintodo/src/components/StatusDot.tsx`:
+
+```tsx
+import { statusDotClass } from "../lib/badges";
+import type { TaskStatus } from "../types";
+
+interface Props {
+  status: TaskStatus;
+  dimmed?: boolean;
+  testId?: string;
+}
+
+export function StatusDot({ status, dimmed = false, testId }: Props) {
+  return (
+    <span
+      data-testid={testId}
+      className={`inline-block w-2.5 h-2.5 rounded-full ${statusDotClass(status)} ${dimmed ? "opacity-40" : ""}`}
+      style={{
+        boxShadow: "0 0 0 2px var(--paper), 0 0 0 3px var(--mid)",
+      }}
+      aria-label={`status: ${status}`}
+      title={`status: ${status}`}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- StatusDot.test
+```
+
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Run full test + check**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: same TaskCard-related failures as Task 2 Step 5 (the new component is not yet wired in). No new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/components/StatusDot.tsx packages/mintodo/src/components/StatusDot.test.tsx
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "feat(mintodo): add StatusDot component"
+```
+
+---
+
+## Task 4: `DueBadge` component
+
+**Files:**
+- Create: `packages/mintodo/src/components/DueBadge.tsx`
+- Create: `packages/mintodo/src/components/DueBadge.test.tsx`
+
+**Interfaces:**
+- Consumes: `DueBadgeInfo` from `../lib/badges`
+- Produces: `<DueBadge due={DueBadgeInfo} />` — renders nothing when `due.kind === "none"`. Otherwise renders a pill with the documented text and color class:
+  - `overdue` → `⚠ 超過` (rose, `bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-400`)
+  - `today` → `🔔 今日` (amber, plus `animate-pulse`)
+  - `future` → `あと N 日` (slate)
+
+- [ ] **Step 1: Create the failing test**
+
+Create `packages/mintodo/src/components/DueBadge.test.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DueBadge } from "./DueBadge";
+import type { DueBadgeInfo } from "../lib/badges";
+
+describe("DueBadge", () => {
+  it("renders nothing for kind none", () => {
+    const { container } = render(<DueBadge due={{ kind: "none", daysFromNow: 0 }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders 超過 for overdue", () => {
+    const { container } = render(<DueBadge due={{ kind: "overdue", daysFromNow: -3 }} />);
+    expect(container.textContent).toContain("超過");
+  });
+
+  it("renders 今日 for today with pulse animation class", () => {
+    const { container } = render(<DueBadge due={{ kind: "today", daysFromNow: 0 }} />);
+    expect(container.textContent).toContain("今日");
+    expect(container.firstChild as HTMLElement).toHaveClass("animate-pulse");
+  });
+
+  it("renders あと N 日 for future", () => {
+    const { container } = render(<DueBadge due={{ kind: "future", daysFromNow: 5 }} />);
+    expect(container.textContent).toBe("あと 5 日");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- DueBadge.test
+```
+
+Expected: FAIL — `Cannot find module './DueBadge'`.
+
+- [ ] **Step 3: Implement `DueBadge`**
+
+Create `packages/mintodo/src/components/DueBadge.tsx`:
+
+```tsx
+import type { DueBadgeInfo } from "../lib/badges";
+
+interface Props {
+  due: DueBadgeInfo;
+}
+
+export function DueBadge({ due }: Props) {
+  if (due.kind === "none") return null;
+  if (due.kind === "overdue") {
+    return (
+      <span className="bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md inline-flex items-center gap-1 shrink-0 border border-rose-200 dark:border-rose-900/30">
+        <span>⚠</span>
+        超過
+      </span>
+    );
+  }
+  if (due.kind === "today") {
+    return (
+      <span className="bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md inline-flex items-center gap-1 shrink-0 border border-amber-200 dark:border-amber-900/30 animate-pulse">
+        <span>🔔</span>
+        今日
+      </span>
+    );
+  }
+  return (
+    <span className="bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 text-[10px] font-medium px-1.5 py-0.5 rounded-md shrink-0">
+      あと {due.daysFromNow} 日
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- DueBadge.test
+```
+
+Expected: PASS — 4 tests pass.
+
+- [ ] **Step 5: Run full test + check**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: same TaskCard-related failures as before. No new failures from DueBadge.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/components/DueBadge.tsx packages/mintodo/src/components/DueBadge.test.tsx
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "feat(mintodo): add DueBadge component"
+```
+
+---
+
+## Task 5: `TaskCheckbox` component
+
+**Files:**
+- Create: `packages/mintodo/src/components/TaskCheckbox.tsx`
+- Create: `packages/mintodo/src/components/TaskCheckbox.test.tsx`
+
+**Interfaces:**
+- Produces: `<TaskCheckbox isDone={boolean} onToggle={() => void} testId={string} />` — a `<button type="button">` 14px square, 3px radius. When `!isDone`: 1.5px `var(--mid)` border, transparent fill. When `isDone`: filled with the status color (passed as `doneClass` default `bg-emerald-500`), white `✓` glyph 10px.
+
+Update the prop set per the implementation below if a simpler shape is preferred; the prop list is part of the spec.
+
+- [ ] **Step 1: Create the failing test**
+
+Create `packages/mintodo/src/components/TaskCheckbox.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TaskCheckbox } from "./TaskCheckbox";
+
+describe("TaskCheckbox", () => {
+  it("renders an empty square when not done", () => {
+    render(<TaskCheckbox isDone={false} onToggle={() => {}} testId="cb" />);
+    const btn = screen.getByTestId("cb");
+    expect(btn.className).toContain("border-[1.5px]");
+    expect(btn.textContent).toBe("");
+  });
+
+  it("renders a check mark and filled background when done", () => {
+    render(<TaskCheckbox isDone={true} onToggle={() => {}} testId="cb" />);
+    const btn = screen.getByTestId("cb");
+    expect(btn.textContent).toBe("✓");
+    expect(btn.className).toContain("bg-emerald-500");
+  });
+
+  it("calls onToggle when clicked and stops propagation", () => {
+    const onToggle = vi.fn();
+    const stop = vi.fn();
+    render(
+      <div onClick={stop}>
+        <TaskCheckbox isDone={false} onToggle={onToggle} testId="cb" />
+      </div>,
+    );
+    fireEvent.click(screen.getByTestId("cb"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- TaskCheckbox.test
+```
+
+Expected: FAIL — `Cannot find module './TaskCheckbox'`.
+
+- [ ] **Step 3: Implement `TaskCheckbox`**
+
+Create `packages/mintodo/src/components/TaskCheckbox.tsx`:
+
+```tsx
+interface Props {
+  isDone: boolean;
+  onToggle: () => void;
+  testId: string;
+}
+
+export function TaskCheckbox({ isDone, onToggle, testId }: Props) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      aria-pressed={isDone}
+      aria-label={isDone ? "Mark as not done" : "Mark as done"}
+      className={
+        isDone
+          ? "w-3.5 h-3.5 rounded-[3px] bg-emerald-500 flex items-center justify-center text-white text-[10px] leading-none shrink-0"
+          : "w-3.5 h-3.5 rounded-[3px] border-[1.5px] shrink-0"
+      }
+      style={isDone ? undefined : { borderColor: "var(--mid)" }}
+    >
+      {isDone ? "✓" : ""}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- TaskCheckbox.test
+```
+
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 5: Run full test + check**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: same TaskCard-related failures. No new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/components/TaskCheckbox.tsx packages/mintodo/src/components/TaskCheckbox.test.tsx
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "feat(mintodo): add TaskCheckbox component"
+```
+
+---
+
+## Task 6: Rewrite `TaskCard` and update its test
+
+**Files:**
+- Modify: `packages/mintodo/src/components/TaskCard.tsx` (full rewrite)
+- Modify: `packages/mintodo/src/components/TaskCard.test.tsx` (update the rose+done assertion: `card.children[2]` → `card.children[1]`; switch the status-dot check on the done case to the collapsed-dot element)
+
+**Interfaces (rewired TaskCard):**
+- Same public prop: `{ node: MindNode }`.
+- Composes `StatusDot`, `DueBadge`, `TaskCheckbox`, and the `priorityClass` helper.
+- DOM order in not-done case: `[MetaRow, Hairline, BodyRow]` (children indices 0, 1, 2).
+- DOM order in done case: `[BodyRow, Hairline]` (children indices 0, 1).
+- The hairline is the LAST visible element in both cases (so the rose+done test can assert `children[1].style.borderTop`).
+- The hairline color is `categoryBorderColor(node.categoryColor)`; opacity is 0.35 when `isDone`, otherwise 1.
+- Test IDs preserved: `task-card-${id}` on the wrapper, `task-check-${id}` inside `TaskCheckbox`, `add-child-${id}` on the add-child button, `status-dot-${id}` on the `StatusDot`. The collapsed-done 8px dot has no testid (the test only checks it is present and is emerald via className, per the updated assertion below).
+
+- [ ] **Step 1: Update `TaskCard.test.tsx` (it will fail against the new TaskCard)**
+
+Replace the entire content of `packages/mintodo/src/components/TaskCard.test.tsx` with:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TaskCard } from "./TaskCard";
+import { MindProvider, useMindStore } from "../hooks/use-mind-store";
+import type { MindNode } from "../types";
+import type { State } from "../store";
+
+function makeNode(over: Partial<MindNode> = {}): MindNode {
+  return {
+    id: "n1",
+    boardId: "b1",
+    text: "牛乳",
+    parentId: "root",
+    isRoot: false,
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    status: "inbox",
+    children: [],
+    x: 0,
+    y: 0,
+    ...over,
+  };
+}
+
+function makeState(over: Partial<State> = {}): State {
+  return {
+    boards: [],
+    currentBoardId: "b1",
+    draggingNodeId: null,
+    drawerOpen: false,
+    hideCompleted: false,
+    layoutVersion: 0,
+    modal: null,
+    viewMode: "mindmap",
+    searchQuery: "",
+    selectedNodeId: "",
+    view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    nodes: { root: makeNode({ id: "root", isRoot: true }), n1: makeNode() },
+    ...over,
+  };
+}
+
+let captured: State | null = null;
+function Capture() {
+  captured = useMindStore().state;
+  return null;
+}
+
+describe("TaskCard", () => {
+  it("renders text, add-child button, and status dot", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode({ status: "wip" })} />
+      </MindProvider>,
+    );
+    expect(screen.getByText("牛乳")).toBeTruthy();
+    expect(screen.getByTestId("add-child-n1")).toBeTruthy();
+    expect(screen.getByTestId("status-dot-n1").className).toContain("bg-sky-500");
+  });
+
+  it("opens edit-new modal when add-child is clicked", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode()} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("add-child-n1"));
+    expect(captured!.modal).toEqual({ kind: "edit-new", parentId: "n1" });
+  });
+
+  it("toggles complete when checkbox is clicked", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode()} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("task-check-n1"));
+    expect(captured!.nodes.n1.completed).toBe(true);
+  });
+
+  it("uses categoryColor for the hairline and renders the collapsed done dot", () => {
+    const { container } = render(
+      <MindProvider initialState={makeState()}>
+        <TaskCard node={makeNode({ categoryColor: "rose", status: "done", completed: true })} />
+      </MindProvider>,
+    );
+    const card = screen.getByTestId("task-card-n1");
+    // done: DOM is [BodyRow, Hairline]; hairline is at index 1
+    const hairline = card.children[1] as HTMLElement;
+    expect(hairline.style.borderTop).toBe("1px solid rgb(244, 63, 94)");
+    expect(hairline.style.opacity).toBe("0.35");
+    // collapsed done: an 8px emerald dot inside BodyRow
+    const bodyRow = card.children[0] as HTMLElement;
+    const dot = bodyRow.querySelector("span.rounded-full.bg-emerald-500") as HTMLElement | null;
+    expect(dot).not.toBeNull();
+    // Meta row (and its StatusDot) is absent
+    expect(screen.queryByTestId("status-dot-n1")).toBeNull();
+    // The body uses Crimson Pro for the title
+    const title = container.querySelector("span.whitespace-pre-wrap") as HTMLElement;
+    expect(title.style.fontFamily).toContain("Crimson Pro");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test -- TaskCard.test
+```
+
+Expected: FAIL — multiple assertions, including `card.children[1]` mismatch and `status-dot-n1` not present.
+
+- [ ] **Step 3: Rewrite `TaskCard.tsx`**
+
+Replace the entire content of `packages/mintodo/src/components/TaskCard.tsx` with:
+
+```tsx
+import { useMindStore } from "../hooks/use-mind-store";
+import { categoryBorderColor, formatBadges } from "../lib/badges";
+import { DueBadge } from "./DueBadge";
+import { StatusDot } from "./StatusDot";
+import { TaskCheckbox } from "./TaskCheckbox";
+import { priorityClass } from "./priority";
+import type { MindNode } from "../types";
+
+interface Props {
+  node: MindNode;
+}
+
+export function TaskCard({ node }: Props) {
+  const { dispatch } = useMindStore();
+  const isDone = node.status === "done" || node.completed;
+  const { due, statusLabel } = formatBadges(node);
+  const hairlineColor = categoryBorderColor(node.categoryColor);
+
+  const metaRow = !isDone ? (
+    <div className="flex items-center gap-1.5 min-w-0" style={{ minHeight: "18px" }}>
+      <DueBadge due={due} />
+      <span className="text-[9px] tracking-widest" style={{ color: "var(--mid)" }}>
+        {statusLabel}
+      </span>
+      <span className="ml-auto">
+        <StatusDot status={node.status} testId={`status-dot-${node.id}`} />
+      </span>
+    </div>
+  ) : null;
+
+  const bodyRow = (
+    <div className="flex items-start gap-2 min-w-0">
+      {isDone ? null : (
+        <TaskCheckbox
+          isDone={isDone}
+          onToggle={() => dispatch({ id: node.id, type: "TOGGLE_COMPLETE" })}
+          testId={`task-check-${node.id}`}
+        />
+      )}
+      <span
+        className={`whitespace-pre-wrap break-words max-w-[240px] flex-1 text-[15px] leading-[1.3] ${
+          isDone ? "line-through" : ""
+        } ${priorityClass(node.priority)}`}
+        style={{
+          fontFamily: '"Crimson Pro", serif',
+          fontWeight: isDone ? 400 : undefined,
+          color: isDone ? "var(--mid)" : "var(--ink)",
+        }}
+      >
+        {node.text}
+      </span>
+      {isDone ? (
+        <span
+          className="w-2 h-2 rounded-full bg-emerald-500 shrink-0 mt-[5px]"
+          aria-label="completed"
+          title="completed"
+        />
+      ) : (
+        <button
+          type="button"
+          data-testid={`add-child-${node.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            dispatch({ modal: { kind: "edit-new", parentId: node.id }, type: "OPEN_MODAL" });
+          }}
+          className="w-[18px] h-[18px] rounded text-[11px] font-semibold flex items-center justify-center shrink-0"
+          style={{
+            background: "color-mix(in srgb, var(--mid) 12%, transparent)",
+            color: "var(--mid)",
+          }}
+          title="子タスクを追加"
+        >
+          +
+        </button>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      data-testid={`task-card-${node.id}`}
+      data-node-id={node.id}
+      className="flex flex-col gap-1.5 min-w-0"
+    >
+      {isDone ? null : metaRow}
+      {bodyRow}
+      <div
+        className="w-full"
+        style={{
+          borderTop: `1px solid ${hairlineColor}`,
+          opacity: isDone ? 0.35 : 1,
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- TaskCard.test
+```
+
+Expected: PASS — 4 tests pass.
+
+- [ ] **Step 5: Run full test + check**
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Expected: all tests pass, 0 type errors, 0 lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io add packages/mintodo/src/components/TaskCard.tsx packages/mintodo/src/components/TaskCard.test.tsx
+git -C /Users/kojima.takashi/src/github.com/mijime/mijime.github.io commit -m "refactor(mintodo): rewrite TaskCard with subcomponents and editorial layout"
+```
+
+---
+
+## Self-Review (run after writing the plan)
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Component split (StatusDot / DueBadge / TaskCheckbox / priority) | Tasks 1, 3, 4, 5, 6 |
+| `formatBadges` → pure data, drop `categoryDotClass`, add `statusLabel` | Task 2 |
+| Subcomponent shapes | Tasks 3, 4, 5 |
+| Visual spec (hairline color, meta row, body row, completed state, dark mode) | Task 6 |
+| Interaction spec (checkbox / add-child / status-dot non-interactive) | Task 6 |
+| Data flow (no new selectors, no new state) | Tasks 2, 6 |
+| File changes table | Tasks 1-6 |
+| Existing test IDs preserved | Task 6 |
+| `lib/badges.test.ts` updated | Task 2 |
+| `TaskCard.test.tsx` rose+done assertion updated | Task 6 |
+| New tests (priority, badges updated, DueBadge, StatusDot) | Tasks 1, 2, 3, 4 |
+| Risks acknowledged | (Plan-level; the implementation matches the mitigations.) |
+
+**Placeholder scan:** No `TBD`, `TODO`, "implement later", "fill in details", "add appropriate error handling", or "similar to Task N". Every code block is complete and runnable.
+
+**Type consistency:** `DueBadgeInfo.kind` and `DueKind` are defined in Task 2 and used in Tasks 4 and 6. `formatBadges` return shape `{ due, showPriority, statusLabel }` is defined in Task 2 and consumed in Task 6. `priorityClass` signature `(Priority) => string` defined in Task 1 and used in Task 6. `StatusDot` props `(status, dimmed?, testId?)` defined in Task 3 and used in Task 6. `TaskCheckbox` props `(isDone, onToggle, testId)` defined in Task 5 and used in Task 6. All match.

--- a/docs/superpowers/specs/2026-06-25-mintodo-taskcard-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-25-mintodo-taskcard-redesign-design.md
@@ -1,0 +1,181 @@
+# mintodo TaskCard Redesign — Design
+
+**Date**: 2026-06-25
+**Branch**: `feat/mintodo-taskcard-redesign`
+**Scope**: TaskCard visual refresh and internal component split
+**Status**: Approved, pending implementation
+
+## Background
+
+`packages/mintodo/src/components/TaskCard.tsx` is the shared task body used by both mindmap nodes (`NodeCard.tsx`) and KANBAN cards (`KanbanCard.tsx`). A visual review revealed several structural issues:
+
+- The metadata row is `flex items-center justify-between` with content only on the left, leaving the right half empty.
+- The category color appears twice for mindmap nodes: NodeCard already paints a 4px left border from `categoryBorderColor`, then TaskCard paints a 1px bottom border from the same value.
+- Priority is binary-visibility: only `high` renders a "重要" rose pill; `low` and `medium` are visually identical.
+- The due-date badge is rendered via `dangerouslySetInnerHTML` with a hard-coded HTML string in `lib/badges.ts`. The string is not user input so it is not a security issue, but it is structurally wrong: it bypasses React, cannot be tested as JSX, and locks badge styling into string concatenation.
+- The add-child button uses a 12px `GitBranch` glyph in a 24px square, while the checkbox uses an 18px icon — inconsistent scale.
+- The title font is system sans across all task text, while the root node uses `Crimson Pro` serif. The two halves of the mindmap do not share a typographic identity.
+- Completed state always shows line-through + grey text + the full metadata row, which wastes vertical space in long lists.
+
+The redesign consolidates these into a single editorial-style layout and splits TaskCard into focused subcomponents that can be tested and styled independently.
+
+## Goals
+
+- Editorial / sophisticated visual treatment: serif title (Crimson Pro), hairline rules, restrained color.
+- Metadata above the body, separated by a 1px hairline whose color is the node's category color.
+- Priority expressed purely through typography (weight + small-caps), no extra badge chrome.
+- Status expressed as a colored dot with a 1px ring, plus a small-caps abbreviation (WIP / REVIEW / DONE / INBOX).
+- Completed state collapses the metadata row to a single line, so finished tasks take ~40% less vertical space.
+- Eliminate `dangerouslySetInnerHTML` from the badge pipeline. `lib/badges.ts` returns plain data; React renders JSX.
+- Split TaskCard into `StatusDot`, `DueBadge`, `TaskCheckbox`, plus a pure `priorityClass` helper. Each is testable on its own.
+
+## Non-Goals
+
+- New store actions, selectors, or data model changes. The dispatch surface (`TOGGLE_COMPLETE`, `OPEN_MODAL`) is unchanged.
+- A clickable status indicator that cycles status (`DONE → REVIEW → WIP → INBOX`). That is a separate wishlist item and is out of scope here. `StatusDot` is structured so that wrapping it in a `<button>` later is a one-line change.
+- Touching `NodeCard` / `KanbanCard` layouts beyond what is required to consume the new TaskCard shape. NodeCard's left border and KanbanCard's breadcrumb bar remain as-is.
+- Removing the existing `TaskCard.test.tsx` test IDs (`task-card-*`, `task-check-*`, `add-child-*`, `status-dot-*`). Tests must keep passing without modification.
+- Any new dependency. Lucide is dropped for the affected icons but no new icon library is added.
+
+## Design
+
+### 1. Component split
+
+```
+TaskCard
+├── MetaRow (omitted when isDone)
+│   ├── DueBadge
+│   ├── StatusLabel       (small-caps abbreviation, always rendered)
+│   └── StatusDot         (right-aligned)
+├── Hairline              (1px solid, color = category color; dimmed when isDone)
+└── BodyRow
+    ├── TaskCheckbox
+    ├── Title             (Crimson Pro; priorityClass applied)
+    └── AddChildButton    (replaces GitBranch with `+`)
+```
+
+`TaskCard.test.tsx` continues to find elements by the existing `data-testid` values. The wrapper element stays `data-testid="task-card-${node.id}"` and its first child is the metadata row (or body row when collapsed). The third child remains the hairline in the not-done case so the existing assertion `card.children[2].style.borderTop === "1px solid rgb(244, 63, 94)"` in the rose+done test can be updated in the test to look at the new position (see Test Plan).
+
+### 2. `formatBadges` → pure data
+
+`packages/mintodo/src/lib/badges.ts` no longer returns `dueHtml: string`. It returns:
+
+```ts
+export interface DueBadgeInfo {
+  kind: "none" | "overdue" | "today" | "future";
+  daysFromNow: number; // negative for overdue, 0 for today
+}
+export interface BadgeInfo {
+  due: DueBadgeInfo;
+  showPriority: boolean; // true only for high
+  statusLabel: "INBOX" | "WIP" | "REVIEW" | "DONE";
+}
+export function formatBadges(node: MindNode): BadgeInfo;
+```
+
+`categoryBorderColor` and `statusDotClass` remain as exports (they are pure mappings used by both TaskCard and NodeCard / KanbanCard).
+
+The `categoryDotClass` export is unused outside the lib and is removed.
+
+### 3. Subcomponent shapes
+
+```tsx
+// StatusDot — presentational only
+interface StatusDotProps {
+  status: TaskStatus;
+  dimmed?: boolean; // true in the completed-collapsed state
+}
+
+// DueBadge — presentational only
+interface DueBadgeProps {
+  due: DueBadgeInfo;
+}
+
+// TaskCheckbox — interactive; calls onToggle
+interface TaskCheckboxProps {
+  isDone: boolean;
+  onToggle: () => void;
+  testId: string;
+}
+
+// priorityClass — pure helper
+export function priorityClass(priority: Priority): string;
+// returns "" | "font-bold tracking-wide uppercase" (high) | "italic" (low) | "" (medium)
+```
+
+`TaskCard` composes these and does not export any new symbols beyond what is needed by NodeCard and KanbanCard (which already import only `TaskCard`).
+
+### 4. Visual specification
+
+**Hairline.** 1px tall. Color is `categoryBorderColor(node.categoryColor)` (slate / sky / emerald / rose). When `isDone`, the hairline stays in place but its opacity drops to 0.35 so the card recedes.
+
+**Metadata row.** Height ~18px. From left:
+- `DueBadge` if `due.kind !== "none"`. Renders one of three pill styles (overdue red, today amber-pulsing, future slate). Always hides when `isDone` because the row itself is hidden.
+- `StatusLabel` as small-caps text (`tracking-widest text-[9px]`), color `var(--mid)`. Always present.
+- `StatusDot` 10px circle with 2px outer-paper + 1px outer-mid ring (the `box-shadow: 0 0 0 2px var(--paper), 0 0 0 3px var(--mid)` pattern). Color via `statusDotClass(status)`. Right-aligned via `ml-auto`.
+
+**Body row.** 14px checkbox (square, 1.5px `var(--mid)` border, 3px corner radius, transparent fill; when done, fills with `var(--mid)` and shows a 10px white `✓` glyph). Title: `font-family: "Crimson Pro"`, `font-weight: 500` (medium) or `700` (high) or `400 italic` (low), `text-size: 15px`, `line-height: 1.3`, color `var(--ink)` (or `var(--mid)` when done). AddChildButton: 18px square, 4px radius, background `var(--mid)` at ~10% alpha, glyph `+` 11px 600-weight, color `var(--mid)`.
+
+**Completed state.** Meta row omitted. Body row carries a single 8px green dot on the right (no ring) to signal completion. Title color is `var(--mid)`, `line-through`, `font-weight: 400`. Hairline at 0.35 opacity.
+
+**Dark mode.** All colors are defined as CSS variables on `:root[data-theme="dark"]` via `@mijime/theme`. No `dark:*` Tailwind variants are needed inside TaskCard; using variables keeps the rules theme-agnostic. The lone exception is the DueBadge pulse animation, which keys off the `kind === "today"` value and not a color class, so it is theme-agnostic.
+
+### 5. Interaction specification
+
+| Element | Click | Keyboard |
+|---|---|---|
+| Checkbox | `dispatch({ id, type: "TOGGLE_COMPLETE" })` | `Enter` / `Space` (native button) |
+| AddChild | `dispatch({ modal: { kind: "edit-new", parentId }, type: "OPEN_MODAL" })` | native |
+| StatusDot | none (out of scope) | none |
+
+Both buttons call `e.stopPropagation()` to prevent the click from bubbling to NodeCard's `onClick={() => dispatch({ id, type: "SELECT" })}`.
+
+### 6. Data flow
+
+Unchanged from the current implementation. The store exposes `state.nodes` and `dispatch`; TaskCard reads the node and the dispatch, derives `isDone` and badge info, and renders. No new selectors, no new effects, no new context.
+
+## File Changes
+
+| File | Change |
+|---|---|
+| `packages/mintodo/src/components/TaskCard.tsx` | Rewrite: compose subcomponents, drop `dangerouslySetInnerHTML`, drop `GitBranch` import |
+| `packages/mintodo/src/components/StatusDot.tsx` | New |
+| `packages/mintodo/src/components/DueBadge.tsx` | New |
+| `packages/mintodo/src/components/TaskCheckbox.tsx` | New |
+| `packages/mintodo/src/components/priority.ts` | New — exports `priorityClass` |
+| `packages/mintodo/src/lib/badges.ts` | Replace `dueHtml` with `DueBadgeInfo`; drop unused `categoryDotClass`; add `statusLabel` mapping |
+| `packages/mintodo/src/lib/badges.test.ts` | Update assertions: drop `dueHtml` checks, add `kind`/`statusLabel` checks; drop `categoryDotClass` block |
+| `packages/mintodo/src/components/TaskCard.test.tsx` | Adjust the rose+done assertion (see Test Plan) |
+
+`NodeCard.tsx` and `KanbanCard.tsx` are not modified.
+
+## Test Plan
+
+`packages/mintodo/src/components/TaskCard.test.tsx` keeps the existing four tests with minor adjustments:
+
+1. **"renders text, add-child button, and status dot"** — unchanged. The `task-card-n1` testid still wraps the card; the `add-child-n1` and `status-dot-n1` testids remain. The `bg-sky-500` check on the status dot still passes because `statusDotClass("wip")` returns `"bg-sky-500"`.
+2. **"opens edit-new modal when add-child is clicked"** — unchanged.
+3. **"toggles complete when checkbox is clicked"** — testid `task-check-n1` remains. `TaskCheckbox` is a `<button>` so `fireEvent.click` still dispatches.
+4. **"uses categoryColor for bottom border and keeps status dot"** — the rose+done test. The hairline is still in TaskCard but the structure is now: row0 (body row, since done collapses meta), row1 (hairline). The assertion `card.children[2].style.borderTop` becomes `card.children[1].style.borderTop` and the expected color stays `rgb(244, 63, 94)`. The done status assertion switches to the new "collapsed dot" element (8px, `bg-emerald-500`, no ring). `queryByTestId("category-dot-n1")` stays null because no separate category dot exists.
+
+New tests are added in this commit:
+
+- `priority.test.ts`: parametrized over `["low","medium","high"]`; asserts `priorityClass` returns the documented substrings.
+- `badges.test.ts`: `formatBadges` returns `due.kind === "today"` for `dueDate === today`; `statusLabel` cycles the four values; `showPriority` is `true` only for `high`.
+- `DueBadge.test.tsx`: renders the three pill variants by stubbing `Date` (not strictly required — the existing integration test in `integration.test.tsx` exercises DueBadge through the full flow).
+- `StatusDot.test.tsx`: renders each of the four `statusDotClass` colors as a class on the outer span.
+
+`pnpm test` and `pnpm run check` must pass. The integration test file `integration.test.tsx` exercises TaskCard indirectly through NodeCard and KanbanCard; it should keep passing without modification because the externally visible testids and dispatch actions are unchanged.
+
+## Risk and Mitigations
+
+- **Hairline + NodeCard left border double-strokes.** NodeCard already draws a 4px left border. TaskCard's 1px hairline is horizontal and crosses the full card width, so the two do not overlap visually. The hairline becomes the only visible category cue in KANBAN (where NodeCard's left border does not exist), which is desirable: KANBAN gets color from the TaskCard hairline, mindmap keeps the strong left rail from NodeCard.
+- **Dark mode regressions.** The redesign uses CSS variables instead of `dark:` Tailwind variants for the parts that change (background, ink, mid). A visual check in both themes is required before merge. The `StatusDot` ring is `2px var(--paper), 3px var(--mid)` so it stays clean in both themes.
+- **Long titles.** `whitespace-pre-wrap break-words max-w-[240px]` is preserved on the title span. NodeCard's `min-w-[220px] max-w-[320px]` continues to cap the outer card.
+- **Click target size on the add-child button.** It shrinks from 24px to 18px. That is below the 24px recommended touch target, but TaskCard is desktop-first and the add-child action is duplicated by `NodeCard`'s collapse/ellipsis area. Acceptable.
+
+## Out of Scope (Future Work)
+
+- Status indicator click → cycle status (`DONE → REVIEW → WIP → INBOX`). `StatusDot` is a presentational span today; promoting it to a button is a one-line change once the cycling action lands in the store.
+- Inline editing of title from TaskCard.
+- Animation on completion (fade-in/out, strike-through draw).

--- a/packages/mintodo/package.json
+++ b/packages/mintodo/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@mijime/theme": "workspace:*",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "dexie": "^4.0.10",
     "lucide-react": "^1.17.0"
   },

--- a/packages/mintodo/package.json
+++ b/packages/mintodo/package.json
@@ -19,9 +19,9 @@
     "format:oxfmt": "oxfmt"
   },
   "dependencies": {
-    "@mijime/theme": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
+    "@mijime/theme": "workspace:*",
     "dexie": "^4.0.10",
     "lucide-react": "^1.17.0"
   },

--- a/packages/mintodo/src/components/Canvas.tsx
+++ b/packages/mintodo/src/components/Canvas.tsx
@@ -52,9 +52,7 @@ export function Canvas() {
   usePanZoom({ containerRef });
   useTween();
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   const visibleNodes = useMemo(
     () =>
@@ -73,15 +71,15 @@ export function Canvas() {
     dispatch({ id, type: "SET_DRAGGING" });
   }
 
-  function handleDragEnd(event: { active: { id: string | number }; over?: { id: string | number } | null }) {
+  function handleDragEnd(event: {
+    active: { id: string | number };
+    over?: { id: string | number } | null;
+  }) {
     const { active, over } = event;
     if (over) {
       const draggedId = String(active.id);
       const targetId = String(over.id);
-      if (
-        draggedId !== targetId &&
-        !isDescendant(state.nodes, draggedId, targetId)
-      ) {
+      if (draggedId !== targetId && !isDescendant(state.nodes, draggedId, targetId)) {
         dispatch({ id: draggedId, newParentId: targetId, type: "REPARENT" });
       }
     }

--- a/packages/mintodo/src/components/Canvas.tsx
+++ b/packages/mintodo/src/components/Canvas.tsx
@@ -1,9 +1,13 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
+import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
 import { usePanZoom } from "../hooks/use-pan-zoom";
 import { useTween } from "../hooks/use-tween";
+import { isDescendant } from "../store";
+import { categoryBorderColor } from "../lib/badges";
 import { ConnectionLines } from "./ConnectionLines";
 import { NodeCard } from "./NodeCard";
+import type { MindNode } from "../types";
 
 function isParentCollapsed(state: ReturnType<typeof useMindStore>["state"], id: string): boolean {
   const node = state.nodes[id];
@@ -18,12 +22,39 @@ function isParentCollapsed(state: ReturnType<typeof useMindStore>["state"], id: 
   return false;
 }
 
+function NodeCardPreview({ node }: { node: MindNode }) {
+  const borderColor = categoryBorderColor(node.categoryColor);
+  return (
+    <div
+      className="px-4 py-3 rounded border-l-4 cursor-grabbing"
+      style={{
+        background: "var(--paper)",
+        color: "var(--ink)",
+        borderTop: "1px solid var(--border)",
+        borderRight: "1px solid var(--border)",
+        borderBottom: "1px solid var(--border)",
+        borderLeft: `4px solid ${borderColor}`,
+        boxShadow: "0 10px 25px rgba(0,0,0,0.2), 0 4px 10px rgba(0,0,0,0.1)",
+        minWidth: "220px",
+        maxWidth: "320px",
+      }}
+    >
+      <span className="truncate text-sm font-medium">{node.text}</span>
+    </div>
+  );
+}
+
 export function Canvas() {
-  const { state } = useMindStore();
+  const { state, dispatch } = useMindStore();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
 
   usePanZoom({ containerRef });
   useTween();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
 
   const visibleNodes = useMemo(
     () =>
@@ -36,22 +67,61 @@ export function Canvas() {
     [state.nodes, state.currentBoardId, state.hideCompleted],
   );
 
+  function handleDragStart(event: { active: { id: string | number } }) {
+    const id = String(event.active.id);
+    setActiveId(id);
+    dispatch({ id, type: "SET_DRAGGING" });
+  }
+
+  function handleDragEnd(event: { active: { id: string | number }; over?: { id: string | number } | null }) {
+    const { active, over } = event;
+    if (over) {
+      const draggedId = String(active.id);
+      const targetId = String(over.id);
+      if (
+        draggedId !== targetId &&
+        !isDescendant(state.nodes, draggedId, targetId)
+      ) {
+        dispatch({ id: draggedId, newParentId: targetId, type: "REPARENT" });
+      }
+    }
+    dispatch({ id: null, type: "SET_DRAGGING" });
+    setActiveId(null);
+  }
+
+  function handleDragCancel() {
+    dispatch({ id: null, type: "SET_DRAGGING" });
+    setActiveId(null);
+  }
+
+  const activeNode = activeId ? state.nodes[activeId] : null;
+
   return (
-    <div
-      ref={containerRef}
-      className="w-full h-full cursor-grab active:cursor-grabbing canvas-grid relative overflow-hidden bg-slate-50 dark:bg-slate-900"
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
-      <ConnectionLines containerRef={containerRef} />
       <div
-        className="transform-container absolute w-px h-px top-1/2 left-1/2"
-        style={{
-          transform: `translate(${state.view.pan.x}px, ${state.view.pan.y}px) scale(${state.view.zoom})`,
-        }}
+        ref={containerRef}
+        className="w-full h-full cursor-grab active:cursor-grabbing canvas-grid relative overflow-hidden bg-slate-50 dark:bg-slate-900"
       >
-        {visibleNodes.map((n) => (
-          <NodeCard key={n.id} node={n} />
-        ))}
+        <ConnectionLines containerRef={containerRef} />
+        <div
+          className="transform-container absolute w-px h-px top-1/2 left-1/2"
+          style={{
+            transform: `translate(${state.view.pan.x}px, ${state.view.pan.y}px) scale(${state.view.zoom})`,
+          }}
+        >
+          {visibleNodes.map((n) => (
+            <NodeCard key={n.id} node={n} />
+          ))}
+        </div>
       </div>
-    </div>
+      <DragOverlay>
+        {activeNode && !activeNode.isRoot ? <NodeCardPreview node={activeNode} /> : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/packages/mintodo/src/components/DueBadge.test.tsx
+++ b/packages/mintodo/src/components/DueBadge.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DueBadge } from "./DueBadge";
+
+describe("DueBadge", () => {
+  it("renders nothing for kind none", () => {
+    const { container } = render(<DueBadge due={{ kind: "none", daysFromNow: 0 }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders 超過 for overdue", () => {
+    const { container } = render(<DueBadge due={{ kind: "overdue", daysFromNow: -3 }} />);
+    expect(container.textContent).toContain("超過");
+  });
+
+  it("renders 今日 for today with pulse animation class", () => {
+    const { container } = render(<DueBadge due={{ kind: "today", daysFromNow: 0 }} />);
+    expect(container.textContent).toContain("今日");
+    expect((container.firstChild as HTMLElement).className).toContain("animate-pulse");
+  });
+
+  it("renders あと N 日 for future", () => {
+    const { container } = render(<DueBadge due={{ kind: "future", daysFromNow: 5 }} />);
+    expect(container.textContent).toBe("あと 5 日");
+  });
+});

--- a/packages/mintodo/src/components/DueBadge.tsx
+++ b/packages/mintodo/src/components/DueBadge.tsx
@@ -1,0 +1,30 @@
+import type { DueBadgeInfo } from "../lib/badges";
+
+interface Props {
+  due: DueBadgeInfo;
+}
+
+export function DueBadge({ due }: Props) {
+  if (due.kind === "none") return null;
+  if (due.kind === "overdue") {
+    return (
+      <span className="bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md inline-flex items-center gap-1 shrink-0 border border-rose-200 dark:border-rose-900/30">
+        <span>⚠</span>
+        超過
+      </span>
+    );
+  }
+  if (due.kind === "today") {
+    return (
+      <span className="bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md inline-flex items-center gap-1 shrink-0 border border-amber-200 dark:border-amber-900/30 animate-pulse">
+        <span>🔔</span>
+        今日
+      </span>
+    );
+  }
+  return (
+    <span className="bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 text-[10px] font-medium px-1.5 py-0.5 rounded-md shrink-0">
+      あと {due.daysFromNow} 日
+    </span>
+  );
+}

--- a/packages/mintodo/src/components/KanbanBoard.tsx
+++ b/packages/mintodo/src/components/KanbanBoard.tsx
@@ -25,9 +25,7 @@ export function KanbanBoard() {
   const { dispatch, state } = useMindStore();
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   function handleDragStart(event: { active: { id: string | number } }) {
     const id = String(event.active.id);
@@ -35,7 +33,10 @@ export function KanbanBoard() {
     dispatch({ id, type: "SET_DRAGGING" });
   }
 
-  function handleDragEnd(event: { active: { id: string | number }; over?: { id: string | number } | null }) {
+  function handleDragEnd(event: {
+    active: { id: string | number };
+    over?: { id: string | number } | null;
+  }) {
     const { active, over } = event;
     if (over) {
       const overId = String(over.id);
@@ -69,9 +70,7 @@ export function KanbanBoard() {
           ))}
         </div>
       </div>
-      <DragOverlay>
-        {activeNode ? <KanbanCardPreview node={activeNode} /> : null}
-      </DragOverlay>
+      <DragOverlay>{activeNode ? <KanbanCardPreview node={activeNode} /> : null}</DragOverlay>
     </DndContext>
   );
 }

--- a/packages/mintodo/src/components/KanbanBoard.tsx
+++ b/packages/mintodo/src/components/KanbanBoard.tsx
@@ -1,14 +1,77 @@
-import { TASK_STATUSES } from "../types";
+import { useState } from "react";
+import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { TASK_STATUSES, type TaskStatus, type MindNode } from "../types";
+import { useMindStore } from "../hooks/use-mind-store";
 import { KanbanColumn } from "./KanbanColumn";
 
-export function KanbanBoard() {
+function KanbanCardPreview({ node }: { node: MindNode }) {
   return (
-    <div data-testid="kanban-board" className="w-full h-full overflow-x-auto">
-      <div className="flex flex-row gap-4 p-4 min-h-full">
-        {TASK_STATUSES.map((status) => (
-          <KanbanColumn key={status} status={status} />
-        ))}
-      </div>
+    <div
+      className="rounded border p-3 cursor-grabbing"
+      style={{
+        background: "var(--paper)",
+        borderColor: "var(--border)",
+        color: "var(--ink)",
+        boxShadow: "0 10px 25px rgba(0,0,0,0.2), 0 4px 10px rgba(0,0,0,0.1)",
+        width: "288px",
+      }}
+    >
+      <span className="truncate text-sm font-medium">{node.text}</span>
     </div>
+  );
+}
+
+export function KanbanBoard() {
+  const { dispatch, state } = useMindStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  function handleDragStart(event: { active: { id: string | number } }) {
+    const id = String(event.active.id);
+    setActiveId(id);
+    dispatch({ id, type: "SET_DRAGGING" });
+  }
+
+  function handleDragEnd(event: { active: { id: string | number }; over?: { id: string | number } | null }) {
+    const { active, over } = event;
+    if (over) {
+      const overId = String(over.id);
+      const taskStatuses: readonly string[] = TASK_STATUSES;
+      if (taskStatuses.includes(overId)) {
+        dispatch({ id: String(active.id), status: overId as TaskStatus, type: "SET_STATUS" });
+      }
+    }
+    dispatch({ id: null, type: "SET_DRAGGING" });
+    setActiveId(null);
+  }
+
+  function handleDragCancel() {
+    dispatch({ id: null, type: "SET_DRAGGING" });
+    setActiveId(null);
+  }
+
+  const activeNode = activeId ? state.nodes[activeId] : null;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div data-testid="kanban-board" className="w-full h-full overflow-x-auto">
+        <div className="flex flex-row gap-4 p-4 min-h-full">
+          {TASK_STATUSES.map((status) => (
+            <KanbanColumn key={status} status={status} />
+          ))}
+        </div>
+      </div>
+      <DragOverlay>
+        {activeNode ? <KanbanCardPreview node={activeNode} /> : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/packages/mintodo/src/components/KanbanCard.test.tsx
+++ b/packages/mintodo/src/components/KanbanCard.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { KanbanCard } from "./KanbanCard";
-import { MindProvider } from "../hooks/use-mind-store";
+import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import { createInitialState, type State } from "../store";
 import type { MindNode } from "../types";
 
@@ -43,6 +43,43 @@ function renderCard(node: MindNode, others: MindNode[] = []) {
   );
 }
 
+let captured: State | null = null;
+function Capture() {
+  captured = useMindStore().state;
+  return null;
+}
+
+describe("KanbanCard multi-line text", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders multi-line text with whitespace-pre-wrap and max-w-[240px]", () => {
+    const multiline = "first line\nsecond line wraps to a longer one";
+    const n = node({
+      id: "n1",
+      boardId: "b",
+      parentId: "root",
+      text: multiline,
+    });
+    const root = node({
+      id: "root",
+      boardId: "b",
+      parentId: null,
+      isRoot: true,
+    });
+    renderCard(n, [root]);
+    const card = screen.getByTestId("kanban-card-n1");
+    const textSpan = card.querySelector("span.whitespace-pre-wrap") as HTMLElement;
+    expect(textSpan).toBeTruthy();
+    expect(textSpan.className).toContain("whitespace-pre-wrap");
+    expect(textSpan.className).toContain("break-words");
+    expect(textSpan.className).toContain("max-w-[240px]");
+    expect(textSpan.className).not.toContain("truncate");
+    expect(textSpan.textContent).toBe(multiline);
+  });
+});
+
 describe("KanbanCard", () => {
   it("renders the node text", () => {
     renderCard(node({ id: "n1", boardId: "b", parentId: "root", text: "Buy milk" }));
@@ -60,13 +97,17 @@ describe("KanbanCard", () => {
     expect(card.textContent).toMatch(/Task/u);
   });
 
-  it("'+' button opens edit-new modal with the card as parent", () => {
+  it("'+' button (inside TaskCard) opens edit-new modal with the card as parent", () => {
     const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true });
     const n = node({ id: "n1", boardId: "b", parentId: "root" });
-    renderCard(n, [root]);
-    fireEvent.click(screen.getByTestId("kanban-add-child-n1"));
-    const modal = screen.getByTestId("kanban-card-n1").ownerDocument.defaultView as Window;
-    void modal;
+    render(
+      <MindProvider initialState={makeState([root, n])}>
+        <Capture />
+        <KanbanCard node={n} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("add-child-n1"));
+    expect(captured!.modal).toEqual({ kind: "edit-new", parentId: "n1" });
   });
 
   it("has dnd-kit draggable attributes", () => {
@@ -75,5 +116,19 @@ describe("KanbanCard", () => {
     renderCard(n, [root]);
     const card = screen.getByTestId("kanban-card-n1");
     expect(card.getAttribute("role")).toBe("button");
+  });
+
+  it("clicking the card body opens the edit modal", () => {
+    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true });
+    const n1 = node({ id: "n1", boardId: "b", parentId: "root" });
+    const state = makeState([root, n1]);
+    render(
+      <MindProvider initialState={state}>
+        <Capture />
+        <KanbanCard node={state.nodes.n1} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("kanban-card-n1"));
+    expect(captured!.modal).toEqual({ kind: "edit", nodeId: "n1" });
   });
 });

--- a/packages/mintodo/src/components/KanbanCard.test.tsx
+++ b/packages/mintodo/src/components/KanbanCard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { KanbanCard } from "./KanbanCard";
 import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import { createInitialState, type State } from "../store";

--- a/packages/mintodo/src/components/KanbanCard.test.tsx
+++ b/packages/mintodo/src/components/KanbanCard.test.tsx
@@ -1,28 +1,9 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { KanbanCard } from "./KanbanCard";
-import { MindProvider, useMindStore } from "../hooks/use-mind-store";
+import { MindProvider } from "../hooks/use-mind-store";
 import { createInitialState, type State } from "../store";
 import type { MindNode } from "../types";
-
-// Jsdom doesn't implement DataTransfer
-class MockDataTransfer {
-  private data = new Map<string, string>();
-  public types: string[] = [];
-  public effectAllowed = "move";
-  public dropEffect = "move";
-
-  public setData(format: string, data: string): void {
-    this.data.set(format, data);
-    if (!this.types.includes(format)) {
-      this.types.push(format);
-    }
-  }
-
-  public getData(format: string): string {
-    return this.data.get(format) ?? "";
-  }
-}
 
 function node(
   opts: Partial<MindNode> & { id: string; boardId: string; parentId: string | null },
@@ -58,14 +39,8 @@ function renderCard(node: MindNode, others: MindNode[] = []) {
   return render(
     <MindProvider initialState={state}>
       <KanbanCard node={node} />
-      <Probe />
     </MindProvider>,
   );
-}
-
-function Probe() {
-  const { state } = useMindStore();
-  return <span data-testid="dragging">{state.draggingNodeId ?? ""}</span>;
 }
 
 describe("KanbanCard", () => {
@@ -90,21 +65,15 @@ describe("KanbanCard", () => {
     const n = node({ id: "n1", boardId: "b", parentId: "root" });
     renderCard(n, [root]);
     fireEvent.click(screen.getByTestId("kanban-add-child-n1"));
-    // The modal would be visible (rendered by EditModal). Assert through the store:
     const modal = screen.getByTestId("kanban-card-n1").ownerDocument.defaultView as Window;
     void modal;
   });
 
-  it("dragstart sets dataTransfer and dispatches SET_DRAGGING", () => {
+  it("has dnd-kit draggable attributes", () => {
     const n = node({ id: "n1", boardId: "b", parentId: "root" });
     const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true });
     renderCard(n, [root]);
     const card = screen.getByTestId("kanban-card-n1");
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(card, { dataTransfer: dt });
-    });
-    expect(dt.getData("application/x-mindnode-id")).toBe("n1");
-    expect(screen.getByTestId("dragging").textContent).toBe("n1");
+    expect(card.getAttribute("role")).toBe("button");
   });
 });

--- a/packages/mintodo/src/components/KanbanCard.tsx
+++ b/packages/mintodo/src/components/KanbanCard.tsx
@@ -1,9 +1,8 @@
 import { Check, Plus, XCircle } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
 import { categoryDotClass, formatBadges } from "../lib/badges";
 import type { MindNode } from "../types";
-
-const DRAG_MIME = "application/x-mindnode-id";
 
 function buildBreadcrumb(nodes: Record<string, MindNode>, targetId: string): string {
   const path: string[] = [];
@@ -18,20 +17,6 @@ function buildBreadcrumb(nodes: Record<string, MindNode>, targetId: string): str
   return `… / ${path.slice(-2).join(" / ")}`;
 }
 
-function handleDragStart(
-  e: React.DragEvent<HTMLDivElement>,
-  nodeId: string,
-  dispatch: ReturnType<typeof useMindStore>["dispatch"],
-) {
-  e.dataTransfer.setData(DRAG_MIME, nodeId);
-  e.dataTransfer.effectAllowed = "move";
-  dispatch({ id: nodeId, type: "SET_DRAGGING" });
-}
-
-function handleDragEnd(dispatch: ReturnType<typeof useMindStore>["dispatch"]) {
-  dispatch({ id: null, type: "SET_DRAGGING" });
-}
-
 interface Props {
   node: MindNode;
 }
@@ -42,18 +27,21 @@ export function KanbanCard({ node }: Props) {
   const breadcrumb = buildBreadcrumb(state.nodes, node.id);
   const { dueHtml, showHigh, showBadgeRow } = formatBadges(node);
 
+  const { setNodeRef, attributes, listeners, isDragging } = useDraggable({ id: node.id });
+
   return (
     <div
+      ref={setNodeRef}
       data-testid={`kanban-card-${node.id}`}
       data-node-id={node.id}
-      draggable
-      onDragStart={(e) => handleDragStart(e, node.id, dispatch)}
-      onDragEnd={() => handleDragEnd(dispatch)}
+      {...attributes}
+      {...listeners}
       className="rounded border p-3 flex flex-col gap-2 cursor-grab active:cursor-grabbing"
       style={{
         background: "var(--paper)",
         borderColor: "var(--border)",
         color: "var(--ink)",
+        opacity: isDragging ? 0.4 : 1,
       }}
     >
       <div className="text-[10px] truncate" style={{ color: "var(--mid)" }} title={breadcrumb}>

--- a/packages/mintodo/src/components/KanbanCard.tsx
+++ b/packages/mintodo/src/components/KanbanCard.tsx
@@ -1,8 +1,7 @@
-import { Check, Plus, XCircle } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
-import { categoryDotClass, formatBadges } from "../lib/badges";
 import type { MindNode } from "../types";
+import { TaskCard } from "./TaskCard";
 
 function buildBreadcrumb(nodes: Record<string, MindNode>, targetId: string): string {
   const path: string[] = [];
@@ -23,9 +22,7 @@ interface Props {
 
 export function KanbanCard({ node }: Props) {
   const { dispatch, state } = useMindStore();
-  const isDone = node.status === "done" || node.completed;
   const breadcrumb = buildBreadcrumb(state.nodes, node.id);
-  const { dueHtml, showHigh, showBadgeRow } = formatBadges(node);
 
   const { setNodeRef, attributes, listeners, isDragging } = useDraggable({ id: node.id });
 
@@ -36,6 +33,10 @@ export function KanbanCard({ node }: Props) {
       data-node-id={node.id}
       {...attributes}
       {...listeners}
+      onClick={() => {
+        if (isDragging) return;
+        dispatch({ modal: { kind: "edit", nodeId: node.id }, type: "OPEN_MODAL" });
+      }}
       className="rounded border p-3 flex flex-col gap-2 cursor-grab active:cursor-grabbing"
       style={{
         background: "var(--paper)",
@@ -47,55 +48,7 @@ export function KanbanCard({ node }: Props) {
       <div className="text-[10px] truncate" style={{ color: "var(--mid)" }} title={breadcrumb}>
         {breadcrumb}
       </div>
-      <div className="flex items-start gap-2 min-w-0">
-        <button
-          type="button"
-          data-testid={`kanban-check-${node.id}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            dispatch({ id: node.id, type: "TOGGLE_COMPLETE" });
-          }}
-          className="shrink-0"
-        >
-          {isDone ? (
-            <Check className="text-indigo-500" size={18} />
-          ) : (
-            <XCircle
-              className="text-slate-300 dark:text-slate-600 hover:text-indigo-500"
-              size={18}
-            />
-          )}
-        </button>
-        <span
-          className={`truncate text-sm font-medium flex-1 ${isDone ? "line-through text-slate-400 dark:text-slate-500" : ""}`}
-        >
-          {node.text}
-        </span>
-        <button
-          type="button"
-          data-testid={`kanban-add-child-${node.id}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            dispatch({ modal: { kind: "edit-new", parentId: node.id }, type: "OPEN_MODAL" });
-          }}
-          className="bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-600 dark:text-slate-300 w-6 h-6 rounded-md flex items-center justify-center transition shrink-0"
-        >
-          <Plus size={12} />
-        </button>
-      </div>
-      {showBadgeRow && (
-        <div className="flex items-center justify-between w-full pt-1.5 border-t border-slate-100 dark:border-slate-700/50">
-          <div className="flex items-center gap-1.5">
-            <span dangerouslySetInnerHTML={{ __html: dueHtml }} />
-            {showHigh && (
-              <span className="bg-rose-50 text-rose-500 dark:bg-rose-950/20 text-[10px] font-bold px-1.5 py-0.5 rounded">
-                重要
-              </span>
-            )}
-          </div>
-          <span className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)}`} />
-        </div>
-      )}
+      <TaskCard node={node} />
     </div>
   );
 }

--- a/packages/mintodo/src/components/KanbanColumn.test.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.test.tsx
@@ -1,28 +1,9 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { KanbanColumn } from "./KanbanColumn";
 import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import { createInitialState, type State } from "../store";
 import type { MindNode, TaskStatus } from "../types";
-
-// Jsdom doesn't implement DataTransfer
-class MockDataTransfer {
-  private data = new Map<string, string>();
-  public types: string[] = [];
-  public effectAllowed = "move";
-  public dropEffect = "move";
-
-  public setData(format: string, data: string): void {
-    this.data.set(format, data);
-    if (!this.types.includes(format)) {
-      this.types.push(format);
-    }
-  }
-
-  public getData(format: string): string {
-    return this.data.get(format) ?? "";
-  }
-}
 
 function node(
   opts: Partial<MindNode> & { id: string; boardId: string; parentId: string | null },
@@ -45,12 +26,15 @@ function node(
   };
 }
 
-function Probe() {
-  const { state } = useMindStore();
-  return <span data-testid="probe-status">{state.nodes["n1"]?.status ?? "missing"}</span>;
+let capturedState: State | null = null;
+
+function Capture() {
+  capturedState = useMindStore().state;
+  return null;
 }
 
 function renderColumn(status: TaskStatus, nodes: MindNode[]) {
+  capturedState = null;
   const s: State = {
     ...createInitialState(),
     currentBoardId: "b",
@@ -59,6 +43,7 @@ function renderColumn(status: TaskStatus, nodes: MindNode[]) {
   };
   return render(
     <MindProvider initialState={s}>
+      <Capture />
       <KanbanColumn status={status} />
     </MindProvider>,
   );
@@ -86,30 +71,11 @@ describe("KanbanColumn", () => {
     const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true });
     renderColumn("review", [root]);
     fireEvent.click(screen.getByTestId("kanban-column-add-review"));
-    expect(screen.getByTestId("kanban-column-review")).toBeTruthy();
+    expect(capturedState!.modal).toEqual({
+      kind: "edit-new",
+      parentId: "root",
+      parentStatusSeed: "review",
+    });
   });
 
-  it("drop dispatches SET_STATUS for the column's status", () => {
-    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true });
-    const n1 = node({ id: "n1", boardId: "b", parentId: "root", status: "inbox" });
-    const s: State = {
-      ...createInitialState(),
-      currentBoardId: "b",
-      boards: [{ id: "b", name: "B", createdAt: 0, updatedAt: 0 }],
-      nodes: Object.fromEntries([root, n1].map((n) => [n.id, n])),
-    };
-    render(
-      <MindProvider initialState={s}>
-        <KanbanColumn status="done" />
-        <Probe />
-      </MindProvider>,
-    );
-    const column = screen.getByTestId("kanban-column-done");
-    const dt = new MockDataTransfer();
-    dt.setData("application/x-mindnode-id", "n1");
-    act(() => {
-      fireEvent.drop(column, { dataTransfer: dt as unknown as DataTransfer });
-    });
-    expect(screen.getByTestId("probe-status").textContent).toBe("done");
-  });
 });

--- a/packages/mintodo/src/components/KanbanColumn.test.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.test.tsx
@@ -77,5 +77,4 @@ describe("KanbanColumn", () => {
       parentStatusSeed: "review",
     });
   });
-
 });

--- a/packages/mintodo/src/components/KanbanColumn.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.tsx
@@ -1,4 +1,5 @@
 import { Plus } from "lucide-react";
+import { useDroppable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
 import { KanbanCard } from "./KanbanCard";
 import type { MindNode, TaskStatus } from "../types";
@@ -9,8 +10,6 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   review: "レビュー",
   done: "完了",
 };
-
-const DRAG_MIME = "application/x-mindnode-id";
 
 interface Props {
   status: TaskStatus;
@@ -29,39 +28,10 @@ function isParentCollapsed(state: ReturnType<typeof useMindStore>["state"], id: 
   return false;
 }
 
-function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
-  if (e.dataTransfer.types.includes(DRAG_MIME)) {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-  }
-}
-
-function handleDragEnter(e: React.DragEvent<HTMLDivElement>) {
-  if (!e.dataTransfer.types.includes(DRAG_MIME)) return;
-  if (e.currentTarget.contains(e.relatedTarget as Node)) return;
-  e.currentTarget.classList.add("ring-2", "ring-sky-400");
-}
-
-function handleDragLeave(e: React.DragEvent<HTMLDivElement>) {
-  if (e.currentTarget.contains(e.relatedTarget as Node)) return;
-  e.currentTarget.classList.remove("ring-2", "ring-sky-400");
-}
-
-function handleDrop(
-  e: React.DragEvent<HTMLDivElement>,
-  status: TaskStatus,
-  dispatch: ReturnType<typeof useMindStore>["dispatch"],
-) {
-  e.preventDefault();
-  e.currentTarget.classList.remove("ring-2", "ring-sky-400");
-  const id = e.dataTransfer.getData(DRAG_MIME);
-  if (!id) return;
-  dispatch({ id, status, type: "SET_STATUS" });
-  dispatch({ id: null, type: "SET_DRAGGING" });
-}
-
 export function KanbanColumn({ status }: Props) {
   const { dispatch, state } = useMindStore();
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+
   const cards = Object.values(state.nodes).filter(
     (n) =>
       n.boardId === state.currentBoardId &&
@@ -72,13 +42,10 @@ export function KanbanColumn({ status }: Props) {
 
   return (
     <div
+      ref={setNodeRef}
       data-testid={`kanban-column-${status}`}
-      className="w-72 shrink-0 flex flex-col gap-2 rounded p-3"
+      className={`w-72 shrink-0 flex flex-col gap-2 rounded p-3 ${isOver ? "ring-2 ring-sky-400" : ""}`}
       style={{ background: "var(--toolbar-bg)", border: "1px solid var(--border)" }}
-      onDragOver={handleDragOver}
-      onDragEnter={handleDragEnter}
-      onDragLeave={handleDragLeave}
-      onDrop={(e) => handleDrop(e, status, dispatch)}
     >
       <div className="flex items-center justify-between mb-1">
         <h3 className="text-sm font-semibold" style={{ color: "var(--ink)" }}>

--- a/packages/mintodo/src/components/NodeCard.test.tsx
+++ b/packages/mintodo/src/components/NodeCard.test.tsx
@@ -1,6 +1,13 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { DndContext, PointerSensor, useSensor, useSensors, type UniqueIdentifier, type DroppableContainer } from "@dnd-kit/core";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type UniqueIdentifier,
+  type DroppableContainer,
+} from "@dnd-kit/core";
 import { NodeCard } from "./NodeCard";
 import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import type { State } from "../store";
@@ -54,11 +61,15 @@ function Capture() {
   return null;
 }
 
-function TestDndProvider({ children, nodeMap }: { children: React.ReactNode; nodeMap: Record<string, MindNode> }) {
+function TestDndProvider({
+  children,
+  nodeMap,
+}: {
+  children: React.ReactNode;
+  nodeMap: Record<string, MindNode>;
+}) {
   const { dispatch } = useMindStore();
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
   // Build collision rects from state node positions (viewport coords)
   const rectMap = new Map<string, { top: number; left: number; width: number; height: number }>();
   for (const n of Object.values(nodeMap)) {
@@ -66,18 +77,24 @@ function TestDndProvider({ children, nodeMap }: { children: React.ReactNode; nod
     const h = 80;
     rectMap.set(n.id, { left: n.x, top: n.y, width: w, height: h });
   }
-  const collisionDetection = (args: { active?: { id: UniqueIdentifier }; droppableContainers: DroppableContainer[]; pointerCoordinates: { x: number; y: number } | null }) => {
+  const collisionDetection = (args: {
+    active?: { id: UniqueIdentifier };
+    droppableContainers: DroppableContainer[];
+    pointerCoordinates: { x: number; y: number } | null;
+  }) => {
     if (!args.pointerCoordinates) return [];
     const activeId = args.active ? String(args.active.id) : null;
     const px = args.pointerCoordinates.x;
     const py = args.pointerCoordinates.y;
-    return args.droppableContainers.filter((c) => {
-      // Exclude the active (dragged) node so a non-active target at the same position is selected
-      if (activeId && String(c.id) === activeId) return false;
-      const r = rectMap.get(String(c.id));
-      if (!r) return false;
-      return px >= r.left && px <= r.left + r.width && py >= r.top && py <= r.top + r.height;
-    }).map((c) => ({ id: c.id, data: { droppableContainer: c } }));
+    return args.droppableContainers
+      .filter((c) => {
+        // Exclude the active (dragged) node so a non-active target at the same position is selected
+        if (activeId && String(c.id) === activeId) return false;
+        const r = rectMap.get(String(c.id));
+        if (!r) return false;
+        return px >= r.left && px <= r.left + r.width && py >= r.top && py <= r.top + r.height;
+      })
+      .map((c) => ({ id: c.id, data: { droppableContainer: c } }));
   };
   return (
     <DndContext
@@ -112,28 +129,57 @@ function dragFromTo(source: HTMLElement, target: HTMLElement) {
   const doc = source.ownerDocument;
   act(() => {
     fireEvent.pointerDown(source, {
-      pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
-      clientX: fromX, clientY: fromY,
+      pointerId: 1,
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+      buttons: 1,
+      clientX: fromX,
+      clientY: fromY,
     });
   });
   // Dispatch subsequent pointer events on document where dnd-kit's native listeners are attached
   act(() => {
-    doc.dispatchEvent(new PointerEvent("pointermove", {
-      pointerId: 1, pointerType: "mouse", isPrimary: true,
-      clientX: fromX + 10, clientY: fromY + 10, buttons: 1, bubbles: true, cancelable: true,
-    }));
+    doc.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: fromX + 10,
+        clientY: fromY + 10,
+        buttons: 1,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
   });
   act(() => {
-    doc.dispatchEvent(new PointerEvent("pointermove", {
-      pointerId: 1, pointerType: "mouse", isPrimary: true,
-      clientX: toX, clientY: toY, buttons: 1, bubbles: true, cancelable: true,
-    }));
+    doc.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: toX,
+        clientY: toY,
+        buttons: 1,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
   });
   act(() => {
-    doc.dispatchEvent(new PointerEvent("pointerup", {
-      pointerId: 1, pointerType: "mouse", isPrimary: true,
-      clientX: toX, clientY: toY, button: 0, bubbles: true, cancelable: true,
-    }));
+    doc.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: toX,
+        clientY: toY,
+        button: 0,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
   });
 }
 
@@ -197,21 +243,34 @@ describe("NodeCard drag-and-drop", () => {
     const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
     act(() => {
       fireEvent.pointerDown(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
-        clientX: 0, clientY: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: 0,
+        clientY: 0,
       });
     });
     act(() => {
       fireEvent.pointerMove(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 10, clientY: 10, buttons: 1,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 10,
+        clientY: 10,
+        buttons: 1,
       });
     });
     expect(capturedState!.draggingNodeId).toBe("a");
     act(() => {
       fireEvent.pointerUp(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 10, clientY: 10, button: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 10,
+        clientY: 10,
+        button: 0,
       });
     });
   });
@@ -288,16 +347,29 @@ describe("NodeCard drag-and-drop", () => {
     const doc = a.ownerDocument;
     act(() => {
       fireEvent.pointerDown(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
-        clientX: 120, clientY: 40,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: 120,
+        clientY: 40,
       });
     });
     // Activate the drag
     act(() => {
-      doc.dispatchEvent(new PointerEvent("pointermove", {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 130, clientY: 50, buttons: 1, bubbles: true, cancelable: true,
-      }));
+      doc.dispatchEvent(
+        new PointerEvent("pointermove", {
+          pointerId: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+          clientX: 130,
+          clientY: 50,
+          buttons: 1,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
     });
     // Now the drag is active; check ring appears on target
     // (collision runs and finds b as over since a is excluded)
@@ -305,10 +377,18 @@ describe("NodeCard drag-and-drop", () => {
     expect(b.className).toContain("ring-sky-400");
     // End the drag
     act(() => {
-      doc.dispatchEvent(new PointerEvent("pointerup", {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 120, clientY: 40, button: 0, bubbles: true, cancelable: true,
-      }));
+      doc.dispatchEvent(
+        new PointerEvent("pointerup", {
+          pointerId: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+          clientX: 120,
+          clientY: 40,
+          button: 0,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
     });
   });
 
@@ -317,27 +397,44 @@ describe("NodeCard drag-and-drop", () => {
     const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
     act(() => {
       fireEvent.pointerDown(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
-        clientX: 0, clientY: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: 0,
+        clientY: 0,
       });
     });
     act(() => {
       fireEvent.pointerMove(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 10, clientY: 10, buttons: 1,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 10,
+        clientY: 10,
+        buttons: 1,
       });
     });
     act(() => {
       fireEvent.pointerMove(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 20, clientY: 20, buttons: 1,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 20,
+        clientY: 20,
+        buttons: 1,
       });
     });
     expect(a.className).not.toContain("ring-2");
     act(() => {
       fireEvent.pointerUp(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 20, clientY: 20, button: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 20,
+        clientY: 20,
+        button: 0,
       });
     });
   });
@@ -348,27 +445,44 @@ describe("NodeCard drag-and-drop", () => {
     const a1 = container.querySelector('[data-node-id="a1"]') as HTMLElement;
     act(() => {
       fireEvent.pointerDown(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
-        clientX: 0, clientY: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: 0,
+        clientY: 0,
       });
     });
     act(() => {
       fireEvent.pointerMove(a, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 10, clientY: 10, buttons: 1,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 10,
+        clientY: 10,
+        buttons: 1,
       });
     });
     act(() => {
       fireEvent.pointerMove(a1, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 0, clientY: -340, buttons: 1,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 0,
+        clientY: -340,
+        buttons: 1,
       });
     });
     expect(a1.className).not.toContain("ring-2");
     act(() => {
       fireEvent.pointerUp(a1, {
-        pointerId: 1, pointerType: "mouse", isPrimary: true,
-        clientX: 0, clientY: -340, button: 0,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+        clientX: 0,
+        clientY: -340,
+        button: 0,
       });
     });
   });

--- a/packages/mintodo/src/components/NodeCard.test.tsx
+++ b/packages/mintodo/src/components/NodeCard.test.tsx
@@ -1,28 +1,10 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { DndContext, PointerSensor, useSensor, useSensors, type UniqueIdentifier, type DroppableContainer } from "@dnd-kit/core";
 import { NodeCard } from "./NodeCard";
 import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import type { State } from "../store";
 import type { MindNode } from "../types";
-
-// Jsdom doesn't implement DataTransfer
-class MockDataTransfer {
-  private data = new Map<string, string>();
-  public types: string[] = [];
-  public effectAllowed = "move";
-  public dropEffect = "move";
-
-  public setData(format: string, data: string): void {
-    this.data.set(format, data);
-    if (!this.types.includes(format)) {
-      this.types.push(format);
-    }
-  }
-
-  public getData(format: string): string {
-    return this.data.get(format) ?? "";
-  }
-}
 
 function makeNode(id: string, parentId: string | null, opts: Partial<MindNode> = {}): MindNode {
   return {
@@ -72,15 +54,100 @@ function Capture() {
   return null;
 }
 
+function TestDndProvider({ children, nodeMap }: { children: React.ReactNode; nodeMap: Record<string, MindNode> }) {
+  const { dispatch } = useMindStore();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+  // Build collision rects from state node positions (viewport coords)
+  const rectMap = new Map<string, { top: number; left: number; width: number; height: number }>();
+  for (const n of Object.values(nodeMap)) {
+    const w = 240;
+    const h = 80;
+    rectMap.set(n.id, { left: n.x, top: n.y, width: w, height: h });
+  }
+  const collisionDetection = (args: { active?: { id: UniqueIdentifier }; droppableContainers: DroppableContainer[]; pointerCoordinates: { x: number; y: number } | null }) => {
+    if (!args.pointerCoordinates) return [];
+    const activeId = args.active ? String(args.active.id) : null;
+    const px = args.pointerCoordinates.x;
+    const py = args.pointerCoordinates.y;
+    return args.droppableContainers.filter((c) => {
+      // Exclude the active (dragged) node so a non-active target at the same position is selected
+      if (activeId && String(c.id) === activeId) return false;
+      const r = rectMap.get(String(c.id));
+      if (!r) return false;
+      return px >= r.left && px <= r.left + r.width && py >= r.top && py <= r.top + r.height;
+    }).map((c) => ({ id: c.id, data: { droppableContainer: c } }));
+  };
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={collisionDetection}
+      onDragStart={(event) => {
+        dispatch({ id: String(event.active.id), type: "SET_DRAGGING" });
+      }}
+      onDragEnd={(event) => {
+        const { active, over } = event;
+        if (over) {
+          dispatch({ id: String(active.id), newParentId: String(over.id), type: "REPARENT" });
+        }
+        dispatch({ id: null, type: "SET_DRAGGING" });
+      }}
+      onDragCancel={() => {
+        dispatch({ id: null, type: "SET_DRAGGING" });
+      }}
+    >
+      {children}
+    </DndContext>
+  );
+}
+
+function dragFromTo(source: HTMLElement, target: HTMLElement) {
+  const srcRect = source.getBoundingClientRect();
+  const tgtRect = target.getBoundingClientRect();
+  const fromX = srcRect.left + srcRect.width / 2;
+  const fromY = srcRect.top + srcRect.height / 2;
+  const toX = tgtRect.left + tgtRect.width / 2;
+  const toY = tgtRect.top + tgtRect.height / 2;
+  const doc = source.ownerDocument;
+  act(() => {
+    fireEvent.pointerDown(source, {
+      pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
+      clientX: fromX, clientY: fromY,
+    });
+  });
+  // Dispatch subsequent pointer events on document where dnd-kit's native listeners are attached
+  act(() => {
+    doc.dispatchEvent(new PointerEvent("pointermove", {
+      pointerId: 1, pointerType: "mouse", isPrimary: true,
+      clientX: fromX + 10, clientY: fromY + 10, buttons: 1, bubbles: true, cancelable: true,
+    }));
+  });
+  act(() => {
+    doc.dispatchEvent(new PointerEvent("pointermove", {
+      pointerId: 1, pointerType: "mouse", isPrimary: true,
+      clientX: toX, clientY: toY, buttons: 1, bubbles: true, cancelable: true,
+    }));
+  });
+  act(() => {
+    doc.dispatchEvent(new PointerEvent("pointerup", {
+      pointerId: 1, pointerType: "mouse", isPrimary: true,
+      clientX: toX, clientY: toY, button: 0, bubbles: true, cancelable: true,
+    }));
+  });
+}
+
 function setup(overrides?: Partial<State>) {
   const s = { ...makeState(), ...overrides };
   capturedState = null;
   return render(
     <MindProvider initialState={s}>
-      <Capture />
-      {Object.values(s.nodes).map((n: MindNode) => (
-        <NodeCard key={n.id} node={n} />
-      ))}
+      <TestDndProvider nodeMap={s.nodes}>
+        <Capture />
+        {Object.values(s.nodes).map((n: MindNode) => (
+          <NodeCard key={n.id} node={n} />
+        ))}
+      </TestDndProvider>
     </MindProvider>,
   );
 }
@@ -114,197 +181,210 @@ describe("NodeCard drag-and-drop", () => {
     document.body.innerHTML = "";
   });
 
-  it("non-root nodes are draggable, root is not", () => {
+  it("non-root nodes have dnd-kit draggable attributes, root does not", () => {
     const { container } = setup();
     const rootEl = container.querySelector('[data-node-id="root"]') as HTMLElement;
     const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    expect(rootEl.draggable).toBe(false);
-    expect(childEl.draggable).toBe(true);
+    expect(rootEl).toBeTruthy();
+    expect(childEl).toBeTruthy();
+    expect(childEl.getAttribute("role")).toBe("button");
+    expect(rootEl.getAttribute("role")).not.toBe("button");
+    expect(rootEl.getAttribute("tabindex")).toBeNull();
   });
 
   it("dragstart sets draggingNodeId in state", () => {
     const { container } = setup();
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
     act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
+      fireEvent.pointerDown(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
+        clientX: 0, clientY: 0,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 10, clientY: 10, buttons: 1,
+      });
     });
     expect(capturedState!.draggingNodeId).toBe("a");
+    act(() => {
+      fireEvent.pointerUp(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 10, clientY: 10, button: 0,
+      });
+    });
   });
 
   it("dragend clears draggingNodeId", () => {
-    const { container } = setup();
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
-    });
-    act(() => {
-      fireEvent.dragEnd(childEl, { dataTransfer: dt });
-    });
-    expect(capturedState!.draggingNodeId).toBeNull();
-  });
-
-  it("drop on a valid target dispatches REPARENT", () => {
-    const s: State = {
-      ...makeState(),
+    const { container } = setup({
       nodes: {
         root: makeNode("root", null, { isRoot: true, children: ["a", "b"] }),
         a: makeNode("a", "root"),
         b: makeNode("b", "root"),
       },
-    };
-    const { container } = render(
-      <MindProvider initialState={s}>
-        <Capture />
-        {Object.values(s.nodes).map((n: MindNode) => (
-          <NodeCard key={n.id} node={n} />
-        ))}
-      </MindProvider>,
-    );
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const targetEl = container.querySelector('[data-node-id="b"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
     });
-    act(() => {
-      fireEvent.drop(targetEl, { dataTransfer: dt });
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const b = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    dragFromTo(a, b);
+    expect(capturedState!.draggingNodeId).toBeNull();
+  });
+
+  it("drop on a valid target dispatches REPARENT", () => {
+    const { container } = setup({
+      nodes: {
+        root: makeNode("root", null, { isRoot: true, children: ["a", "b"], x: -9999, y: -9999 }),
+        a: makeNode("a", "root", { x: 0, y: 0 }),
+        b: makeNode("b", "root", { x: 0, y: 0 }),
+      },
     });
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const b = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    dragFromTo(a, b);
     expect(capturedState!.nodes.a.parentId).toBe("b");
     expect(capturedState!.nodes.b.children).toContain("a");
   });
 
   it("drop on self does nothing", () => {
     const { container } = setup();
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
-    });
-    act(() => {
-      fireEvent.drop(childEl, { dataTransfer: dt });
-    });
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    dragFromTo(a, a);
     expect(capturedState!.nodes.a.parentId).toBe("root");
   });
 
   it("drop on a descendant does nothing", () => {
     const { container } = setup();
-    const parentEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const childEl = container.querySelector('[data-node-id="a1"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(parentEl, { dataTransfer: dt });
-    });
-    act(() => {
-      fireEvent.drop(childEl, { dataTransfer: dt });
-    });
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const a1 = container.querySelector('[data-node-id="a1"]') as HTMLElement;
+    dragFromTo(a, a1);
     expect(capturedState!.nodes.a.parentId).toBe("root");
   });
 
   it("reparent to root works", () => {
-    const s: State = {
-      ...makeState(),
+    const { container } = setup({
       nodes: {
         root: makeNode("root", null, { isRoot: true, children: ["a"] }),
         a: makeNode("a", "root", { children: ["b"] }),
         b: makeNode("b", "a"),
       },
-    };
-    const { container } = render(
-      <MindProvider initialState={s}>
-        <Capture />
-        {Object.values(s.nodes).map((n: MindNode) => (
-          <NodeCard key={n.id} node={n} />
-        ))}
-      </MindProvider>,
-    );
-    const childEl = container.querySelector('[data-node-id="b"]') as HTMLElement;
-    const rootEl = container.querySelector('[data-node-id="root"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
     });
-    act(() => {
-      fireEvent.drop(rootEl, { dataTransfer: dt });
-    });
+    const b = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    const root = container.querySelector('[data-node-id="root"]') as HTMLElement;
+    dragFromTo(b, root);
     expect(capturedState!.nodes.b.parentId).toBe("root");
     expect(capturedState!.nodes.root.children).toContain("b");
   });
 
-  it("dragenter adds highlight class, dragleave removes it", () => {
-    const s: State = {
-      ...makeState(),
+  it("dragenter adds ring-2 ring-sky-400 class to valid target", () => {
+    const { container } = setup({
       nodes: {
-        root: makeNode("root", null, { isRoot: true, children: ["a", "b"] }),
-        a: makeNode("a", "root"),
-        b: makeNode("b", "root"),
+        root: makeNode("root", null, { isRoot: true, children: ["a", "b"], x: -9999, y: -9999 }),
+        a: makeNode("a", "root", { x: 0, y: 0 }),
+        b: makeNode("b", "root", { x: 0, y: 0 }),
       },
-    };
-    const { container } = render(
-      <MindProvider initialState={s}>
-        <Capture />
-        {Object.values(s.nodes).map((n: MindNode) => (
-          <NodeCard key={n.id} node={n} />
-        ))}
-      </MindProvider>,
-    );
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const targetEl = container.querySelector('[data-node-id="b"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
     });
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const b = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    const doc = a.ownerDocument;
     act(() => {
-      fireEvent.dragEnter(targetEl, { dataTransfer: dt });
+      fireEvent.pointerDown(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
+        clientX: 120, clientY: 40,
+      });
     });
-    expect(targetEl.classList.contains("ring-2")).toBe(true);
-    expect(targetEl.classList.contains("ring-sky-400")).toBe(true);
+    // Activate the drag
     act(() => {
-      fireEvent.dragLeave(targetEl, { dataTransfer: dt });
+      doc.dispatchEvent(new PointerEvent("pointermove", {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 130, clientY: 50, buttons: 1, bubbles: true, cancelable: true,
+      }));
     });
-    expect(targetEl.classList.contains("ring-2")).toBe(false);
-    expect(targetEl.classList.contains("ring-sky-400")).toBe(false);
+    // Now the drag is active; check ring appears on target
+    // (collision runs and finds b as over since a is excluded)
+    expect(b.className).toContain("ring-2");
+    expect(b.className).toContain("ring-sky-400");
+    // End the drag
+    act(() => {
+      doc.dispatchEvent(new PointerEvent("pointerup", {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 120, clientY: 40, button: 0, bubbles: true, cancelable: true,
+      }));
+    });
   });
 
-  it("dragend clears all highlight classes", () => {
-    const s: State = {
-      ...makeState(),
+  it("ring class is not added to dragged node itself", () => {
+    const { container } = setup();
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    act(() => {
+      fireEvent.pointerDown(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
+        clientX: 0, clientY: 0,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 10, clientY: 10, buttons: 1,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 20, clientY: 20, buttons: 1,
+      });
+    });
+    expect(a.className).not.toContain("ring-2");
+    act(() => {
+      fireEvent.pointerUp(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 20, clientY: 20, button: 0,
+      });
+    });
+  });
+
+  it("ring class is not added to descendants of dragged node", () => {
+    const { container } = setup();
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const a1 = container.querySelector('[data-node-id="a1"]') as HTMLElement;
+    act(() => {
+      fireEvent.pointerDown(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0, buttons: 1,
+        clientX: 0, clientY: 0,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(a, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 10, clientY: 10, buttons: 1,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(a1, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 0, clientY: -340, buttons: 1,
+      });
+    });
+    expect(a1.className).not.toContain("ring-2");
+    act(() => {
+      fireEvent.pointerUp(a1, {
+        pointerId: 1, pointerType: "mouse", isPrimary: true,
+        clientX: 0, clientY: -340, button: 0,
+      });
+    });
+  });
+
+  it("dragend clears all ring classes", () => {
+    const { container } = setup({
       nodes: {
-        root: makeNode("root", null, { isRoot: true, children: ["a", "b", "c"] }),
+        root: makeNode("root", null, { isRoot: true, children: ["a", "b"], x: -9999, y: -9999 }),
         a: makeNode("a", "root"),
         b: makeNode("b", "root"),
-        c: makeNode("c", "root"),
       },
-    };
-    const { container } = render(
-      <MindProvider initialState={s}>
-        <Capture />
-        {Object.values(s.nodes).map((n: MindNode) => (
-          <NodeCard key={n.id} node={n} />
-        ))}
-      </MindProvider>,
-    );
-    const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
-    const target1 = container.querySelector('[data-node-id="b"]') as HTMLElement;
-    const target2 = container.querySelector('[data-node-id="c"]') as HTMLElement;
-    const dt = new MockDataTransfer() as unknown as DataTransfer;
-    act(() => {
-      fireEvent.dragStart(childEl, { dataTransfer: dt });
     });
-    act(() => {
-      fireEvent.dragEnter(target1, { dataTransfer: dt });
-    });
-    act(() => {
-      fireEvent.dragEnter(target2, { dataTransfer: dt });
-    });
-    // Both targets should have the highlight
-    expect(target1.classList.contains("ring-2")).toBe(true);
-    expect(target2.classList.contains("ring-2")).toBe(true);
-    act(() => {
-      fireEvent.dragEnd(childEl, { dataTransfer: dt });
-    });
-    expect(target1.classList.contains("ring-2")).toBe(false);
-    expect(target2.classList.contains("ring-2")).toBe(false);
+    const a = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    const b = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    dragFromTo(a, b);
+    expect(b.className).not.toContain("ring-2");
+    expect(b.className).not.toContain("ring-sky-400");
   });
 });

--- a/packages/mintodo/src/components/NodeCard.tsx
+++ b/packages/mintodo/src/components/NodeCard.tsx
@@ -1,76 +1,12 @@
 import { Check, ChevronDown, ChevronUp, EllipsisVertical, Plus, XCircle } from "lucide-react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
 import { isDescendant } from "../store";
 import type { MindNode } from "../types";
 import { categoryBorderColor, categoryDotClass, formatBadges } from "../lib/badges";
 
-const DRAG_MIME = "application/x-mindnode-id";
-
 interface Props {
   node: MindNode;
-}
-
-function handleDragStart(
-  e: React.DragEvent<HTMLDivElement>,
-  nodeId: string,
-  isRoot: boolean,
-  onDispatch: ReturnType<typeof useMindStore>["dispatch"],
-) {
-  if (isRoot) {
-    e.preventDefault();
-    return;
-  }
-  e.dataTransfer.setData(DRAG_MIME, nodeId);
-  e.dataTransfer.effectAllowed = "move";
-  onDispatch({ id: nodeId, type: "SET_DRAGGING" });
-}
-
-function handleDragOver(
-  e: React.DragEvent<HTMLDivElement>,
-  nodeId: string,
-  state: ReturnType<typeof useMindStore>["state"],
-) {
-  const draggedId = state.draggingNodeId;
-  if (!draggedId || draggedId === nodeId) return;
-  if (isDescendant(state.nodes, draggedId, nodeId)) return;
-  e.preventDefault();
-  e.dataTransfer.dropEffect = "move";
-}
-
-function handleDragEnter(
-  e: React.DragEvent<HTMLDivElement>,
-  nodeId: string,
-  state: ReturnType<typeof useMindStore>["state"],
-) {
-  const draggedId = state.draggingNodeId;
-  if (!draggedId || draggedId === nodeId) return;
-  if (isDescendant(state.nodes, draggedId, nodeId)) return;
-  e.currentTarget.classList.add("ring-2", "ring-sky-400");
-}
-
-function handleDragLeave(e: React.DragEvent<HTMLDivElement>) {
-  e.currentTarget.classList.remove("ring-2", "ring-sky-400");
-}
-
-function handleDrop(
-  e: React.DragEvent<HTMLDivElement>,
-  nodeId: string,
-  state: ReturnType<typeof useMindStore>["state"],
-  onDispatch: ReturnType<typeof useMindStore>["dispatch"],
-) {
-  e.preventDefault();
-  e.currentTarget.classList.remove("ring-2", "ring-sky-400");
-  const draggedId = e.dataTransfer.getData(DRAG_MIME);
-  if (!draggedId || draggedId === nodeId) return;
-  if (isDescendant(state.nodes, draggedId, nodeId)) return;
-  onDispatch({ id: draggedId, newParentId: nodeId, type: "REPARENT" });
-}
-
-function handleDragEnd(onDispatch: ReturnType<typeof useMindStore>["dispatch"]) {
-  for (const el of document.querySelectorAll(".ring-2.ring-sky-400")) {
-    el.classList.remove("ring-2", "ring-sky-400");
-  }
-  onDispatch({ id: null, type: "SET_DRAGGING" });
 }
 
 export function NodeCard({ node }: Props) {
@@ -78,19 +14,36 @@ export function NodeCard({ node }: Props) {
   const isSelected = state.selectedNodeId === node.id;
   const isMatch = state.searchQuery === "" || node.text.toLowerCase().includes(state.searchQuery);
 
+  const {
+    setNodeRef: dragRef,
+    attributes,
+    listeners,
+    isDragging,
+  } = useDraggable({ id: node.id, disabled: node.isRoot });
+  const {
+    setNodeRef: dropRef,
+    isOver,
+  } = useDroppable({ id: node.id });
+
+  const setNodeRef = (el: HTMLElement | null) => {
+    dragRef(el);
+    dropRef(el);
+  };
+
+  const draggedId = state.draggingNodeId;
+  const isRingVisible =
+    isOver &&
+    draggedId !== null &&
+    draggedId !== node.id &&
+    !isDescendant(state.nodes, draggedId, node.id);
+
   if (node.isRoot) {
     return (
       <div
+        ref={setNodeRef}
         id={`node-dom-${node.id}`}
         data-node-id={node.id}
-        draggable={!node.isRoot}
-        onDragStart={(e) => handleDragStart(e, node.id, node.isRoot, dispatch)}
-        onDragOver={(e) => handleDragOver(e, node.id, state)}
-        onDragEnter={(e) => handleDragEnter(e, node.id, state)}
-        onDragLeave={handleDragLeave}
-        onDrop={(e) => handleDrop(e, node.id, state, dispatch)}
-        onDragEnd={() => handleDragEnd(dispatch)}
-        className={`absolute -translate-x-1/2 -translate-y-1/2 p-4 rounded flex items-center justify-between gap-3 min-w-[200px] min-h-[60px] max-w-[280px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"}`}
+        className={`absolute -translate-x-1/2 -translate-y-1/2 p-4 rounded flex items-center justify-between gap-3 min-w-[200px] min-h-[60px] max-w-[280px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"} ${isRingVisible ? "ring-2 ring-sky-400" : ""}`}
         style={{
           left: node.x,
           top: node.y,
@@ -124,17 +77,13 @@ export function NodeCard({ node }: Props) {
 
   return (
     <div
+      ref={setNodeRef}
       id={`node-dom-${node.id}`}
       data-node-id={node.id}
-      draggable={!node.isRoot}
-      onDragStart={(e) => handleDragStart(e, node.id, node.isRoot, dispatch)}
-      onDragOver={(e) => handleDragOver(e, node.id, state)}
-      onDragEnter={(e) => handleDragEnter(e, node.id, state)}
-      onDragLeave={handleDragLeave}
-      onDrop={(e) => handleDrop(e, node.id, state, dispatch)}
-      onDragEnd={() => handleDragEnd(dispatch)}
+      {...attributes}
+      {...listeners}
       onClick={() => dispatch({ id: node.id, type: "SELECT" })}
-      className={`absolute -translate-x-1/2 -translate-y-1/2 px-4 py-3 rounded border-l-4 flex flex-col justify-between gap-1.5 min-w-[220px] max-w-[320px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"}`}
+      className={`absolute -translate-x-1/2 -translate-y-1/2 px-4 py-3 rounded border-l-4 flex flex-col justify-between gap-1.5 min-w-[220px] max-w-[320px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"} ${isRingVisible ? "ring-2 ring-sky-400" : ""}`}
       style={{
         left: node.x,
         top: node.y,
@@ -145,6 +94,7 @@ export function NodeCard({ node }: Props) {
         borderBottom: "1px solid var(--border)",
         borderLeft: `4px solid ${borderColor}`,
         boxShadow: priBorder ? "0 0 0 1px var(--terra)" : undefined,
+        opacity: isDragging ? 0.4 : 1,
       }}
     >
       <div className="flex items-start justify-between w-full gap-2">

--- a/packages/mintodo/src/components/NodeCard.tsx
+++ b/packages/mintodo/src/components/NodeCard.tsx
@@ -1,9 +1,10 @@
-import { Check, ChevronDown, ChevronUp, EllipsisVertical, Plus, XCircle } from "lucide-react";
+import { ChevronDown, ChevronUp, EllipsisVertical, Plus } from "lucide-react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
 import { isDescendant } from "../store";
 import type { MindNode } from "../types";
-import { categoryBorderColor, categoryDotClass, formatBadges } from "../lib/badges";
+import { categoryBorderColor } from "../lib/badges";
+import { TaskCard } from "./TaskCard";
 
 interface Props {
   node: MindNode;
@@ -73,7 +74,6 @@ export function NodeCard({ node }: Props) {
 
   const borderColor = categoryBorderColor(node.categoryColor);
   const priBorder = node.priority === "high";
-  const { dueHtml, showHigh, showBadgeRow } = formatBadges(node);
 
   return (
     <div
@@ -83,7 +83,7 @@ export function NodeCard({ node }: Props) {
       {...attributes}
       {...listeners}
       onClick={() => dispatch({ id: node.id, type: "SELECT" })}
-      className={`absolute -translate-x-1/2 -translate-y-1/2 px-4 py-3 rounded border-l-4 flex flex-col justify-between gap-1.5 min-w-[220px] max-w-[320px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"} ${isRingVisible ? "ring-2 ring-sky-400" : ""}`}
+      className={`absolute -translate-x-1/2 -translate-y-1/2 px-4 py-3 rounded border-l-4 flex flex-col gap-1.5 min-w-[220px] max-w-[320px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"} ${isRingVisible ? "ring-2 ring-sky-400" : ""}`}
       style={{
         left: node.x,
         top: node.y,
@@ -98,29 +98,8 @@ export function NodeCard({ node }: Props) {
       }}
     >
       <div className="flex items-start justify-between w-full gap-2">
-        <div className="flex items-start gap-2 flex-1 min-w-0">
-          <button
-            type="button"
-            className="flex items-center justify-center shrink-0 mt-0.5"
-            onClick={(e) => {
-              e.stopPropagation();
-              dispatch({ id: node.id, type: "TOGGLE_COMPLETE" });
-            }}
-          >
-            {node.completed ? (
-              <Check className="text-indigo-500" size={18} />
-            ) : (
-              <XCircle
-                className="text-slate-300 dark:text-slate-600 hover:text-indigo-500"
-                size={18}
-              />
-            )}
-          </button>
-          <span
-            className={`truncate flex-1 text-sm font-medium ${node.completed ? "line-through text-slate-400 dark:text-slate-500" : ""}`}
-          >
-            {node.text}
-          </span>
+        <div className="flex-1 min-w-0">
+          <TaskCard node={node} />
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {node.children.length > 0 && (
@@ -146,31 +125,8 @@ export function NodeCard({ node }: Props) {
           >
             <EllipsisVertical size={12} />
           </button>
-          <button
-            type="button"
-            className="bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-600 dark:text-slate-300 w-6 h-6 rounded-md flex items-center justify-center transition"
-            onClick={(e) => {
-              e.stopPropagation();
-              dispatch({ modal: { kind: "edit-new", parentId: node.id }, type: "OPEN_MODAL" });
-            }}
-          >
-            <Plus size={12} />
-          </button>
         </div>
       </div>
-      {showBadgeRow && (
-        <div className="flex items-center justify-between w-full pt-1.5 border-t border-slate-100 dark:border-slate-700/50">
-          <div className="flex items-center gap-1.5">
-            <span dangerouslySetInnerHTML={{ __html: dueHtml }} />
-            {showHigh && (
-              <span className="bg-rose-50 text-rose-500 dark:bg-rose-950/20 text-[10px] font-bold px-1.5 py-0.5 rounded">
-                重要
-              </span>
-            )}
-          </div>
-          <span className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)}`} />
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/mintodo/src/components/NodeCard.tsx
+++ b/packages/mintodo/src/components/NodeCard.tsx
@@ -21,10 +21,7 @@ export function NodeCard({ node }: Props) {
     listeners,
     isDragging,
   } = useDraggable({ id: node.id, disabled: node.isRoot });
-  const {
-    setNodeRef: dropRef,
-    isOver,
-  } = useDroppable({ id: node.id });
+  const { setNodeRef: dropRef, isOver } = useDroppable({ id: node.id });
 
   const setNodeRef = (el: HTMLElement | null) => {
     dragRef(el);

--- a/packages/mintodo/src/components/StatusDot.test.tsx
+++ b/packages/mintodo/src/components/StatusDot.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatusDot } from "./StatusDot";
+
+describe("StatusDot", () => {
+  it("renders wip with bg-sky-500", () => {
+    render(<StatusDot status="wip" testId="dot" />);
+    const el = screen.getByTestId("dot");
+    expect(el.className).toContain("bg-sky-500");
+    expect(el.className).toContain("rounded-full");
+  });
+
+  it("renders review with bg-amber-500", () => {
+    render(<StatusDot status="review" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-amber-500");
+  });
+
+  it("renders done with bg-emerald-500", () => {
+    render(<StatusDot status="done" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-emerald-500");
+  });
+
+  it("renders inbox with bg-slate-400", () => {
+    render(<StatusDot status="inbox" testId="dot" />);
+    expect(screen.getByTestId("dot").className).toContain("bg-slate-400");
+  });
+
+  it("uses box-shadow ring", () => {
+    const { container } = render(<StatusDot status="wip" />);
+    const el = container.querySelector("span") as HTMLElement;
+    expect(el.style.boxShadow).toContain("var(--paper)");
+    expect(el.style.boxShadow).toContain("var(--mid)");
+  });
+});

--- a/packages/mintodo/src/components/StatusDot.tsx
+++ b/packages/mintodo/src/components/StatusDot.tsx
@@ -15,8 +15,6 @@ export function StatusDot({ status, dimmed = false, testId }: Props) {
       style={{
         boxShadow: "0 0 0 2px var(--paper), 0 0 0 3px var(--mid)",
       }}
-      aria-label={`status: ${status}`}
-      title={`status: ${status}`}
     />
   );
 }

--- a/packages/mintodo/src/components/StatusDot.tsx
+++ b/packages/mintodo/src/components/StatusDot.tsx
@@ -1,0 +1,22 @@
+import { statusDotClass } from "../lib/badges";
+import type { TaskStatus } from "../types";
+
+interface Props {
+  status: TaskStatus;
+  dimmed?: boolean;
+  testId?: string;
+}
+
+export function StatusDot({ status, dimmed = false, testId }: Props) {
+  return (
+    <span
+      data-testid={testId}
+      className={`inline-block w-2.5 h-2.5 rounded-full ${statusDotClass(status)} ${dimmed ? "opacity-40" : ""}`}
+      style={{
+        boxShadow: "0 0 0 2px var(--paper), 0 0 0 3px var(--mid)",
+      }}
+      aria-label={`status: ${status}`}
+      title={`status: ${status}`}
+    />
+  );
+}

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { TaskCard } from "./TaskCard";
 import { MindProvider, useMindStore } from "../hooks/use-mind-store";
 import type { MindNode } from "../types";
@@ -36,11 +36,11 @@ function makeState(over: Partial<State> = {}): State {
     modal: null,
     viewMode: "mindmap",
     searchQuery: "",
-    selectedNodeId: null,
+    selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
     nodes: { root: makeNode({ id: "root", isRoot: true }), n1: makeNode() },
     ...over,
-  } as State;
+  };
 }
 
 let captured: State | null = null;

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TaskCard } from "./TaskCard";
+import { MindProvider, useMindStore } from "../hooks/use-mind-store";
+import type { MindNode } from "../types";
+import type { State } from "../store";
+
+function makeNode(over: Partial<MindNode> = {}): MindNode {
+  return {
+    id: "n1",
+    boardId: "b1",
+    text: "牛乳",
+    parentId: "root",
+    isRoot: false,
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    status: "inbox",
+    children: [],
+    x: 0,
+    y: 0,
+    ...over,
+  };
+}
+
+function makeState(over: Partial<State> = {}): State {
+  return {
+    boards: [],
+    currentBoardId: "b1",
+    draggingNodeId: null,
+    drawerOpen: false,
+    hideCompleted: false,
+    layoutVersion: 0,
+    modal: null,
+    viewMode: "mindmap",
+    searchQuery: "",
+    selectedNodeId: null,
+    view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    nodes: { root: makeNode({ id: "root", isRoot: true }), n1: makeNode() },
+    ...over,
+  } as State;
+}
+
+let captured: State | null = null;
+function Capture() {
+  captured = useMindStore().state;
+  return null;
+}
+
+describe("TaskCard", () => {
+  it("renders text, add-child button, and status dot", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode({ status: "wip" })} />
+      </MindProvider>,
+    );
+    expect(screen.getByText("牛乳")).toBeTruthy();
+    expect(screen.getByTestId("add-child-n1")).toBeTruthy();
+    expect(screen.getByTestId("status-dot-n1").className).toContain("bg-sky-500");
+  });
+
+  it("opens edit-new modal when add-child is clicked", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode()} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("add-child-n1"));
+    expect(captured!.modal).toEqual({ kind: "edit-new", parentId: "n1" });
+  });
+
+  it("toggles complete when checkbox is clicked", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode()} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("task-check-n1"));
+    expect(captured!.nodes.n1.completed).toBe(true);
+  });
+
+  it("renders categoryColor dot alongside status dot", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <TaskCard node={makeNode({ categoryColor: "rose", status: "done" })} />
+      </MindProvider>,
+    );
+    expect(screen.getByTestId("category-dot-n1").className).toContain("bg-rose-400");
+    expect(screen.getByTestId("status-dot-n1").className).toContain("bg-emerald-500");
+  });
+});

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -84,13 +84,25 @@ describe("TaskCard", () => {
     expect(captured!.nodes.n1.completed).toBe(true);
   });
 
-  it("renders categoryColor dot alongside status dot", () => {
-    render(
+  it("uses categoryColor for the hairline and renders the collapsed done dot", () => {
+    const { container } = render(
       <MindProvider initialState={makeState()}>
-        <TaskCard node={makeNode({ categoryColor: "rose", status: "done" })} />
+        <TaskCard node={makeNode({ categoryColor: "rose", status: "done", completed: true })} />
       </MindProvider>,
     );
-    expect(screen.getByTestId("category-dot-n1").className).toContain("bg-rose-400");
-    expect(screen.getByTestId("status-dot-n1").className).toContain("bg-emerald-500");
+    const card = screen.getByTestId("task-card-n1");
+    // Done: DOM is [BodyRow, Hairline]; hairline is at index 1
+    const hairline = card.children[1] as HTMLElement;
+    expect(hairline.style.borderTop).toBe("1px solid rgb(244, 63, 94)");
+    expect(hairline.style.opacity).toBe("0.35");
+    // Collapsed done: an 8px emerald dot inside BodyRow
+    const bodyRow = card.children[0] as HTMLElement;
+    const dot = bodyRow.querySelector("span.rounded-full.bg-emerald-500") as HTMLElement | null;
+    expect(dot).not.toBeNull();
+    // Meta row (and its StatusDot) is absent
+    expect(screen.queryByTestId("status-dot-n1")).toBeNull();
+    // The body uses Crimson Pro for the title
+    const title = container.querySelector("span.whitespace-pre-wrap") as HTMLElement;
+    expect(title.style.fontFamily).toContain("Crimson Pro");
   });
 });

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -84,6 +84,19 @@ describe("TaskCard", () => {
     expect(captured!.nodes.n1.completed).toBe(true);
   });
 
+  it("places the hairline between meta and body in the not-done case", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <TaskCard node={makeNode({ status: "wip", categoryColor: "sky" })} />
+      </MindProvider>,
+    );
+    const card = screen.getByTestId("task-card-n1");
+    // [MetaRow, Hairline, BodyRow] — children[1] is the hairline
+    const hairline = card.children[1] as HTMLElement;
+    expect(hairline.style.borderTop).toBe("1px solid rgb(14, 165, 233)");
+    expect(hairline.style.opacity).toBe("");
+  });
+
   it("uses categoryColor for the hairline and renders the collapsed done dot", () => {
     const { container } = render(
       <MindProvider initialState={makeState()}>

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -1,0 +1,96 @@
+import { Check, GitBranch, XCircle } from "lucide-react";
+import { useMindStore } from "../hooks/use-mind-store";
+import { categoryDotClass, formatBadges, statusDotClass } from "../lib/badges";
+import type { MindNode } from "../types";
+
+interface Props {
+  node: MindNode;
+}
+
+export function TaskCard({ node }: Props) {
+  const { dispatch } = useMindStore();
+  const isDone = node.status === "done" || node.completed;
+  const { dueHtml, showHigh, showBadgeRow } = formatBadges(node);
+
+  return (
+    <div
+      data-testid={`task-card-${node.id}`}
+      data-node-id={node.id}
+      className="flex flex-col gap-1.5 min-w-0"
+    >
+      <div className="flex items-start gap-2 min-w-0">
+        <button
+          type="button"
+          data-testid={`task-check-${node.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            dispatch({ id: node.id, type: "TOGGLE_COMPLETE" });
+          }}
+          className="shrink-0"
+        >
+          {isDone ? (
+            <Check className="text-indigo-500" size={18} />
+          ) : (
+            <XCircle
+              className="text-slate-300 dark:text-slate-600 hover:text-indigo-500"
+              size={18}
+            />
+          )}
+        </button>
+        <span
+          className={`whitespace-pre-wrap break-words max-w-[240px] flex-1 text-sm font-medium ${isDone ? "line-through text-slate-400 dark:text-slate-500" : ""}`}
+        >
+          {node.text}
+        </span>
+        <button
+          type="button"
+          data-testid={`add-child-${node.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            dispatch({ modal: { kind: "edit-new", parentId: node.id }, type: "OPEN_MODAL" });
+          }}
+          className="bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-600 dark:text-slate-300 w-6 h-6 rounded-md flex items-center justify-center transition shrink-0"
+          title="子タスクを追加"
+        >
+          <GitBranch size={12} />
+        </button>
+      </div>
+      {showBadgeRow && (
+        <div className="flex items-center justify-between w-full pt-1.5 border-t border-slate-100 dark:border-slate-700/50">
+          <div className="flex items-center gap-1.5">
+            <span dangerouslySetInnerHTML={{ __html: dueHtml }} />
+            {showHigh && (
+              <span className="bg-rose-50 text-rose-500 dark:bg-rose-950/20 text-[10px] font-bold px-1.5 py-0.5 rounded">
+                重要
+              </span>
+            )}
+            <span
+              data-testid={`status-dot-${node.id}`}
+              className={`w-2 h-2 rounded-full ${statusDotClass(node.status)}`}
+              title={`status: ${node.status}`}
+            />
+          </div>
+          <span
+            data-testid={`category-dot-${node.id}`}
+            className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)}`}
+            title={`category: ${node.categoryColor}`}
+          />
+        </div>
+      )}
+      {!showBadgeRow && (
+        <div className="flex items-center justify-end w-full pt-1">
+          <span
+            data-testid={`status-dot-${node.id}`}
+            className={`w-2 h-2 rounded-full ${statusDotClass(node.status)}`}
+            title={`status: ${node.status}`}
+          />
+          <span
+            data-testid={`category-dot-${node.id}`}
+            className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)} ml-1`}
+            title={`category: ${node.categoryColor}`}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -1,6 +1,9 @@
-import { Check, GitBranch, XCircle } from "lucide-react";
 import { useMindStore } from "../hooks/use-mind-store";
-import { categoryDotClass, formatBadges, statusDotClass } from "../lib/badges";
+import { categoryBorderColor, formatBadges } from "../lib/badges";
+import { DueBadge } from "./DueBadge";
+import { StatusDot } from "./StatusDot";
+import { TaskCheckbox } from "./TaskCheckbox";
+import { priorityClass } from "./priority";
 import type { MindNode } from "../types";
 
 interface Props {
@@ -10,38 +13,49 @@ interface Props {
 export function TaskCard({ node }: Props) {
   const { dispatch } = useMindStore();
   const isDone = node.status === "done" || node.completed;
-  const { dueHtml, showHigh, showBadgeRow } = formatBadges(node);
+  const { due, statusLabel } = formatBadges(node);
+  const hairlineColor = categoryBorderColor(node.categoryColor);
 
-  return (
-    <div
-      data-testid={`task-card-${node.id}`}
-      data-node-id={node.id}
-      className="flex flex-col gap-1.5 min-w-0"
-    >
-      <div className="flex items-start gap-2 min-w-0">
-        <button
-          type="button"
-          data-testid={`task-check-${node.id}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            dispatch({ id: node.id, type: "TOGGLE_COMPLETE" });
-          }}
-          className="shrink-0"
-        >
-          {isDone ? (
-            <Check className="text-indigo-500" size={18} />
-          ) : (
-            <XCircle
-              className="text-slate-300 dark:text-slate-600 hover:text-indigo-500"
-              size={18}
-            />
-          )}
-        </button>
+  const metaRow = isDone ? null : (
+    <div className="flex items-center gap-1.5 min-w-0" style={{ minHeight: "18px" }}>
+      <DueBadge due={due} />
+      <span className="text-[9px] tracking-widest" style={{ color: "var(--mid)" }}>
+        {statusLabel}
+      </span>
+      <span className="ml-auto">
+        <StatusDot status={node.status} testId={`status-dot-${node.id}`} />
+      </span>
+    </div>
+  );
+
+  const bodyRow = (
+    <div className="flex items-start gap-2 min-w-0">
+      {isDone ? null : (
+        <TaskCheckbox
+          isDone={isDone}
+          onToggle={() => dispatch({ id: node.id, type: "TOGGLE_COMPLETE" })}
+          testId={`task-check-${node.id}`}
+        />
+      )}
+      <span
+        className={`whitespace-pre-wrap break-words max-w-[240px] flex-1 text-[15px] leading-[1.3] ${
+          isDone ? "line-through" : ""
+        } ${priorityClass(node.priority)}`}
+        style={{
+          fontFamily: '"Crimson Pro", serif',
+          fontWeight: isDone ? 400 : undefined,
+          color: isDone ? "var(--mid)" : "var(--ink)",
+        }}
+      >
+        {node.text}
+      </span>
+      {isDone ? (
         <span
-          className={`whitespace-pre-wrap break-words max-w-[240px] flex-1 text-sm font-medium ${isDone ? "line-through text-slate-400 dark:text-slate-500" : ""}`}
-        >
-          {node.text}
-        </span>
+          className="w-2 h-2 rounded-full bg-emerald-500 shrink-0 mt-[5px]"
+          aria-label="completed"
+          title="completed"
+        />
+      ) : (
         <button
           type="button"
           data-testid={`add-child-${node.id}`}
@@ -49,48 +63,34 @@ export function TaskCard({ node }: Props) {
             e.stopPropagation();
             dispatch({ modal: { kind: "edit-new", parentId: node.id }, type: "OPEN_MODAL" });
           }}
-          className="bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-600 dark:text-slate-300 w-6 h-6 rounded-md flex items-center justify-center transition shrink-0"
+          className="w-[18px] h-[18px] rounded text-[11px] font-semibold flex items-center justify-center shrink-0"
+          style={{
+            background: "color-mix(in srgb, var(--mid) 12%, transparent)",
+            color: "var(--mid)",
+          }}
           title="子タスクを追加"
         >
-          <GitBranch size={12} />
+          +
         </button>
-      </div>
-      {showBadgeRow && (
-        <div className="flex items-center justify-between w-full pt-1.5 border-t border-slate-100 dark:border-slate-700/50">
-          <div className="flex items-center gap-1.5">
-            <span dangerouslySetInnerHTML={{ __html: dueHtml }} />
-            {showHigh && (
-              <span className="bg-rose-50 text-rose-500 dark:bg-rose-950/20 text-[10px] font-bold px-1.5 py-0.5 rounded">
-                重要
-              </span>
-            )}
-            <span
-              data-testid={`status-dot-${node.id}`}
-              className={`w-2 h-2 rounded-full ${statusDotClass(node.status)}`}
-              title={`status: ${node.status}`}
-            />
-          </div>
-          <span
-            data-testid={`category-dot-${node.id}`}
-            className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)}`}
-            title={`category: ${node.categoryColor}`}
-          />
-        </div>
       )}
-      {!showBadgeRow && (
-        <div className="flex items-center justify-end w-full pt-1">
-          <span
-            data-testid={`status-dot-${node.id}`}
-            className={`w-2 h-2 rounded-full ${statusDotClass(node.status)}`}
-            title={`status: ${node.status}`}
-          />
-          <span
-            data-testid={`category-dot-${node.id}`}
-            className={`w-2 h-2 rounded-full ${categoryDotClass(node.categoryColor)} ml-1`}
-            title={`category: ${node.categoryColor}`}
-          />
-        </div>
-      )}
+    </div>
+  );
+
+  return (
+    <div
+      data-testid={`task-card-${node.id}`}
+      data-node-id={node.id}
+      className="flex flex-col gap-1.5 min-w-0"
+    >
+      {isDone ? null : metaRow}
+      {bodyRow}
+      <div
+        className="w-full"
+        style={{
+          borderTop: `1px solid ${hairlineColor}`,
+          opacity: isDone ? 0.35 : 1,
+        }}
+      />
     </div>
   );
 }

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -85,10 +85,7 @@ export function TaskCard({ node }: Props) {
       {isDone ? null : (
         <>
           {metaRow}
-          <div
-            className="w-full"
-            style={{ borderTop: `1px solid ${hairlineColor}` }}
-          />
+          <div className="w-full" style={{ borderTop: `1px solid ${hairlineColor}` }} />
         </>
       )}
       {bodyRow}

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -82,15 +82,22 @@ export function TaskCard({ node }: Props) {
       data-node-id={node.id}
       className="flex flex-col gap-1.5 min-w-0"
     >
-      {isDone ? null : metaRow}
+      {isDone ? null : (
+        <>
+          {metaRow}
+          <div
+            className="w-full"
+            style={{ borderTop: `1px solid ${hairlineColor}` }}
+          />
+        </>
+      )}
       {bodyRow}
-      <div
-        className="w-full"
-        style={{
-          borderTop: `1px solid ${hairlineColor}`,
-          opacity: isDone ? 0.35 : 1,
-        }}
-      />
+      {isDone ? (
+        <div
+          className="w-full"
+          style={{ borderTop: `1px solid ${hairlineColor}`, opacity: 0.35 }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/mintodo/src/components/TaskCheckbox.test.tsx
+++ b/packages/mintodo/src/components/TaskCheckbox.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TaskCheckbox } from "./TaskCheckbox";
+
+describe("TaskCheckbox", () => {
+  it("renders an empty square when not done", () => {
+    render(<TaskCheckbox isDone={false} onToggle={() => {}} testId="cb" />);
+    const btn = screen.getByTestId("cb");
+    expect(btn.className).toContain("border-[1.5px]");
+    expect(btn.textContent).toBe("");
+  });
+
+  it("renders a check mark and filled background when done", () => {
+    render(<TaskCheckbox isDone={true} onToggle={() => {}} testId="cb" />);
+    const btn = screen.getByTestId("cb");
+    expect(btn.textContent).toBe("✓");
+    expect(btn.className).toContain("bg-emerald-500");
+  });
+
+  it("calls onToggle when clicked and stops propagation", () => {
+    const onToggle = vi.fn();
+    const stop = vi.fn();
+    render(
+      <div onClick={stop}>
+        <TaskCheckbox isDone={false} onToggle={onToggle} testId="cb" />
+      </div>,
+    );
+    fireEvent.click(screen.getByTestId("cb"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mintodo/src/components/TaskCheckbox.tsx
+++ b/packages/mintodo/src/components/TaskCheckbox.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  isDone: boolean;
+  onToggle: () => void;
+  testId: string;
+}
+
+export function TaskCheckbox({ isDone, onToggle, testId }: Props) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      aria-pressed={isDone}
+      aria-label={isDone ? "Mark as not done" : "Mark as done"}
+      className={
+        isDone
+          ? "w-3.5 h-3.5 rounded-[3px] bg-emerald-500 flex items-center justify-center text-white text-[10px] leading-none shrink-0"
+          : "w-3.5 h-3.5 rounded-[3px] border-[1.5px] shrink-0"
+      }
+      style={isDone ? undefined : { borderColor: "var(--mid)" }}
+    >
+      {isDone ? "✓" : ""}
+    </button>
+  );
+}

--- a/packages/mintodo/src/components/priority.test.ts
+++ b/packages/mintodo/src/components/priority.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { priorityClass } from "./priority";
+
+describe("priorityClass", () => {
+  it("returns empty string for medium", () => {
+    expect(priorityClass("medium")).toBe("");
+  });
+
+  it("returns bold + uppercase classes for high", () => {
+    const out = priorityClass("high");
+    expect(out).toContain("font-bold");
+    expect(out).toContain("uppercase");
+  });
+
+  it("returns italic for low", () => {
+    expect(priorityClass("low")).toBe("italic");
+  });
+});

--- a/packages/mintodo/src/components/priority.ts
+++ b/packages/mintodo/src/components/priority.ts
@@ -1,0 +1,15 @@
+import type { Priority } from "../types";
+
+export function priorityClass(priority: Priority): string {
+  switch (priority) {
+    case "high": {
+      return "font-bold tracking-wide uppercase";
+    }
+    case "low": {
+      return "italic";
+    }
+    default: {
+      return "";
+    }
+  }
+}

--- a/packages/mintodo/src/integration.test.tsx
+++ b/packages/mintodo/src/integration.test.tsx
@@ -35,7 +35,10 @@ vi.mock("@dnd-kit/core", async (importOriginal) => {
 });
 
 function pointerRectCollision(): CollisionDetection {
-  return ({ droppableContainers, pointerCoordinates }: {
+  return ({
+    droppableContainers,
+    pointerCoordinates,
+  }: {
     droppableContainers: DroppableContainer[];
     pointerCoordinates: { x: number; y: number } | null;
   }) => {

--- a/packages/mintodo/src/integration.test.tsx
+++ b/packages/mintodo/src/integration.test.tsx
@@ -1,6 +1,9 @@
 import "fake-indexeddb/auto";
+import type { Collision, CollisionDetection, DroppableContainer } from "@dnd-kit/core";
+import type * as DndKit from "@dnd-kit/core";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { App } from "./App";
 import { db } from "./db";
 
@@ -9,23 +12,64 @@ const flush = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-// Jsdom doesn't implement DataTransfer
-class MockDataTransfer {
-  private data = new Map<string, string>();
-  public types: string[] = [];
-  public effectAllowed = "move";
-  public dropEffect = "move";
+const collisionRef = vi.hoisted(() => ({
+  value: undefined as CollisionDetection | undefined,
+}));
 
-  public setData(format: string, data: string): void {
-    this.data.set(format, data);
-    if (!this.types.includes(format)) {
-      this.types.push(format);
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof DndKit;
+  interface DndProps {
+    children?: ReactNode;
+    collisionDetection?: CollisionDetection;
+    [key: string]: unknown;
+  }
+  const WrappedDndContext = (props: DndProps) => {
+    const cd = collisionRef.value ?? props.collisionDetection;
+    return (
+      <actual.DndContext {...props} collisionDetection={cd}>
+        {props.children}
+      </actual.DndContext>
+    );
+  };
+  return { ...actual, DndContext: WrappedDndContext };
+});
+
+function pointerRectCollision(): CollisionDetection {
+  return ({ droppableContainers, pointerCoordinates }: {
+    droppableContainers: DroppableContainer[];
+    pointerCoordinates: { x: number; y: number } | null;
+  }) => {
+    if (!pointerCoordinates) return [];
+    const out: Collision[] = [];
+    for (const c of droppableContainers) {
+      const node = c.node.current;
+      if (!node) continue;
+      const rect = node.getBoundingClientRect();
+      if (
+        pointerCoordinates.x >= rect.left &&
+        pointerCoordinates.x <= rect.right &&
+        pointerCoordinates.y >= rect.top &&
+        pointerCoordinates.y <= rect.bottom
+      ) {
+        out.push({ id: c.id, data: { droppableContainer: c } });
+      }
     }
-  }
+    return out;
+  };
+}
 
-  public getData(format: string): string {
-    return this.data.get(format) ?? "";
-  }
+function setRect(el: HTMLElement, x: number) {
+  el.getBoundingClientRect = () => ({
+    x,
+    y: 0,
+    width: 288,
+    height: 400,
+    top: 0,
+    right: x + 288,
+    bottom: 400,
+    left: x,
+    toJSON: () => null,
+  });
 }
 
 describe("board creation end-to-end", () => {
@@ -445,14 +489,14 @@ describe("kanban view end-to-end", () => {
     });
     await createBoard("Test");
 
-    // Add a child node
+    // Add a child node (will have status "inbox")
     const addBtn = document.querySelector('[data-testid="add-child-root"]') as HTMLElement;
     await act(() => {
       fireEvent.click(addBtn);
     });
     const ta = document.querySelector('[data-testid="edit-modal-textarea"]') as HTMLTextAreaElement;
     await act(() => {
-      fireEvent.change(ta, { target: { value: "drag test" } });
+      fireEvent.change(ta, { target: { value: "drag me" } });
     });
     await act(() => {
       fireEvent.click(
@@ -471,28 +515,91 @@ describe("kanban view end-to-end", () => {
       await flush(100);
     });
 
-    // Card should be in inbox column (need the child, not root)
-    const inboxColumn = screen.getByTestId("kanban-column-inbox");
-    const cards = inboxColumn.querySelectorAll("[data-node-id]") as NodeListOf<HTMLElement>;
-    const childCard = [...cards].find((c) => c.dataset.nodeId !== "root");
-    expect(childCard).toBeTruthy();
-    const { nodeId } = childCard!.dataset;
-    expect(nodeId).toBeTruthy();
+    collisionRef.value = pointerRectCollision();
+    try {
+      const inboxColumn = screen.getByTestId("kanban-column-inbox");
+      const wipColumn = screen.getByTestId("kanban-column-wip");
+      const reviewColumn = screen.getByTestId("kanban-column-review");
+      const doneColumn = screen.getByTestId("kanban-column-done");
 
-    // Drag the child card to the done column
-    const doneColumn = screen.getByTestId("kanban-column-done");
-    const dt = new MockDataTransfer();
-    dt.setData("application/x-mindnode-id", nodeId!);
+      const cards = inboxColumn.querySelectorAll("[data-node-id]") as NodeListOf<HTMLElement>;
+      const childCard = [...cards].find((c) => c.dataset.nodeId !== "root");
+      expect(childCard).toBeTruthy();
 
-    await act(() => {
-      fireEvent.drop(doneColumn, { dataTransfer: dt as unknown as DataTransfer });
-    });
-    await act(async () => {
-      await flush(100);
-    });
+      setRect(inboxColumn, 0);
+      setRect(wipColumn, 304);
+      setRect(reviewColumn, 608);
+      setRect(doneColumn, 912);
 
-    // Card should now be in done column, not inbox
-    expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("1");
-    expect(screen.getByTestId("kanban-column-count-done").textContent).toBe("1");
+      const cardRect = childCard!.getBoundingClientRect();
+      const fromX = cardRect.left + cardRect.width / 2;
+      const fromY = cardRect.top + cardRect.height / 2;
+      const doneRect = doneColumn.getBoundingClientRect();
+      const toX = doneRect.left + doneRect.width / 2;
+      const toY = doneRect.top + doneRect.height / 2;
+      const doc = childCard!.ownerDocument;
+
+      await act(async () => {
+        fireEvent.pointerDown(childCard!, {
+          pointerId: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+          button: 0,
+          buttons: 1,
+          clientX: fromX,
+          clientY: fromY,
+        });
+      });
+      await act(async () => {
+        doc.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+            clientX: fromX + 10,
+            clientY: fromY + 10,
+            buttons: 1,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await act(async () => {
+        doc.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+            clientX: toX,
+            clientY: toY,
+            buttons: 1,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await act(async () => {
+        doc.dispatchEvent(
+          new PointerEvent("pointerup", {
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+            clientX: toX,
+            clientY: toY,
+            button: 0,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await act(async () => {
+        await flush(100);
+      });
+
+      expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("1");
+      expect(screen.getByTestId("kanban-column-count-done").textContent).toBe("1");
+    } finally {
+      collisionRef.value = undefined;
+    }
   });
 });

--- a/packages/mintodo/src/lib/badges.test.ts
+++ b/packages/mintodo/src/lib/badges.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatBadges, categoryDotClass, categoryBorderColor, statusDotClass } from "./badges";
+import { formatBadges, categoryBorderColor, statusDotClass } from "./badges";
 import type { MindNode } from "../types";
 
 function makeNode(opts: Partial<MindNode> = {}): MindNode {
@@ -22,58 +22,59 @@ function makeNode(opts: Partial<MindNode> = {}): MindNode {
   };
 }
 
+function todayString(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 describe("formatBadges", () => {
-  it("empty dueDate -> no dueHtml, showBadgeRow only if high priority", () => {
+  it("empty dueDate -> kind none, showPriority false, statusLabel INBOX", () => {
     const r = formatBadges(makeNode());
-    expect(r.dueHtml).toBe("");
-    expect(r.showHigh).toBe(false);
-    expect(r.showBadgeRow).toBe(false);
+    expect(r.due.kind).toBe("none");
+    expect(r.due.daysFromNow).toBe(0);
+    expect(r.showPriority).toBe(false);
+    expect(r.statusLabel).toBe("INBOX");
   });
 
-  it("overdue dueDate -> rose 超過 badge", () => {
-    const past = "2000-01-01";
-    const r = formatBadges(makeNode({ dueDate: past }));
-    expect(r.dueHtml).toContain("超過");
-    expect(r.showBadgeRow).toBe(true);
+  it("past dueDate -> kind overdue, negative daysFromNow", () => {
+    const r = formatBadges(makeNode({ dueDate: "2000-01-01" }));
+    expect(r.due.kind).toBe("overdue");
+    expect(r.due.daysFromNow).toBeLessThan(0);
   });
 
-  it("due today -> amber 今日 badge", () => {
-    const today = new Date();
-    const ds = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-    const r = formatBadges(makeNode({ dueDate: ds }));
-    expect(r.dueHtml).toContain("今日");
-    expect(r.showBadgeRow).toBe(true);
+  it("due today -> kind today, daysFromNow 0", () => {
+    const r = formatBadges(makeNode({ dueDate: todayString() }));
+    expect(r.due.kind).toBe("today");
+    expect(r.due.daysFromNow).toBe(0);
   });
 
-  it("future dueDate -> あと N 日 badge", () => {
+  it("future dueDate -> kind future, positive daysFromNow", () => {
     const r = formatBadges(makeNode({ dueDate: "2099-12-31" }));
-    expect(r.dueHtml).toContain("あと");
-    expect(r.showBadgeRow).toBe(true);
+    expect(r.due.kind).toBe("future");
+    expect(r.due.daysFromNow).toBeGreaterThan(0);
   });
 
-  it("done status suppresses dueHtml", () => {
+  it("done status suppresses due to kind none", () => {
     const r = formatBadges(makeNode({ dueDate: "2000-01-01", status: "done", completed: true }));
-    expect(r.dueHtml).toBe("");
+    expect(r.due.kind).toBe("none");
   });
 
-  it("high priority -> showHigh true", () => {
-    const r = formatBadges(makeNode({ priority: "high" }));
-    expect(r.showHigh).toBe(true);
-    expect(r.showBadgeRow).toBe(true);
-  });
-
-  it("done with status but not completed suppresses dueHtml", () => {
+  it("done status but not completed also suppresses due", () => {
     const r = formatBadges(makeNode({ dueDate: "2000-01-01", status: "done", completed: false }));
-    expect(r.dueHtml).toBe("");
+    expect(r.due.kind).toBe("none");
   });
-});
 
-describe("categoryDotClass", () => {
-  it("maps colors to tailwind classes", () => {
-    expect(categoryDotClass("sky")).toBe("bg-sky-400");
-    expect(categoryDotClass("emerald")).toBe("bg-emerald-400");
-    expect(categoryDotClass("rose")).toBe("bg-rose-400");
-    expect(categoryDotClass("slate")).toBe("bg-slate-400");
+  it("showPriority is true only for high", () => {
+    expect(formatBadges(makeNode({ priority: "low" })).showPriority).toBe(false);
+    expect(formatBadges(makeNode({ priority: "medium" })).showPriority).toBe(false);
+    expect(formatBadges(makeNode({ priority: "high" })).showPriority).toBe(true);
+  });
+
+  it("statusLabel maps each TaskStatus", () => {
+    expect(formatBadges(makeNode({ status: "inbox" })).statusLabel).toBe("INBOX");
+    expect(formatBadges(makeNode({ status: "wip" })).statusLabel).toBe("WIP");
+    expect(formatBadges(makeNode({ status: "review" })).statusLabel).toBe("REVIEW");
+    expect(formatBadges(makeNode({ status: "done" })).statusLabel).toBe("DONE");
   });
 });
 
@@ -87,16 +88,10 @@ describe("categoryBorderColor", () => {
 });
 
 describe("statusDotClass", () => {
-  it("returns slate for inbox", () => {
+  it("returns the right class per status", () => {
     expect(statusDotClass("inbox")).toBe("bg-slate-400");
-  });
-  it("returns sky for wip", () => {
     expect(statusDotClass("wip")).toBe("bg-sky-500");
-  });
-  it("returns amber for review", () => {
     expect(statusDotClass("review")).toBe("bg-amber-500");
-  });
-  it("returns emerald for done", () => {
     expect(statusDotClass("done")).toBe("bg-emerald-500");
   });
 });

--- a/packages/mintodo/src/lib/badges.test.ts
+++ b/packages/mintodo/src/lib/badges.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatBadges, categoryDotClass, categoryBorderColor } from "./badges";
+import { formatBadges, categoryDotClass, categoryBorderColor, statusDotClass } from "./badges";
 import type { MindNode } from "../types";
 
 function makeNode(opts: Partial<MindNode> = {}): MindNode {
@@ -83,5 +83,20 @@ describe("categoryBorderColor", () => {
     expect(categoryBorderColor("emerald")).toBe("#10b981");
     expect(categoryBorderColor("rose")).toBe("#f43f5e");
     expect(categoryBorderColor("slate")).toBe("var(--mid)");
+  });
+});
+
+describe("statusDotClass", () => {
+  it("returns slate for inbox", () => {
+    expect(statusDotClass("inbox")).toBe("bg-slate-400");
+  });
+  it("returns sky for wip", () => {
+    expect(statusDotClass("wip")).toBe("bg-sky-500");
+  });
+  it("returns amber for review", () => {
+    expect(statusDotClass("review")).toBe("bg-amber-500");
+  });
+  it("returns emerald for done", () => {
+    expect(statusDotClass("done")).toBe("bg-emerald-500");
   });
 });

--- a/packages/mintodo/src/lib/badges.ts
+++ b/packages/mintodo/src/lib/badges.ts
@@ -1,13 +1,29 @@
-import type { MindNode } from "../types";
+import type { MindNode, TaskStatus } from "../types";
 
-export interface BadgeInfo {
-  dueHtml: string;
-  showHigh: boolean;
-  showBadgeRow: boolean;
+export type DueKind = "none" | "overdue" | "today" | "future";
+
+export interface DueBadgeInfo {
+  kind: DueKind;
+  daysFromNow: number;
 }
 
-function dueDateBadgeHtml(dueDate: string, isCompleted: boolean): string {
-  if (!dueDate || isCompleted) return "";
+export interface BadgeInfo {
+  due: DueBadgeInfo;
+  showPriority: boolean;
+  statusLabel: "INBOX" | "WIP" | "REVIEW" | "DONE";
+}
+
+const STATUS_LABEL: Record<TaskStatus, BadgeInfo["statusLabel"]> = {
+  inbox: "INBOX",
+  wip: "WIP",
+  review: "REVIEW",
+  done: "DONE",
+};
+
+function dueBadgeInfo(dueDate: string, isCompleted: boolean): DueBadgeInfo {
+  if (!dueDate || isCompleted) {
+    return { kind: "none", daysFromNow: 0 };
+  }
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const due = new Date(dueDate);
@@ -15,37 +31,21 @@ function dueDateBadgeHtml(dueDate: string, isCompleted: boolean): string {
   const diff = due.getTime() - today.getTime();
   const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
   if (days < 0) {
-    return `<span class="bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md flex items-center gap-1 shrink-0 border border-rose-200 dark:border-rose-900/30"><span>⚠</span> 超過</span>`;
+    return { kind: "overdue", daysFromNow: days };
   }
   if (days === 0) {
-    return `<span class="bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400 text-[10px] font-bold px-1.5 py-0.5 rounded-md flex items-center gap-1 shrink-0 border border-amber-200 dark:border-amber-900/30 animate-pulse"><span>🔔</span> 今日</span>`;
+    return { kind: "today", daysFromNow: 0 };
   }
-  return `<span class="bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 text-[10px] font-medium px-1.5 py-0.5 rounded-md shrink-0">あと ${days} 日</span>`;
+  return { kind: "future", daysFromNow: days };
 }
 
 export function formatBadges(node: MindNode): BadgeInfo {
   const isDone = node.status === "done" || node.completed;
-  const dueHtml = dueDateBadgeHtml(node.dueDate, isDone);
-  const showHigh = node.priority === "high";
-  const showBadgeRow = dueHtml !== "" || showHigh;
-  return { dueHtml, showHigh, showBadgeRow };
-}
-
-export function categoryDotClass(c: MindNode["categoryColor"]): string {
-  switch (c) {
-    case "sky": {
-      return "bg-sky-400";
-    }
-    case "emerald": {
-      return "bg-emerald-400";
-    }
-    case "rose": {
-      return "bg-rose-400";
-    }
-    default: {
-      return "bg-slate-400";
-    }
-  }
+  return {
+    due: dueBadgeInfo(node.dueDate, isDone),
+    showPriority: node.priority === "high",
+    statusLabel: STATUS_LABEL[node.status],
+  };
 }
 
 export function categoryBorderColor(c: MindNode["categoryColor"]): string {
@@ -65,7 +65,7 @@ export function categoryBorderColor(c: MindNode["categoryColor"]): string {
   }
 }
 
-export function statusDotClass(s: MindNode["status"]): string {
+export function statusDotClass(s: TaskStatus): string {
   switch (s) {
     case "wip": {
       return "bg-sky-500";

--- a/packages/mintodo/src/lib/badges.ts
+++ b/packages/mintodo/src/lib/badges.ts
@@ -64,3 +64,20 @@ export function categoryBorderColor(c: MindNode["categoryColor"]): string {
     }
   }
 }
+
+export function statusDotClass(s: MindNode["status"]): string {
+  switch (s) {
+    case "wip": {
+      return "bg-sky-500";
+    }
+    case "review": {
+      return "bg-amber-500";
+    }
+    case "done": {
+      return "bg-emerald-500";
+    }
+    default: {
+      return "bg-slate-400";
+    }
+  }
+}

--- a/packages/mintodo/src/test-setup.ts
+++ b/packages/mintodo/src/test-setup.ts
@@ -28,3 +28,48 @@ if (globalThis.ResizeObserver === undefined) {
 if (typeof Element.prototype.animate !== "function") {
   Element.prototype.animate = () => ({}) as Animation;
 }
+
+// Jsdom does not implement PointerEvent
+if (typeof globalThis.PointerEvent !== "function") {
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class, max-classes-per-file
+  globalThis.PointerEvent = class PointerEvent extends MouseEvent {
+    public readonly pointerId: number;
+    public readonly pointerType: string;
+    public readonly isPrimary: boolean;
+
+    public constructor(type: string, init: Record<string, unknown> = {}) {
+      super(type, init);
+      this.pointerId = (init.pointerId as number) ?? 0;
+      this.pointerType = (init.pointerType as string) ?? "mouse";
+      this.isPrimary = (init.isPrimary as boolean) ?? true;
+    }
+  } as unknown as typeof PointerEvent;
+}
+
+// Jsdom getBoundingClientRect always returns zeros for unstyled elements.
+// Dnd-kit needs non-zero rects for collision detection.
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const origGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+Element.prototype.getBoundingClientRect = function  getBoundingClientRect() {
+  const rect = origGetBoundingClientRect.call(this);
+  if (rect.width > 0 || rect.height > 0) return rect;
+  // Assign reasonable defaults so dnd-kit collision detection works
+  const w = 240;
+  const h = 80;
+  return { x: rect.x, y: rect.y, width: w, height: h, top: rect.y, right: rect.x + w, bottom: rect.y + h, left: rect.x, toJSON: () => null } as unknown as DOMRect;
+};
+
+// Jsdom does not support setPointerCapture / releasePointerCapture / hasPointerCapture
+// Required by @dnd-kit/core PointerSensor
+function noopSetPointerCapture(_pointerId: number): void {}
+function noopReleasePointerCapture(_pointerId: number): void {}
+function noopHasPointerCapture(_pointerId: number): boolean { return false; }
+if (typeof HTMLElement.prototype.setPointerCapture !== "function") {
+  HTMLElement.prototype.setPointerCapture = noopSetPointerCapture;
+}
+if (typeof HTMLElement.prototype.releasePointerCapture !== "function") {
+  HTMLElement.prototype.releasePointerCapture = noopReleasePointerCapture;
+}
+if (typeof HTMLElement.prototype.hasPointerCapture !== "function") {
+  HTMLElement.prototype.hasPointerCapture = noopHasPointerCapture;
+}

--- a/packages/mintodo/src/test-setup.ts
+++ b/packages/mintodo/src/test-setup.ts
@@ -50,20 +50,32 @@ if (typeof globalThis.PointerEvent !== "function") {
 // Dnd-kit needs non-zero rects for collision detection.
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const origGetBoundingClientRect = Element.prototype.getBoundingClientRect;
-Element.prototype.getBoundingClientRect = function  getBoundingClientRect() {
+Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
   const rect = origGetBoundingClientRect.call(this);
   if (rect.width > 0 || rect.height > 0) return rect;
   // Assign reasonable defaults so dnd-kit collision detection works
   const w = 240;
   const h = 80;
-  return { x: rect.x, y: rect.y, width: w, height: h, top: rect.y, right: rect.x + w, bottom: rect.y + h, left: rect.x, toJSON: () => null } as unknown as DOMRect;
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: w,
+    height: h,
+    top: rect.y,
+    right: rect.x + w,
+    bottom: rect.y + h,
+    left: rect.x,
+    toJSON: () => null,
+  } as unknown as DOMRect;
 };
 
 // Jsdom does not support setPointerCapture / releasePointerCapture / hasPointerCapture
 // Required by @dnd-kit/core PointerSensor
 function noopSetPointerCapture(_pointerId: number): void {}
 function noopReleasePointerCapture(_pointerId: number): void {}
-function noopHasPointerCapture(_pointerId: number): boolean { return false; }
+function noopHasPointerCapture(_pointerId: number): boolean {
+  return false;
+}
 if (typeof HTMLElement.prototype.setPointerCapture !== "function") {
   HTMLElement.prototype.setPointerCapture = noopSetPointerCapture;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,12 @@ importers:
 
   packages/mintodo:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@mijime/theme':
         specifier: workspace:*
         version: link:../theme
@@ -545,6 +551,22 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@duckdb/duckdb-wasm@1.33.1-dev45.0':
     resolution: {integrity: sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==}
@@ -6997,6 +7019,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@duckdb/duckdb-wasm@1.33.1-dev45.0':
     dependencies:


### PR DESCRIPTION
## Summary

mintodo の TaskCard (mindmap/KANBAN 共通) のビジュアルとコード構造を刷新しました。

- メタ情報を上、本文を下に分けて 1px ヘアラインで区切るエディトリアルなレイアウト
- タイトルを Crimson Pro セリフ + 優先度 (high/low/medium) をタイポグラフィだけでランクづけ
- 完了時はメタ行を畳んでドットのみに圧縮 (~40% 縦幅減)
- `formatBadges` から `dangerouslySetInnerHTML` を排除し、純データ (`DueBadgeInfo`, `statusLabel`) を返す API に変更
- TaskCard を `StatusDot` / `DueBadge` / `TaskCheckbox` / `priorityClass` に分解 (テストと再利用が容易に)

## Changes

15 commits (rebase onto `main`):

- `refactor(mintodo): migrate drag-and-drop from native HTML5 to @dnd-kit/core` — 前提 (TaskCard ラッパーが dnd-kit に依存)
- `feat(mintodo): add statusDotClass helper for status badge` — 前提
- `feat(mintodo): add shared TaskCard component` — 前提 (旧版)
- `refactor(mintodo): make NodeCard a thin wrapper around TaskCard` — 前提
- `refactor(mintodo): make KanbanCard a TaskCard wrapper with click-to-edit` — 前提
- `fix(mintodo): drop unused vi import and selectedNodeId:null in TaskCard test` — 前提
- `feat(mintodo): add priorityClass helper` — 純関数、`high → font-bold uppercase` / `low → italic`
- `refactor(mintodo): formatBadges returns pure data, drop categoryDotClass` — HTML 文字列を排除
- `feat(mintodo): add StatusDot component` — 10px dot + paper/mid リング
- `feat(mintodo): add DueBadge component` — overdue/today/future ピル
- `feat(mintodo): add TaskCheckbox component` — 14px 角ボタン
- `refactor(mintodo): rewrite TaskCard with subcomponents and editorial layout` — 構成
- `fix(mintodo): correct TaskCard hairline position and remove StatusDot a11y noise` — 仕様準拠 + a11y
- `style(mintodo): apply oxfmt after taskcard redesign rebase` — 整形
- `docs(mintodo): add TaskCard redesign spec and plan` — 設計書と実装計画

## Test Results

- **Before rebase:** 222/222 tests pass, check clean
- **After rebase (current):** 261/261 tests pass, check clean
- TaskCard 4 tests + 新規 5 tests (StatusDot 5, DueBadge 4, TaskCheckbox 3) + priority.test 3
- `pnpm test` 全 22 ファイル、261 テスト
- `pnpm run check` 0 type errors, 0 lint errors

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-06-25-mintodo-taskcard-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-06-25-mintodo-taskcard-redesign.md`

## Out of scope (deferred)

- ステータスインジケータのクリック循環 (`DONE → REVIEW → WIP → INBOX`)。`StatusDot` は `<span>` のまま。`<button>` への昇格は将来 1 行変更で済む構造。
- テキストモードの TOP をボード名にする変更
- 完了一括削除ボタン