### PR TITLE
feat(saiflow): 内訳表・内訳グラフ・CSVダウンロード追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 node = "22"
 lefthook = "latest"
-pnpm = "latest"
+"npm:pnpm" = "latest"
 
 [tasks."format:pnpm"]
 run = "pnpm run format"

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "type": "module",
   "packageManager": "pnpm@11.5.1",
-  "workspaces": ["apps/*", "packages/*"]
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ]
 }

--- a/packages/saiflow/src/App.tsx
+++ b/packages/saiflow/src/App.tsx
@@ -3,31 +3,51 @@ import { SaiflowProvider, useSaiflowDispatch, useSaiflowState, type State } from
 import { ProfileBar } from "./components/ProfileBar";
 import { EditorPanel } from "./components/EditorPanel";
 import { ResultTable } from "./components/ResultTable";
+import { CategoryTable } from "./components/CategoryTable";
 import { BarChart } from "./components/BarChart";
+import { CategoryChart } from "./components/CategoryChart";
 import { LineChart } from "./components/LineChart";
 import { parseDSL } from "./parser";
 import { listScenarios, saveScenario } from "./storage";
 
-type ViewMode = "table" | "line" | "bar";
+type ViewMode = "table" | "category" | "category-chart" | "line" | "bar";
 
 function RightPanel() {
   const [view, setView] = useState<ViewMode>("table");
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-1 px-2 py-1 border-b border-(--border)">
-        {(["table", "line", "bar"] as ViewMode[]).map((v) => (
+      <div className="flex items-center gap-1 px-2 py-1 border-b border-(--border) flex-wrap">
+        {(
+          [
+            ["table", "収支表"],
+            ["category", "内訳表"],
+            ["category-chart", "内訳グラフ"],
+            ["line", "資産推移"],
+            ["bar", "収支比較"],
+          ] as [ViewMode, string][]
+        ).map(([v, label]) => (
           <button
             key={v}
             className={`px-2 py-0.5 text-xs rounded ${view === v ? "bg-(--terra) text-white" : "text-(--ink) opacity-50"}`}
             onClick={() => setView(v)}
           >
-            {v === "table" ? "収支表" : v === "line" ? "資産推移" : "収支比較"}
+            {label}
           </button>
         ))}
       </div>
       <div className="flex-1 overflow-hidden">
-        {view === "table" ? <ResultTable /> : view === "line" ? <LineChart /> : <BarChart />}
+        {view === "table" ? (
+          <ResultTable />
+        ) : view === "category" ? (
+          <CategoryTable />
+        ) : view === "category-chart" ? (
+          <CategoryChart />
+        ) : view === "line" ? (
+          <LineChart />
+        ) : (
+          <BarChart />
+        )}
       </div>
     </div>
   );

--- a/packages/saiflow/src/categories.ts
+++ b/packages/saiflow/src/categories.ts
@@ -1,0 +1,47 @@
+import type { YearRow } from "./types";
+
+export function categoryName(eventName: string): string {
+  return eventName.replaceAll(/\([^)]*\)/g, "").trim();
+}
+
+export interface CategoryBreakdown {
+  age: number;
+  income: Record<string, number>;
+  expense: Record<string, number>;
+  net: Record<string, number>;
+}
+
+export function computeCategories(rows: YearRow[]): {
+  allCategories: string[];
+  breakdowns: CategoryBreakdown[];
+} {
+  const catSet = new Set<string>();
+
+  for (const row of rows) {
+    for (const { eventName } of row.operations) {
+      catSet.add(categoryName(eventName));
+    }
+  }
+
+  const allCategories = [...catSet].toSorted();
+
+  const breakdowns: CategoryBreakdown[] = rows.map((row) => {
+    const income: Record<string, number> = {};
+    const expense: Record<string, number> = {};
+
+    for (const { eventName, op } of row.operations) {
+      const cat = categoryName(eventName);
+      if (op.op === "+") income[cat] = (income[cat] ?? 0) + op.value;
+      if (op.op === "-") expense[cat] = (expense[cat] ?? 0) + op.value;
+    }
+
+    const net: Record<string, number> = {};
+    for (const cat of allCategories) {
+      net[cat] = (income[cat] ?? 0) - (expense[cat] ?? 0);
+    }
+
+    return { age: row.age, income, expense, net };
+  });
+
+  return { allCategories, breakdowns };
+}

--- a/packages/saiflow/src/components/CategoryChart.tsx
+++ b/packages/saiflow/src/components/CategoryChart.tsx
@@ -1,0 +1,260 @@
+import React from "react";
+import { useSaiflowState } from "../store";
+import { computeCategories } from "../categories";
+import { ChartTooltip } from "./ChartTooltip";
+import { logTicks } from "./BarChart";
+
+const PALETTE = [
+  "hsl(120, 65%, 50%)",
+  "hsl(200, 65%, 55%)",
+  "hsl(30, 80%, 55%)",
+  "hsl(280, 55%, 55%)",
+  "hsl(160, 55%, 45%)",
+  "hsl(0, 65%, 55%)",
+  "hsl(45, 75%, 50%)",
+  "hsl(240, 55%, 60%)",
+  "hsl(320, 50%, 50%)",
+  "hsl(80, 55%, 45%)",
+  "hsl(180, 50%, 45%)",
+  "hsl(10, 70%, 50%)",
+];
+
+export function CategoryChart() {
+  const state = useSaiflowState();
+  const { rows } = state;
+  if (!rows || rows.length === 0) return null;
+
+  const { allCategories, breakdowns } = computeCategories(rows);
+
+  const denseCats = allCategories.filter((cat) =>
+    breakdowns.some((b) => b.net[cat] !== 0),
+  );
+
+  const catColors = new Map<string, string>();
+  denseCats.forEach((cat, i) => {
+    catColors.set(cat, PALETTE[i % PALETTE.length]);
+  });
+
+  const [hover, setHover] = React.useState<{
+    i: number;
+    mx: number;
+    my: number;
+  } | null>(null);
+
+  const padding = { top: 24, right: 24, bottom: 40, left: 56 };
+  const width = Math.max(600, rows.length * 14 + padding.left + padding.right);
+  const height = 380;
+  const midY = height / 2;
+  const plotH = (height - padding.top - padding.bottom) / 2;
+
+  const maxIncome = Math.max(
+    ...breakdowns.map((b) => denseCats.reduce((s, c) => s + (b.income[c] ?? 0), 0)),
+    0,
+  );
+  const maxExpense = Math.max(
+    ...breakdowns.map((b) => denseCats.reduce((s, c) => s + (b.expense[c] ?? 0), 0)),
+    0,
+  );
+  const maxVal = Math.max(maxIncome, maxExpense, 1) * 1.05;
+
+  const step = (width - padding.left - padding.right) / rows.length;
+  const barW = Math.max(3, step * 0.65);
+  const x = (i: number) => padding.left + i * step + step / 2;
+
+  const scale = (v: number) => Math.log10(v + 1) / Math.log10(maxVal + 1);
+  const incomeY = (v: number) => midY - scale(v) * plotH;
+  const expenseY = (v: number) => midY + scale(v) * plotH;
+
+  const yTicks = logTicks(maxVal);
+  const xTickInterval = Math.max(1, Math.floor(rows.length / 10));
+
+  return (
+    <div className="h-full overflow-auto relative">
+      <svg width={width} height={height} className="font-sans text-xs">
+        <line
+          x1={padding.left}
+          y1={midY}
+          x2={width - padding.right}
+          y2={midY}
+          stroke="rgba(128,128,128,0.3)"
+        />
+
+        {yTicks.map((v) => (
+          <g key={`t${v}`}>
+            <line
+              x1={padding.left}
+              y1={incomeY(v)}
+              x2={width - padding.right}
+              y2={incomeY(v)}
+              stroke="rgba(128,128,128,0.08)"
+            />
+            <line
+              x1={padding.left}
+              y1={expenseY(v)}
+              x2={width - padding.right}
+              y2={expenseY(v)}
+              stroke="rgba(128,128,128,0.08)"
+            />
+            <text
+              x={padding.left - 6}
+              y={incomeY(v) + 4}
+              textAnchor="end"
+              fill="var(--ink)"
+              opacity={0.5}
+            >
+              {v}
+            </text>
+            <text
+              x={padding.left - 6}
+              y={expenseY(v) + 4}
+              textAnchor="end"
+              fill="var(--ink)"
+              opacity={0.5}
+            >
+              {v}
+            </text>
+          </g>
+        ))}
+
+        {breakdowns.map((b, i) => {
+          const xi = x(i);
+          let incomeCum = 0;
+          const incomeRects = denseCats
+            .map((cat) => {
+              const v = b.income[cat] ?? 0;
+              if (v <= 0) return null;
+              const bottom = incomeCum;
+              incomeCum += v;
+              const top = incomeCum;
+              const sy = incomeY(top);
+              const h = incomeY(bottom) - incomeY(top);
+              return (
+                <rect
+                  key={`inc-${cat}`}
+                  x={xi - barW / 2}
+                  y={sy}
+                  width={barW}
+                  height={Math.max(0.5, h)}
+                  fill={catColors.get(cat)!}
+                  opacity={0.75}
+                  rx={1}
+                />
+              );
+            })
+            .filter(Boolean);
+
+          let expenseCum = 0;
+          const expenseRects = denseCats
+            .map((cat) => {
+              const v = b.expense[cat] ?? 0;
+              if (v <= 0) return null;
+              const bottom = expenseCum;
+              expenseCum += v;
+              const top = expenseCum;
+              const sy = expenseY(bottom);
+              const h = expenseY(top) - expenseY(bottom);
+              return (
+                <rect
+                  key={`exp-${cat}`}
+                  x={xi - barW / 2}
+                  y={sy}
+                  width={barW}
+                  height={Math.max(0.5, h)}
+                  fill={catColors.get(cat)!}
+                  opacity={0.75}
+                  rx={1}
+                />
+              );
+            })
+            .filter(Boolean);
+
+          return (
+            <g key={i}>
+              {incomeRects}
+              {expenseRects}
+            </g>
+          );
+        })}
+
+        {rows.map((_, i) => (
+          <rect
+            key={`hb${i}`}
+            x={x(i) - step / 2}
+            y={padding.top}
+            width={step}
+            height={height - padding.top - padding.bottom}
+            fill="transparent"
+            onMouseEnter={(e) => setHover({ i, mx: e.clientX, my: e.clientY })}
+            onMouseMove={(e) =>
+              setHover((h) => (h ? { ...h, mx: e.clientX, my: e.clientY } : null))
+            }
+            onMouseLeave={() => setHover(null)}
+          />
+        ))}
+
+        {rows.map((r, i) => {
+          if (i % xTickInterval !== 0 && i !== rows.length - 1) return null;
+          return (
+            <text
+              key={`x${i}`}
+              x={x(i)}
+              y={height - padding.bottom + 16}
+              textAnchor="middle"
+              fill="var(--ink)"
+              opacity={0.5}
+            >
+              {r.age}
+            </text>
+          );
+        })}
+
+        <g transform={`translate(${padding.left}, 4)`}>
+          {denseCats.map((cat, i) => {
+            const col = i % 6;
+            const row = Math.floor(i / 6);
+            const lx = col * 130;
+            const ly = row * 16;
+            return (
+              <g key={cat} transform={`translate(${lx}, ${ly})`}>
+                <rect x={0} y={-10} width={14} height={10} rx={2} fill={catColors.get(cat)!} opacity={0.75} />
+                <text x={18} y={0} fill="var(--ink)" opacity={0.7} fontSize={11}>
+                  {cat}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+      <ChartTooltip
+        data={
+          hover
+            ? (() => {
+                const b = breakdowns[hover.i];
+                const lines: { label: string; value: string }[] = [
+                  { label: "年齢", value: String(b.age) },
+                ];
+                for (const cat of denseCats) {
+                  const inc = b.income[cat] ?? 0;
+                  const exp = b.expense[cat] ?? 0;
+                  if (inc === 0 && exp === 0) continue;
+                  const net = inc - exp;
+                  const sign = net >= 0 ? "+" : "";
+                  lines.push({
+                    label: cat,
+                    value: `${sign}${net.toLocaleString()}`,
+                  });
+                }
+                const totalInc = denseCats.reduce((s, c) => s + (b.income[c] ?? 0), 0);
+                const totalExp = denseCats.reduce((s, c) => s + (b.expense[c] ?? 0), 0);
+                lines.push(
+                  { label: "収入計", value: totalInc.toLocaleString() },
+                  { label: "支出計", value: totalExp.toLocaleString() },
+                );
+                return { x: hover.mx, y: hover.my, lines };
+              })()
+            : null
+        }
+      />
+    </div>
+  );
+}

--- a/packages/saiflow/src/components/CategoryTable.tsx
+++ b/packages/saiflow/src/components/CategoryTable.tsx
@@ -1,0 +1,82 @@
+import { useSaiflowState } from "../store";
+import { computeCategories } from "../categories";
+
+export function CategoryTable() {
+  const state = useSaiflowState();
+  const { rows } = state;
+
+  if (!rows || rows.length === 0) return null;
+
+  const { allCategories, breakdowns } = computeCategories(rows);
+
+  const denseCats = allCategories.filter((cat) =>
+    breakdowns.some((b) => b.net[cat] !== 0),
+  );
+
+  return (
+    <div className="h-full overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead className="sticky top-0 bg-(--toolbar-bg)">
+          <tr>
+            <th className="px-2 py-1 text-left border-b border-(--border)">年齢</th>
+            {denseCats.map((cat) => (
+              <th key={cat} className="px-2 py-1 text-right border-b border-(--border)">
+                {cat}
+              </th>
+            ))}
+            <th className="px-2 py-1 text-right border-b border-(--border)">収入計</th>
+            <th className="px-2 py-1 text-right border-b border-(--border)">支出計</th>
+            <th className="px-2 py-1 text-right border-b border-(--border)">収支</th>
+          </tr>
+        </thead>
+        <tbody>
+          {breakdowns.map((b) => {
+            const totalIncome = denseCats.reduce((s, c) => s + (b.income[c] ?? 0), 0);
+            const totalExpense = denseCats.reduce((s, c) => s + (b.expense[c] ?? 0), 0);
+            const net = totalIncome - totalExpense;
+            const netNegative = net < 0;
+            return (
+              <tr key={b.age} className={netNegative ? "bg-red-100 dark:bg-red-950" : ""}>
+                <td className="px-2 py-0.5 border-b border-(--border)">{b.age}</td>
+                {denseCats.map((cat) => {
+                  const v = b.net[cat] ?? 0;
+                  if (v === 0) {
+                    return (
+                      <td key={cat} className="px-2 py-0.5 text-right border-b border-(--border) opacity-30">
+                        0
+                      </td>
+                    );
+                  }
+                  const neg = v < 0;
+                  return (
+                    <td
+                      key={cat}
+                      className={`px-2 py-0.5 text-right border-b border-(--border) tabular-nums ${neg ? "text-red-500" : ""}`}
+                    >
+                      {neg ? fmt(Math.abs(v)) : fmt(v)}
+                    </td>
+                  );
+                })}
+                <td className="px-2 py-0.5 text-right border-b border-(--border) tabular-nums">
+                  {fmt(totalIncome)}
+                </td>
+                <td className="px-2 py-0.5 text-right border-b border-(--border) tabular-nums">
+                  {fmt(totalExpense)}
+                </td>
+                <td
+                  className={`px-2 py-0.5 text-right border-b border-(--border) tabular-nums ${netNegative ? "text-red-500" : ""}`}
+                >
+                  {fmt(Math.abs(net))}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function fmt(n: number): string {
+  return Math.round(n).toLocaleString("ja-JP");
+}

--- a/packages/saiflow/src/components/ResultTable.tsx
+++ b/packages/saiflow/src/components/ResultTable.tsx
@@ -1,15 +1,55 @@
 import { useSaiflowState } from "../store";
 
-export function ResultTable() {
+function downloadCsv(rows: ReturnType<typeof useCsvData>) {
+  if (!rows) return;
+  const header = ["年齢", "収入計", "支出計", "収支", ...rows.assetNames, "総資産"];
+  const lines = [header.join(",")];
+  for (const r of rows.data) {
+    const net = r.totalIncome - r.totalExpense;
+    const row = [
+      r.age,
+      r.totalIncome,
+      r.totalExpense,
+      net,
+      ...rows.assetNames.map((a) => r.balances[a] ?? 0),
+      r.totalAssets,
+    ];
+    lines.push(row.join(","));
+  }
+  const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "saiflow.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function useCsvData() {
   const state = useSaiflowState();
   const { rows } = state;
-
   if (!rows || rows.length === 0) return null;
-
   const assetNames = [...new Set(rows.flatMap((r) => Object.keys(r.balances)))];
+  return { data: rows, assetNames };
+}
+
+export function ResultTable() {
+  const csvData = useCsvData();
+
+  if (!csvData) return null;
+
+  const { data: rows, assetNames } = csvData;
 
   return (
     <div className="h-full overflow-auto">
+      <div className="flex justify-end px-2 py-1">
+        <button
+          className="text-xs text-(--ink) opacity-40 hover:opacity-100 transition-opacity"
+          onClick={() => downloadCsv(csvData)}
+        >
+          CSVダウンロード
+        </button>
+      </div>
       <table className="w-full border-collapse text-sm">
         <thead className="sticky top-0 bg-(--toolbar-bg)">
           <tr>


### PR DESCRIPTION
## Summary
- イベント名から `(補足)` 部分を除去してカテゴリ別に収入/支出を集計するロジックを追加 (`categories.ts`)
- カテゴリ別年次内訳を表示する「内訳表」タブを追加 (`CategoryTable.tsx`)
- カテゴリ別積み上げ棒グラフの「内訳グラフ」タブを追加 (`CategoryChart.tsx`)
- 収支表に CSV ダウンロードボタンを追加

## Test Plan
- [x] typecheck (`tsgo --noEmit`) 通過
- [x] lint (`oxlint`) 通過
- [x] 全82テスト通過