### PR TITLE
fix(saiflow): load indexedDB data before rendering to fix initial state

### DIFF
--- a/packages/saiflow/src/App.test.tsx
+++ b/packages/saiflow/src/App.test.tsx
@@ -1,23 +1,29 @@
 import { describe, it, expect } from "vitest";
 import "fake-indexeddb/auto";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { App } from "./App";
 
 describe("App", () => {
-  it("renders ProfileBar", () => {
+  it("renders ProfileBar", async () => {
     render(<App />);
-    expect(screen.getByLabelText("年齢")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("年齢")).toBeInTheDocument();
+    });
   });
 
-  it("renders editor tabs", () => {
+  it("renders editor tabs", async () => {
     render(<App />);
-    expect(screen.getByRole("button", { name: "DSL" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "DSL" })).toBeInTheDocument();
+    });
     expect(screen.getByRole("button", { name: "GUI" })).toBeInTheDocument();
   });
 
-  it("renders view toggle buttons", () => {
+  it("renders view toggle buttons", async () => {
     render(<App />);
-    expect(screen.getByRole("button", { name: "収支表" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "収支表" })).toBeInTheDocument();
+    });
     expect(screen.getByRole("button", { name: "資産推移" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "収支比較" })).toBeInTheDocument();
   });

--- a/packages/saiflow/src/App.tsx
+++ b/packages/saiflow/src/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { SaiflowProvider, useSaiflowDispatch, useSaiflowState } from "./store";
+import { SaiflowProvider, useSaiflowDispatch, useSaiflowState, type State } from "./store";
 import { ProfileBar } from "./components/ProfileBar";
 import { EditorPanel } from "./components/EditorPanel";
 import { ResultTable } from "./components/ResultTable";
 import { BarChart } from "./components/BarChart";
 import { LineChart } from "./components/LineChart";
+import { parseDSL } from "./parser";
 import { listScenarios, saveScenario } from "./storage";
 
 type ViewMode = "table" | "line" | "bar";
@@ -38,24 +39,13 @@ function useAutoSave() {
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const stateRef = useRef(state);
   stateRef.current = state;
-  const loadedRef = useRef(false);
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    listScenarios().then((scenarios) => {
-      if (scenarios.length > 0) {
-        const [s] = scenarios;
-        dispatch({ type: "SET_DSL", text: s.dslText });
-        dispatch({ type: "SET_AGE", age: s.currentAge });
-        dispatch({ type: "SET_YEARS", years: s.simulationYears });
-        dispatch({ type: "SET_SCENARIO_ID", id: s.id! });
-        dispatch({ type: "SET_SCENARIO_NAME", name: s.name });
-      }
-      loadedRef.current = true;
-    });
-  }, [dispatch]);
-
-  useEffect(() => {
-    if (!loadedRef.current) return;
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       const { scenarioId, scenarioName, dslText, currentAge, simulationYears } = stateRef.current;
@@ -109,8 +99,31 @@ function MainLayout() {
 }
 
 export function App() {
+  const [initState, setInitState] = useState<Partial<State> | null>(null);
+
+  useEffect(() => {
+    listScenarios().then((scenarios) => {
+      if (scenarios.length > 0) {
+        const [s] = scenarios;
+        const result = parseDSL(s.dslText);
+        setInitState({
+          dslText: s.dslText,
+          currentAge: s.currentAge,
+          simulationYears: s.simulationYears,
+          scenarioId: s.id!,
+          scenarioName: s.name,
+          scenarios: result.scenarios.length > 0 ? result.scenarios : undefined,
+        });
+      } else {
+        setInitState({});
+      }
+    });
+  }, []);
+
+  if (initState === null) return null;
+
   return (
-    <SaiflowProvider>
+    <SaiflowProvider state={initState}>
       <MainLayout />
     </SaiflowProvider>
   );


### PR DESCRIPTION
## Summary
- Fix IndexedDB data not loading on initial page open in saiflow
- Move async loading from `useAutoSave` effect to `App` component, passing loaded data via `SaiflowProvider` state prop before child components render
- Simplify `useAutoSave` to only handle save logic

## Root Cause
IndexedDB data was loaded asynchronously in a `useEffect` after mount, so child components (GuiEditor) initialized with empty state before the load completed. The data only appeared when switching to the DSL tab because `DslEditor`'s `useEffect` on `dslText` would parse and populate `scenarios`.

## Test Plan
- [x] All 62 tests pass
- [x] Typecheck clean (tsgo --noEmit)
- [x] Lint clean (oxlint: 0 warnings, 0 errors)
- [ ] Manual verification: open app with saved data, verify GUI editor shows events immediately