### PR TITLE
feat(mintodo): 6 UX enhancements (delete-completed, status cycle, KANBAN leaves, child progress, modal-on-tap, board-name header)

### DIFF
--- a/packages/mintodo/src/components/KanbanBoard.test.tsx
+++ b/packages/mintodo/src/components/KanbanBoard.test.tsx
@@ -54,14 +54,14 @@ describe("KanbanBoard", () => {
     expect(screen.getByTestId("kanban-column-done")).toBeTruthy();
   });
 
-  it("distributes nodes to their status columns", () => {
+  it("distributes nodes to their status columns (root is excluded)", () => {
     const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox" });
     const wipNode = node({ id: "n1", boardId: "b", parentId: "root", status: "wip" });
     const doneNode = node({ id: "n2", boardId: "b", parentId: "root", status: "done" });
     renderBoard([root, wipNode, doneNode]);
     expect(screen.getByTestId("kanban-column-count-wip").textContent).toBe("1");
     expect(screen.getByTestId("kanban-column-count-done").textContent).toBe("1");
-    expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("1");
+    expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("0");
     expect(screen.getByTestId("kanban-column-count-review").textContent).toBe("0");
   });
 });

--- a/packages/mintodo/src/components/KanbanColumn.test.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.test.tsx
@@ -86,7 +86,14 @@ describe("KanbanColumn", () => {
   });
 
   it("hides a parent that has a non-completed leaf descendant (leaves only)", () => {
-    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox", children: ["p"] });
+    const root = node({
+      id: "root",
+      boardId: "b",
+      parentId: null,
+      isRoot: true,
+      status: "inbox",
+      children: ["p"],
+    });
     const p = node({
       id: "p",
       boardId: "b",
@@ -104,7 +111,14 @@ describe("KanbanColumn", () => {
   });
 
   it("shows a parent instead of its leaves when every leaf descendant is completed", () => {
-    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox", children: ["p"] });
+    const root = node({
+      id: "root",
+      boardId: "b",
+      parentId: null,
+      isRoot: true,
+      status: "inbox",
+      children: ["p"],
+    });
     const p = node({
       id: "p",
       boardId: "b",

--- a/packages/mintodo/src/components/KanbanColumn.test.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.test.tsx
@@ -20,7 +20,7 @@ function node(
     categoryColor: "slate",
     dueDate: "",
     status: opts.status ?? "inbox",
-    children: [],
+    children: opts.children ?? [],
     x: 0,
     y: 0,
   };
@@ -76,5 +76,49 @@ describe("KanbanColumn", () => {
       parentId: "root",
       parentStatusSeed: "review",
     });
+  });
+
+  it("excludes the root even when its status matches the column", () => {
+    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox" });
+    renderColumn("inbox", [root]);
+    expect(screen.queryByTestId("kanban-card-root")).toBeNull();
+    expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("0");
+  });
+
+  it("hides a parent that has a non-completed leaf descendant (leaves only)", () => {
+    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox", children: ["p"] });
+    const p = node({
+      id: "p",
+      boardId: "b",
+      parentId: "root",
+      status: "wip",
+      completed: false,
+      children: ["a", "b"],
+    });
+    const a = node({ id: "a", boardId: "b", parentId: "p", status: "done", completed: true });
+    const b = node({ id: "b", boardId: "b", parentId: "p", status: "wip", completed: false });
+    renderColumn("wip", [root, p, a, b]);
+    expect(screen.queryByTestId("kanban-card-p")).toBeNull();
+    expect(screen.getByTestId("kanban-card-b")).toBeTruthy();
+    expect(screen.getByTestId("kanban-column-count-wip").textContent).toBe("1");
+  });
+
+  it("shows a parent instead of its leaves when every leaf descendant is completed", () => {
+    const root = node({ id: "root", boardId: "b", parentId: null, isRoot: true, status: "inbox", children: ["p"] });
+    const p = node({
+      id: "p",
+      boardId: "b",
+      parentId: "root",
+      status: "done",
+      completed: true,
+      children: ["a", "b"],
+    });
+    const a = node({ id: "a", boardId: "b", parentId: "p", status: "done", completed: true });
+    const b = node({ id: "b", boardId: "b", parentId: "p", status: "done", completed: true });
+    renderColumn("done", [root, p, a, b]);
+    expect(screen.getByTestId("kanban-card-p")).toBeTruthy();
+    expect(screen.queryByTestId("kanban-card-a")).toBeNull();
+    expect(screen.queryByTestId("kanban-card-b")).toBeNull();
+    expect(screen.getByTestId("kanban-column-count-done").textContent).toBe("1");
   });
 });

--- a/packages/mintodo/src/components/KanbanColumn.tsx
+++ b/packages/mintodo/src/components/KanbanColumn.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { useMindStore } from "../hooks/use-mind-store";
+import { isKanbanVisible } from "../lib/tree";
 import { KanbanCard } from "./KanbanCard";
 import type { MindNode, TaskStatus } from "../types";
 
@@ -37,6 +38,7 @@ export function KanbanColumn({ status }: Props) {
       n.boardId === state.currentBoardId &&
       n.status === status &&
       !isParentCollapsed(state, n.id) &&
+      isKanbanVisible(state.nodes, n.id) &&
       !(state.hideCompleted && n.completed && !n.isRoot),
   );
 

--- a/packages/mintodo/src/components/NodeCard.test.tsx
+++ b/packages/mintodo/src/components/NodeCard.test.tsx
@@ -227,13 +227,14 @@ describe("NodeCard selection", () => {
     document.body.innerHTML = "";
   });
 
-  it("clicking a non-root node selects it", () => {
+  it("clicking a non-root node selects it and opens the edit modal", () => {
     const { container } = setup();
     const childEl = container.querySelector('[data-node-id="a"]') as HTMLElement;
     act(() => {
       fireEvent.click(childEl);
     });
     expect(capturedState!.selectedNodeId).toBe("a");
+    expect(capturedState!.modal).toEqual({ kind: "edit", nodeId: "a" });
   });
 
   it("clicking a child button inside the card does not change selection", () => {

--- a/packages/mintodo/src/components/NodeCard.tsx
+++ b/packages/mintodo/src/components/NodeCard.tsx
@@ -79,7 +79,10 @@ export function NodeCard({ node }: Props) {
       data-node-id={node.id}
       {...attributes}
       {...listeners}
-      onClick={() => dispatch({ id: node.id, type: "SELECT" })}
+      onClick={() => {
+        dispatch({ id: node.id, type: "SELECT" });
+        dispatch({ modal: { kind: "edit", nodeId: node.id }, type: "OPEN_MODAL" });
+      }}
       className={`absolute -translate-x-1/2 -translate-y-1/2 px-4 py-3 rounded border-l-4 flex flex-col gap-1.5 min-w-[220px] max-w-[320px] ${isSelected ? "node-selected" : ""} ${isMatch ? "" : "opacity-30"} ${isRingVisible ? "ring-2 ring-sky-400" : ""}`}
       style={{
         left: node.x,

--- a/packages/mintodo/src/components/StatusDot.test.tsx
+++ b/packages/mintodo/src/components/StatusDot.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { StatusDot } from "./StatusDot";
 
 describe("StatusDot", () => {
@@ -30,5 +30,14 @@ describe("StatusDot", () => {
     const el = container.querySelector("span") as HTMLElement;
     expect(el.style.boxShadow).toContain("var(--paper)");
     expect(el.style.boxShadow).toContain("var(--mid)");
+  });
+
+  it("renders as a button and calls onClick when onClick is provided", () => {
+    const onClick = vi.fn();
+    render(<StatusDot status="wip" testId="btn" onClick={onClick} />);
+    const el = screen.getByTestId("btn");
+    expect(el.tagName).toBe("BUTTON");
+    fireEvent.click(el);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mintodo/src/components/StatusDot.tsx
+++ b/packages/mintodo/src/components/StatusDot.tsx
@@ -5,16 +5,26 @@ interface Props {
   status: TaskStatus;
   dimmed?: boolean;
   testId?: string;
+  onClick?: () => void;
 }
 
-export function StatusDot({ status, dimmed = false, testId }: Props) {
-  return (
-    <span
-      data-testid={testId}
-      className={`inline-block w-2.5 h-2.5 rounded-full ${statusDotClass(status)} ${dimmed ? "opacity-40" : ""}`}
-      style={{
-        boxShadow: "0 0 0 2px var(--paper), 0 0 0 3px var(--mid)",
-      }}
-    />
-  );
+export function StatusDot({ status, dimmed = false, testId, onClick }: Props) {
+  const className = `inline-block w-2.5 h-2.5 rounded-full ${statusDotClass(status)} ${dimmed ? "opacity-40" : ""}`;
+  const style = { boxShadow: "0 0 0 2px var(--paper), 0 0 0 3px var(--mid)" };
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-testid={testId}
+        aria-label={`status ${status} (click to cycle backwards)`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+        className={`${className} cursor-pointer border-0 p-0`}
+        style={style}
+      />
+    );
+  }
+  return <span data-testid={testId} className={className} style={style} />;
 }

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -108,6 +108,51 @@ describe("TaskCard", () => {
     expect(captured!.nodes.n1.status).toBe("inbox");
   });
 
+  it("shows child progress M/N when the node has children", () => {
+    const child1 = makeNode({ id: "c1", parentId: "n1", completed: true });
+    const child2 = makeNode({ id: "c2", parentId: "n1", completed: false });
+    const state = makeState({
+      nodes: {
+        root: makeNode({ id: "root", isRoot: true }),
+        n1: makeNode({ status: "wip", children: ["c1", "c2"] }),
+        c1: child1,
+        c2: child2,
+      },
+    });
+    render(
+      <MindProvider initialState={state}>
+        <TaskCard node={state.nodes.n1!} />
+      </MindProvider>,
+    );
+    expect(screen.getByTestId("task-card-progress-n1").textContent).toBe("1 / 2");
+  });
+
+  it("hides the progress row when the node is a leaf", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <TaskCard node={makeNode()} />
+      </MindProvider>,
+    );
+    expect(screen.queryByTestId("task-card-progress-n1")).toBeNull();
+  });
+
+  it("hides the progress row when the node is done", () => {
+    const child = makeNode({ id: "c1", parentId: "n1", completed: true });
+    const state = makeState({
+      nodes: {
+        root: makeNode({ id: "root", isRoot: true }),
+        n1: makeNode({ status: "done", completed: true, children: ["c1"] }),
+        c1: child,
+      },
+    });
+    render(
+      <MindProvider initialState={state}>
+        <TaskCard node={state.nodes.n1!} />
+      </MindProvider>,
+    );
+    expect(screen.queryByTestId("task-card-progress-n1")).toBeNull();
+  });
+
   it("uses categoryColor for the hairline and renders the collapsed done dot", () => {
     const { container } = render(
       <MindProvider initialState={makeState()}>

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -59,7 +59,7 @@ describe("TaskCard", () => {
     );
     expect(screen.getByText("牛乳")).toBeTruthy();
     expect(screen.getByTestId("add-child-n1")).toBeTruthy();
-    expect(screen.getByTestId("status-dot-n1").className).toContain("bg-sky-500");
+    expect(screen.getByTestId("status-dot-button-n1").className).toContain("bg-sky-500");
   });
 
   it("opens edit-new modal when add-child is clicked", () => {
@@ -97,6 +97,17 @@ describe("TaskCard", () => {
     expect(hairline.style.opacity).toBe("");
   });
 
+  it("clicking the status dot cycles status backwards", () => {
+    render(
+      <MindProvider initialState={makeState()}>
+        <Capture />
+        <TaskCard node={makeNode({ status: "wip" })} />
+      </MindProvider>,
+    );
+    fireEvent.click(screen.getByTestId("status-dot-button-n1"));
+    expect(captured!.nodes.n1.status).toBe("inbox");
+  });
+
   it("uses categoryColor for the hairline and renders the collapsed done dot", () => {
     const { container } = render(
       <MindProvider initialState={makeState()}>
@@ -113,7 +124,7 @@ describe("TaskCard", () => {
     const dot = bodyRow.querySelector("span.rounded-full.bg-emerald-500") as HTMLElement | null;
     expect(dot).not.toBeNull();
     // Meta row (and its StatusDot) is absent
-    expect(screen.queryByTestId("status-dot-n1")).toBeNull();
+    expect(screen.queryByTestId("status-dot-button-n1")).toBeNull();
     // The body uses Crimson Pro for the title
     const title = container.querySelector("span.whitespace-pre-wrap") as HTMLElement;
     expect(title.style.fontFamily).toContain("Crimson Pro");

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -1,6 +1,8 @@
+import { useMemo } from "react";
 import { useMindStore } from "../hooks/use-mind-store";
 import { categoryBorderColor, formatBadges } from "../lib/badges";
 import { previousStatus } from "../lib/status-cycle";
+import { countDescendants } from "../lib/tree";
 import { DueBadge } from "./DueBadge";
 import { StatusDot } from "./StatusDot";
 import { TaskCheckbox } from "./TaskCheckbox";
@@ -12,10 +14,14 @@ interface Props {
 }
 
 export function TaskCard({ node }: Props) {
-  const { dispatch } = useMindStore();
+  const { dispatch, state } = useMindStore();
   const isDone = node.status === "done" || node.completed;
   const { due, statusLabel } = formatBadges(node);
   const hairlineColor = categoryBorderColor(node.categoryColor);
+  const { total: childTotal, completed: childCompleted } = useMemo(
+    () => countDescendants(state.nodes, node.id),
+    [state.nodes, node.id],
+  );
 
   const metaRow = isDone ? null : (
     <div className="flex items-center gap-1.5 min-w-0" style={{ minHeight: "18px" }}>
@@ -100,6 +106,15 @@ export function TaskCard({ node }: Props) {
         </>
       )}
       {bodyRow}
+      {!isDone && childTotal > 0 ? (
+        <div
+          data-testid={`task-card-progress-${node.id}`}
+          className="text-[10px] tracking-wider"
+          style={{ color: "var(--mid)" }}
+        >
+          {childCompleted} / {childTotal}
+        </div>
+      ) : null}
       {isDone ? (
         <div
           className="w-full"

--- a/packages/mintodo/src/components/TaskCard.tsx
+++ b/packages/mintodo/src/components/TaskCard.tsx
@@ -1,5 +1,6 @@
 import { useMindStore } from "../hooks/use-mind-store";
 import { categoryBorderColor, formatBadges } from "../lib/badges";
+import { previousStatus } from "../lib/status-cycle";
 import { DueBadge } from "./DueBadge";
 import { StatusDot } from "./StatusDot";
 import { TaskCheckbox } from "./TaskCheckbox";
@@ -23,7 +24,17 @@ export function TaskCard({ node }: Props) {
         {statusLabel}
       </span>
       <span className="ml-auto">
-        <StatusDot status={node.status} testId={`status-dot-${node.id}`} />
+        <StatusDot
+          status={node.status}
+          testId={`status-dot-button-${node.id}`}
+          onClick={() =>
+            dispatch({
+              id: node.id,
+              status: previousStatus(node.status),
+              type: "SET_STATUS",
+            })
+          }
+        />
       </span>
     </div>
   );

--- a/packages/mintodo/src/components/TextEditor.test.tsx
+++ b/packages/mintodo/src/components/TextEditor.test.tsx
@@ -55,14 +55,14 @@ function Capture() {
 }
 
 describe("TextEditor", () => {
-  it("renders the serialized DSL on mount", () => {
+  it("renders the serialized DSL on mount (no 'mindmap' header)", () => {
     render(
       <MindProvider initialState={makeState()}>
         <TextEditor />
       </MindProvider>,
     );
     const ta = screen.getByTestId("text-editor-textarea") as HTMLTextAreaElement;
-    expect(ta.value).toContain("mindmap");
+    expect(ta.value).not.toContain("mindmap");
     expect(ta.value).toContain("* Root");
     expect(ta.value).toContain("* Child");
   });

--- a/packages/mintodo/src/components/Toolbar.test.tsx
+++ b/packages/mintodo/src/components/Toolbar.test.tsx
@@ -1,7 +1,29 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Toolbar } from "./Toolbar";
-import { MindProvider } from "../hooks/use-mind-store";
+import { MindProvider, useMindStore } from "../hooks/use-mind-store";
+import { createInitialState, type State } from "../store";
+import type { MindNode } from "../types";
+
+function makeNode(id: string, over: Partial<MindNode> = {}): MindNode {
+  return {
+    id,
+    boardId: "b1",
+    text: id,
+    parentId: null,
+    isRoot: id === "root",
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    status: "inbox",
+    children: [],
+    x: 0,
+    y: 0,
+    ...over,
+  };
+}
 
 describe("Toolbar header", () => {
   afterEach(() => {
@@ -25,5 +47,53 @@ describe("Toolbar header", () => {
       </MindProvider>,
     );
     expect(screen.queryByTitle("テーマ切り替え")).toBeNull();
+  });
+});
+
+describe("Toolbar delete-completed button", () => {
+  let captured: State | null = null;
+  function Capture() {
+    captured = useMindStore().state;
+    return null;
+  }
+
+  function renderWithNodes(nodes: MindNode[]) {
+    captured = null;
+    const s: State = {
+      ...createInitialState(),
+      currentBoardId: "b1",
+      nodes: Object.fromEntries(nodes.map((n) => [n.id, n])),
+    };
+    return render(
+      <MindProvider initialState={s}>
+        <Capture />
+        <Toolbar />
+      </MindProvider>,
+    );
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches DELETE_COMPLETED after confirming", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderWithNodes([
+      makeNode("root", { children: ["a"] }),
+      makeNode("a", { parentId: "root", status: "done", completed: true }),
+    ]);
+    fireEvent.click(screen.getByTestId("toolbar-delete-completed"));
+    expect(captured!.nodes.a).toBeUndefined();
+    expect(captured!.nodes.root).toBeDefined();
+  });
+
+  it("does nothing when confirm is cancelled", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderWithNodes([
+      makeNode("root", { children: ["a"] }),
+      makeNode("a", { parentId: "root", status: "done", completed: true }),
+    ]);
+    fireEvent.click(screen.getByTestId("toolbar-delete-completed"));
+    expect(captured!.nodes.a).toBeDefined();
   });
 });

--- a/packages/mintodo/src/components/Toolbar.tsx
+++ b/packages/mintodo/src/components/Toolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  CheckCircle2,
   Eye,
   Keyboard,
   Network,
@@ -26,6 +27,11 @@ export function Toolbar() {
   const { state, dispatch } = useMindStore();
 
   const onToggleDrawer = () => dispatch({ type: "TOGGLE_DRAWER" });
+  const onDeleteCompleted = () => {
+    if (!state.currentBoardId) return;
+    if (!window.confirm("完了済みのタスクをすべて削除しますか？")) return;
+    dispatch({ type: "DELETE_COMPLETED" });
+  };
 
   return (
     <header
@@ -97,6 +103,20 @@ export function Toolbar() {
           onClick={() => dispatch({ type: "TOGGLE_HIDE_COMPLETED" })}
         >
           <Eye size={16} /> <span className="hidden sm:inline">未完了のみ</span>
+        </button>
+        <button
+          type="button"
+          data-testid="toolbar-delete-completed"
+          className="p-2 rounded text-xs font-semibold transition flex items-center gap-1.5"
+          style={{
+            background: "var(--paper)",
+            border: "1px solid var(--border)",
+            color: "var(--ink)",
+          }}
+          title="完了済みタスクをすべて削除"
+          onClick={onDeleteCompleted}
+        >
+          <CheckCircle2 size={16} /> <span className="hidden sm:inline">完了を削除</span>
         </button>
       </div>
       <div className="flex items-center justify-between lg:justify-end gap-3 w-full lg:w-auto">

--- a/packages/mintodo/src/dsl.test.ts
+++ b/packages/mintodo/src/dsl.test.ts
@@ -38,8 +38,11 @@ describe("parseDSL — Mermaid mindmap", () => {
     expect(n.status).toBe("wip");
   });
 
-  it("returns null when header is missing", () => {
-    expect(parseDSL("  * Root\n", "b1")).toBeNull();
+  it("parses without the 'mindmap' header (board name is the first line)", () => {
+    const r = parseDSL("  * Root\n", "b1");
+    expect(r).not.toBeNull();
+    expect(r!.board.name).toBe("Root");
+    expect(r!.nodes[0].isRoot).toBe(true);
   });
 
   it("returns null when indent is invalid (tab or odd)", () => {

--- a/packages/mintodo/src/dsl.ts
+++ b/packages/mintodo/src/dsl.ts
@@ -101,7 +101,8 @@ export function parseDSL(text: string, boardId: string): DslParseResult | null {
   const lines = text.replaceAll(/\r\n?/gu, "\n").split("\n");
   if (lines.length === 0) return null;
   const header = lines[0].trim().toLowerCase();
-  if (header !== "mindmap") return null;
+  const hasHeader = header === "mindmap";
+  const startIndex = hasHeader ? 1 : 0;
 
   const nodes: MindNode[] = [];
   let counter = 0;
@@ -109,7 +110,7 @@ export function parseDSL(text: string, boardId: string): DslParseResult | null {
   let hasRoot = false;
   const stack: { depth: number; node: MindNode }[] = [];
 
-  for (let i = 1; i < lines.length; i++) {
+  for (let i = startIndex; i < lines.length; i++) {
     const raw = lines[i];
     if (raw === "" || /^\s*#/u.test(raw)) continue;
 
@@ -175,9 +176,9 @@ export function parseDSL(text: string, boardId: string): DslParseResult | null {
 
 export function serializeDSL(board: { name: string }, nodes: Record<string, MindNode>): string {
   const rootNode = Object.values(nodes).find((n) => n.isRoot);
-  if (!rootNode) return `mindmap\n  * ${board.name}\n`;
+  if (!rootNode) return `  * ${board.name}\n`;
 
-  const out: string[] = ["mindmap"];
+  const out: string[] = [];
   const walk = (node: MindNode, depth: number): void => {
     const indent = "  ".repeat(depth + 1);
     const attrs: string[] = [];

--- a/packages/mintodo/src/integration.test.tsx
+++ b/packages/mintodo/src/integration.test.tsx
@@ -446,7 +446,7 @@ describe("kanban view end-to-end", () => {
     expect(screen.queryByTestId("kanban-board")).toBeNull();
   });
 
-  it("kanban view shows 4 columns with the root in inbox", async () => {
+  it("kanban view shows 4 columns", async () => {
     render(<App />);
     await act(async () => {
       await flush(100);
@@ -460,7 +460,7 @@ describe("kanban view end-to-end", () => {
     expect(screen.getByTestId("kanban-column-review")).toBeTruthy();
     expect(screen.getByTestId("kanban-column-done")).toBeTruthy();
     const count = screen.getByTestId("kanban-column-count-inbox").textContent;
-    expect(count).toBe("1");
+    expect(count).toBe("0");
   });
 
   it("viewMode round-trips through IndexedDB meta", async () => {
@@ -599,7 +599,7 @@ describe("kanban view end-to-end", () => {
         await flush(100);
       });
 
-      expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("1");
+      expect(screen.getByTestId("kanban-column-count-inbox").textContent).toBe("0");
       expect(screen.getByTestId("kanban-column-count-done").textContent).toBe("1");
     } finally {
       collisionRef.value = undefined;

--- a/packages/mintodo/src/lib/status-cycle.test.ts
+++ b/packages/mintodo/src/lib/status-cycle.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { previousStatus } from "./status-cycle";
+import type { TaskStatus } from "../types";
+
+describe("previousStatus", () => {
+  const cases: Array<[TaskStatus, TaskStatus]> = [
+    ["done", "review"],
+    ["review", "wip"],
+    ["wip", "inbox"],
+    ["inbox", "done"],
+  ];
+  for (const [from, to] of cases) {
+    it(`cycles ${from} → ${to}`, () => {
+      expect(previousStatus(from)).toBe(to);
+    });
+  }
+});

--- a/packages/mintodo/src/lib/status-cycle.ts
+++ b/packages/mintodo/src/lib/status-cycle.ts
@@ -1,0 +1,8 @@
+import type { TaskStatus } from "../types";
+
+const ORDER: readonly TaskStatus[] = ["done", "review", "wip", "inbox"];
+
+export function previousStatus(current: TaskStatus): TaskStatus {
+  const i = ORDER.indexOf(current);
+  return ORDER[(i + 1) % ORDER.length]!;
+}

--- a/packages/mintodo/src/lib/tree.test.ts
+++ b/packages/mintodo/src/lib/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { MindNode } from "../types";
-import { countDescendants, isKanbanVisible, isLeaf } from "./tree";
+import { countDescendants, isKanbanVisible } from "./tree";
 
 function n(id: string, opts: Partial<MindNode> = {}): MindNode {
   return {
@@ -21,19 +21,6 @@ function n(id: string, opts: Partial<MindNode> = {}): MindNode {
     ...opts,
   };
 }
-
-describe("isLeaf", () => {
-  it("returns true for a node with no children", () => {
-    const nodes = { root: n("root"), a: n("a", { parentId: "root" }) };
-    nodes.root = { ...nodes.root, children: ["a"] };
-    expect(isLeaf(nodes, "a")).toBe(true);
-  });
-
-  it("returns false for a node with children", () => {
-    const nodes = { root: n("root", { children: ["a"] }), a: n("a", { parentId: "root" }) };
-    expect(isLeaf(nodes, "root")).toBe(false);
-  });
-});
 
 describe("countDescendants", () => {
   it("returns 0/0 for a leaf", () => {

--- a/packages/mintodo/src/lib/tree.test.ts
+++ b/packages/mintodo/src/lib/tree.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { MindNode } from "../types";
+import { countDescendants, isKanbanVisible, isLeaf } from "./tree";
+
+function n(id: string, opts: Partial<MindNode> = {}): MindNode {
+  return {
+    id,
+    boardId: "b1",
+    text: id,
+    parentId: null,
+    isRoot: id === "root",
+    completed: false,
+    collapsed: false,
+    priority: "medium",
+    categoryColor: "slate",
+    dueDate: "",
+    status: "inbox",
+    children: [],
+    x: 0,
+    y: 0,
+    ...opts,
+  };
+}
+
+describe("isLeaf", () => {
+  it("returns true for a node with no children", () => {
+    const nodes = { root: n("root"), a: n("a", { parentId: "root" }) };
+    nodes.root = { ...nodes.root, children: ["a"] };
+    expect(isLeaf(nodes, "a")).toBe(true);
+  });
+
+  it("returns false for a node with children", () => {
+    const nodes = { root: n("root", { children: ["a"] }), a: n("a", { parentId: "root" }) };
+    expect(isLeaf(nodes, "root")).toBe(false);
+  });
+});
+
+describe("countDescendants", () => {
+  it("returns 0/0 for a leaf", () => {
+    const nodes = { a: n("a") };
+    expect(countDescendants(nodes, "a")).toEqual({ total: 0, completed: 0 });
+  });
+
+  it("counts all descendants and completed descendants", () => {
+    const nodes = {
+      p: n("p", { children: ["a", "b"], completed: true }),
+      a: n("a", { parentId: "p", completed: true }),
+      b: n("b", { parentId: "p", completed: false }),
+      gp: n("gp", { children: ["p"] }),
+    };
+    expect(countDescendants(nodes, "gp")).toEqual({ total: 3, completed: 2 });
+  });
+});
+
+describe("isKanbanVisible", () => {
+  it("returns false for the root", () => {
+    const nodes = { root: n("root") };
+    expect(isKanbanVisible(nodes, "root")).toBe(false);
+  });
+
+  it("returns true for a leaf", () => {
+    const nodes = { root: n("root", { children: ["a"] }), a: n("a", { parentId: "root" }) };
+    expect(isKanbanVisible(nodes, "a")).toBe(true);
+  });
+
+  it("returns true for a parent whose every leaf descendant is completed", () => {
+    const nodes = {
+      root: n("root", { children: ["p"] }),
+      p: n("p", { parentId: "root", children: ["a", "b"], completed: true }),
+      a: n("a", { parentId: "p", completed: true }),
+      b: n("b", { parentId: "p", completed: true }),
+    };
+    expect(isKanbanVisible(nodes, "p")).toBe(true);
+  });
+
+  it("returns false for a parent with at least one non-completed leaf descendant", () => {
+    const nodes = {
+      root: n("root", { children: ["p"] }),
+      p: n("p", { parentId: "root", children: ["a", "b"] }),
+      a: n("a", { parentId: "p", completed: true }),
+      b: n("b", { parentId: "p", completed: false }),
+    };
+    expect(isKanbanVisible(nodes, "p")).toBe(false);
+  });
+});

--- a/packages/mintodo/src/lib/tree.ts
+++ b/packages/mintodo/src/lib/tree.ts
@@ -1,0 +1,35 @@
+import type { MindNode } from "../types";
+
+export function isLeaf(nodes: Record<string, MindNode>, id: string): boolean {
+  return (nodes[id]?.children.length ?? 0) === 0;
+}
+
+export function countDescendants(
+  nodes: Record<string, MindNode>,
+  id: string,
+): { total: number; completed: number } {
+  const root = nodes[id];
+  if (!root) return { total: 0, completed: 0 };
+  let total = 0;
+  let completed = 0;
+  const visit = (n: MindNode): void => {
+    for (const cid of n.children) {
+      const child = nodes[cid];
+      if (!child) continue;
+      total += 1;
+      if (child.completed) completed += 1;
+      visit(child);
+    }
+  };
+  visit(root);
+  return { total, completed };
+}
+
+export function isKanbanVisible(nodes: Record<string, MindNode>, id: string): boolean {
+  const node = nodes[id];
+  if (!node) return false;
+  if (node.isRoot) return false;
+  if (node.children.length === 0) return true;
+  const { total, completed } = countDescendants(nodes, id);
+  return total > 0 && total === completed;
+}

--- a/packages/mintodo/src/lib/tree.ts
+++ b/packages/mintodo/src/lib/tree.ts
@@ -29,6 +29,14 @@ export function isKanbanVisible(nodes: Record<string, MindNode>, id: string): bo
   const node = nodes[id];
   if (!node) return false;
   if (node.isRoot) return false;
+  let current: MindNode | null = node.parentId ? (nodes[node.parentId] ?? null) : null;
+  while (current && !current.isRoot) {
+    if (current.children.length > 0) {
+      const { total, completed } = countDescendants(nodes, current.id);
+      if (total > 0 && total === completed) return false;
+    }
+    current = current.parentId ? (nodes[current.parentId] ?? null) : null;
+  }
   if (node.children.length === 0) return true;
   const { total, completed } = countDescendants(nodes, id);
   return total > 0 && total === completed;

--- a/packages/mintodo/src/lib/tree.ts
+++ b/packages/mintodo/src/lib/tree.ts
@@ -1,9 +1,5 @@
 import type { MindNode } from "../types";
 
-export function isLeaf(nodes: Record<string, MindNode>, id: string): boolean {
-  return (nodes[id]?.children.length ?? 0) === 0;
-}
-
 export function countDescendants(
   nodes: Record<string, MindNode>,
   id: string,

--- a/packages/mintodo/src/store.test.ts
+++ b/packages/mintodo/src/store.test.ts
@@ -640,3 +640,59 @@ describe("reducer - SNAP_BACK", () => {
     expect(next.nodes.a.y).toBe(-240);
   });
 });
+
+describe("reducer - DELETE_COMPLETED", () => {
+  it("removes completed non-root nodes and cascades into subtrees", () => {
+    const s = {
+      ...createInitialState(),
+      currentBoardId: "b-a",
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, children: ["p"] }),
+        p: makeNode("p", "b-a", {
+          parentId: "root",
+          status: "done",
+          completed: true,
+          children: ["c", "d"],
+        }),
+        c: makeNode("c", "b-a", { parentId: "p", status: "done", completed: true }),
+        d: makeNode("d", "b-a", { parentId: "p", status: "inbox", completed: false }),
+      },
+    };
+    const next = reducer(s, { type: "DELETE_COMPLETED" });
+    expect(Object.keys(next.nodes).toSorted()).toEqual(["root"].toSorted());
+    expect(next.nodes.p).toBeUndefined();
+    expect(next.nodes.c).toBeUndefined();
+    expect(next.nodes.d).toBeUndefined();
+    expect(next.nodes.root.children).toEqual([]);
+  });
+
+  it("never deletes the root (defensive)", () => {
+    const s = {
+      ...createInitialState(),
+      currentBoardId: "b-a",
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, status: "done", completed: true }) },
+    };
+    const next = reducer(s, { type: "DELETE_COMPLETED" });
+    expect(next.nodes.root).toBeDefined();
+  });
+
+  it("resets selectedNodeId to root when the selected node is deleted", () => {
+    const s = {
+      ...createInitialState(),
+      currentBoardId: "b-a",
+      selectedNodeId: "p",
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, children: ["p"] }),
+        p: makeNode("p", "b-a", { parentId: "root", status: "done", completed: true }),
+      },
+    };
+    const next = reducer(s, { type: "DELETE_COMPLETED" });
+    expect(next.selectedNodeId).toBe("root");
+  });
+
+  it("is a no-op when there is no current board", () => {
+    const s = { ...createInitialState(), currentBoardId: null };
+    const next = reducer(s, { type: "DELETE_COMPLETED" });
+    expect(next).toBe(s);
+  });
+});

--- a/packages/mintodo/src/store.test.ts
+++ b/packages/mintodo/src/store.test.ts
@@ -695,4 +695,17 @@ describe("reducer - DELETE_COMPLETED", () => {
     const next = reducer(s, { type: "DELETE_COMPLETED" });
     expect(next).toBe(s);
   });
+
+  it("is a no-op when no completed nodes exist", () => {
+    const s = {
+      ...createInitialState(),
+      currentBoardId: "b-a",
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, children: ["a"] }),
+        a: makeNode("a", "b-a", { parentId: "root", status: "inbox", completed: false }),
+      },
+    };
+    const next = reducer(s, { type: "DELETE_COMPLETED" });
+    expect(next).toBe(s);
+  });
 });

--- a/packages/mintodo/src/store.ts
+++ b/packages/mintodo/src/store.ts
@@ -49,6 +49,7 @@ export type Action =
   | { type: "TOGGLE_HIDE_COMPLETED" }
   | { type: "SET_STATUS"; id: string; status: TaskStatus }
   | { type: "SET_VIEW_MODE"; viewMode: ViewMode }
+  | { type: "DELETE_COMPLETED" }
   | {
       type: "CREATE_CHILD";
       newId: string;
@@ -368,6 +369,35 @@ export function reducer(state: State, action: Action): State {
 
     case "SNAP_BACK": {
       return withRadialLayout(state, state.nodes);
+    }
+    case "DELETE_COMPLETED": {
+      const boardId = state.currentBoardId;
+      if (!boardId) return state;
+      const toDelete = Object.values(state.nodes).filter(
+        (n) => n.boardId === boardId && n.completed && !n.isRoot,
+      );
+      if (toDelete.length === 0) return state;
+      const updated = new Map(Object.entries(state.nodes));
+      const remove = (id: string) => {
+        const n = updated.get(id);
+        if (!n) return;
+        for (const childId of n.children) remove(childId);
+        updated.delete(id);
+      };
+      for (const n of toDelete) remove(n.id);
+      for (const [id, n] of updated) {
+        if (n.children.length === 0) continue;
+        const filtered = n.children.filter((c) => updated.has(c));
+        if (filtered.length !== n.children.length) {
+          updated.set(id, { ...n, children: filtered });
+        }
+      }
+      const nextNodes = Object.fromEntries(updated);
+      const nextSelected = nextNodes[state.selectedNodeId] ? state.selectedNodeId : "root";
+      return withRadialLayout(
+        { ...state, nodes: nextNodes, selectedNodeId: nextSelected },
+        nextNodes,
+      );
     }
     default: {
       return state;


### PR DESCRIPTION
## Summary

Six UX enhancements to the mintodo package, each in its own commit:

| # | Feature | Spec |
|---|---------|------|
| 1 | 完了タスクを全て削除ボタン (toolbar) | "完了タスクを全て削除するボタンを追加する" |
| 2 | Status dot クリックで逆順サイクル | "インディケーターを押したらステータスが戻る DONE → REVIEW → WIP → INBOX" |
| 3 | TaskCard 子タスク進捗 (M/N) | "子課題の件数と完了件数から進捗表示をタスクカードに表示する" |
| 4 | KANBAN: 末端のみ + 親フォールバック + root 非表示 | "KANBANでは末端のタスクしか表示しない。末端のタスクが全て完了している場合は、親タスクを表示する" + "rootノードは表示しない" |
| 5 | Mindmap 短いタップで編集モーダル | "mindmap modeでも短いタップで編集モーダルを出す" |
| 6 | テキストモード先頭行 = ボード名 | "テキストモードのTOPにはmindmapではなくボード名を書く" |

## Architecture

- `src/lib/tree.ts` — `countDescendants` and `isKanbanVisible` (the latter walks ancestors to hide leaves under an all-done parent). Shared by TaskCard progress and KANBAN filter.
- `src/lib/status-cycle.ts` — `previousStatus` (done → review → wip → inbox → done).
- `DELETE_COMPLETED` reducer action cascades subtrees (consistent with `DELETE_NODE`).
- `StatusDot` accepts optional `onClick`; renders as `<button>` when present.
- `NodeCard` body click now dispatches `SELECT` + `OPEN_MODAL` (selectedNodeId preserved for keyboard handler).
- DSL header "mindmap" is now optional; textarea content starts with the board name directly.

## Test Results

- 247/247 tests passing
- `pnpm run check` clean (tsgo + oxlint)
- pre-push CI hook passed (lint + typecheck + format + all packages' tests)

## Commits

```
ca4bbf6 style(mintodo): format KanbanColumn test root fixtures
7a21a2c refactor(mintodo): remove unused isLeaf helper, add DELETE_COMPLETED no-op test
f6c2220 feat(mintodo): text mode top line is the board name (drop "mindmap" header)
be457b7 feat(mintodo): short tap on mindmap node opens edit modal
defc6cc feat(mintodo): toolbar button to delete all completed tasks
8e8b00e feat(mintodo): show child progress M/N on task card
cfd2bd4 feat(mintodo): click status dot to cycle status backwards
fb8f63a feat(mintodo): kanban shows only leaves with parent fallback and excludes root
c32adfc feat(mintodo): add tree helpers (isLeaf, countDescendants, isKanbanVisible)
```