### PR TITLE
feat(mintodo): undo/redo, worklog badge, kanban scroll, gantt fix

### DIFF
--- a/packages/mintodo/src/components/ConnectionLines.test.tsx
+++ b/packages/mintodo/src/components/ConnectionLines.test.tsx
@@ -43,6 +43,8 @@ function makeState(): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
   };
 }
 

--- a/packages/mintodo/src/components/EditModal.test.tsx
+++ b/packages/mintodo/src/components/EditModal.test.tsx
@@ -46,6 +46,8 @@ function makeState(): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
   };
 }
 

--- a/packages/mintodo/src/components/GanttBoard.test.tsx
+++ b/packages/mintodo/src/components/GanttBoard.test.tsx
@@ -41,6 +41,9 @@ function makeState(over: Partial<State> = {}): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
+
     nodes: {
       root: makeNode("root", null, { isRoot: true, text: "Root", children: ["a", "b"] }),
       a: makeNode("a", "root", { text: "Task A", estimate: 4 }),

--- a/packages/mintodo/src/components/GanttBoard.tsx
+++ b/packages/mintodo/src/components/GanttBoard.tsx
@@ -67,7 +67,7 @@ const HOURS_PER_DAY = 8;
 function toPxFromOrigin(date: Date, origin: Date): number {
   const realHours = (date.getTime() - origin.getTime()) / 3_600_000;
   const calDays = Math.floor(realHours / 24);
-  const intraHours = realHours - calDays * 24;
+  const intraHours = Math.min(realHours - calDays * 24, HOURS_PER_DAY);
   return calDays * HOURS_PER_DAY * PIXELS_PER_HOUR + intraHours * PIXELS_PER_HOUR;
 }
 
@@ -240,9 +240,9 @@ export function GanttBoard() {
           {rows.map(({ node }) => {
             const sched = scheduleById.get(node.id);
             if (!sched) return null;
-            const hourWidth = (sched.end.getTime() - sched.start.getTime()) / 3_600_000;
             const left = toPxFromOrigin(sched.start, originDate);
-            const width = Math.max(hourWidth * PIXELS_PER_HOUR, 2);
+            const right = toPxFromOrigin(sched.end, originDate);
+            const width = Math.max(right - left, 2);
             const isLeaf = node.children.length === 0;
             return (
               <div
@@ -291,10 +291,9 @@ export function GanttBoard() {
                       const childSched = scheduleById.get(cid);
                       const childNode = nodes[cid];
                       if (!childSched || !childNode) return null;
-                      const childHourWidth =
-                        (childSched.end.getTime() - childSched.start.getTime()) / 3_600_000;
                       const childLeft = toPxFromOrigin(childSched.start, originDate);
-                      const childWidth = Math.max(childHourWidth * PIXELS_PER_HOUR, 2);
+                      const childRight = toPxFromOrigin(childSched.end, originDate);
+                      const childWidth = Math.max(childRight - childLeft, 2);
                       return (
                         <div
                           key={cid}

--- a/packages/mintodo/src/components/KanbanBoard.tsx
+++ b/packages/mintodo/src/components/KanbanBoard.tsx
@@ -32,7 +32,9 @@ export function KanbanBoard() {
   const { dispatch, state } = useMindStore();
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8, delay: 200 } }),
+  );
 
   function handleDragStart(event: { active: { id: string | number } }) {
     const id = String(event.active.id);

--- a/packages/mintodo/src/components/KanbanCard.tsx
+++ b/packages/mintodo/src/components/KanbanCard.tsx
@@ -23,7 +23,7 @@ export function KanbanCard({ node }: Props) {
     borderColor: "var(--border)",
     color: "var(--ink)",
     opacity: isDragging ? 0.4 : 1,
-    touchAction: "none",
+    touchAction: "manipulation",
     transform: CSS.Translate.toString(transform),
     transition,
   };
@@ -63,6 +63,7 @@ export function KanbanCard({ node }: Props) {
           <button
             type="button"
             data-testid={`kanban-card-worklog-${node.id}`}
+            className="relative"
             onClick={(e) => {
               e.stopPropagation();
               dispatch({
@@ -74,6 +75,11 @@ export function KanbanCard({ node }: Props) {
             title="作業履歴"
           >
             <ListOrdered size={12} />
+            {node.workLogs.length > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 bg-slate-500 text-white text-[8px] font-bold rounded-full min-w-[14px] h-[14px] flex items-center justify-center px-0.5 leading-none">
+                {node.workLogs.length}
+              </span>
+            )}
           </button>
         </div>
       </div>

--- a/packages/mintodo/src/components/NodeCard.test.tsx
+++ b/packages/mintodo/src/components/NodeCard.test.tsx
@@ -49,6 +49,8 @@ function makeState(): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
     nodes: {
       root: makeNode("root", null, { isRoot: true, children: ["a"] }),
       a: makeNode("a", "root", { x: 0, y: -340, children: ["a1"] }),

--- a/packages/mintodo/src/components/NodeCard.tsx
+++ b/packages/mintodo/src/components/NodeCard.tsx
@@ -138,7 +138,7 @@ export function NodeCard({ node }: Props) {
           <button
             type="button"
             data-testid={`worklog-button-${node.id}`}
-            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 p-1 rounded-md transition"
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 p-1 rounded-md transition relative"
             onClick={(e) => {
               e.stopPropagation();
               dispatch({ modal: { kind: "work-log", nodeId: node.id }, type: "OPEN_MODAL" });
@@ -147,6 +147,11 @@ export function NodeCard({ node }: Props) {
             title="作業履歴"
           >
             <ListOrdered size={12} />
+            {node.workLogs.length > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 bg-slate-500 text-white text-[8px] font-bold rounded-full min-w-[14px] h-[14px] flex items-center justify-center px-0.5 leading-none">
+                {node.workLogs.length}
+              </span>
+            )}
           </button>
         </div>
       </div>

--- a/packages/mintodo/src/components/TaskCard.test.tsx
+++ b/packages/mintodo/src/components/TaskCard.test.tsx
@@ -41,6 +41,9 @@ function makeState(over: Partial<State> = {}): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
+
     nodes: { root: makeNode({ id: "root", isRoot: true }), n1: makeNode() },
     ...over,
   };

--- a/packages/mintodo/src/components/TextEditor.test.tsx
+++ b/packages/mintodo/src/components/TextEditor.test.tsx
@@ -43,6 +43,9 @@ function makeState(over: Partial<State> = {}): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
+
     nodes: {
       root: makeNode({ id: "root", isRoot: true, text: "Root", children: ["n1"] }),
       n1: makeNode(),

--- a/packages/mintodo/src/hooks/use-keyboard.ts
+++ b/packages/mintodo/src/hooks/use-keyboard.ts
@@ -20,6 +20,12 @@ export function useKeyboard(): void {
         }
         return;
       }
+      if ((e.key === "z" || e.key === "Z") && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        dispatch({ type: e.shiftKey ? "REDO" : "UNDO" });
+        return;
+      }
+
       if (state.modal) return;
       if (isEditableTarget(e.target)) return;
 

--- a/packages/mintodo/src/hooks/use-tween.test.tsx
+++ b/packages/mintodo/src/hooks/use-tween.test.tsx
@@ -48,6 +48,8 @@ function makeState(): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
   };
 }
 

--- a/packages/mintodo/src/store.test.ts
+++ b/packages/mintodo/src/store.test.ts
@@ -862,3 +862,96 @@ describe("reducer — REORDER_CHILDREN", () => {
     expect(next).toBe(s);
   });
 });
+
+describe("reducer — UNDO / REDO", () => {
+  it("UNDO restores state before an undoable action", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, children: [] }) },
+    };
+    const next = reducer(s, { newId: "n1", parentId: "root", type: "ADD_CHILD" });
+    expect(next.past.length).toBe(1);
+    expect(next.future.length).toBe(0);
+    const undone = reducer(next, { type: "UNDO" });
+    expect(undone.past.length).toBe(0);
+    expect(undone.future.length).toBe(1);
+    expect(undone.nodes.n1).toBeUndefined();
+    expect(undone.nodes.root.children).toEqual([]);
+  });
+
+  it("REDO re-applies the undone action", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, children: [] }) },
+    };
+    const next = reducer(s, { newId: "n1", parentId: "root", type: "ADD_CHILD" });
+    const undone = reducer(next, { type: "UNDO" });
+    const redone = reducer(undone, { type: "REDO" });
+    expect(redone.future.length).toBe(0);
+    expect(redone.past.length).toBe(1);
+    expect(redone.nodes.n1).toBeDefined();
+  });
+
+  it("new action after UNDO clears the future stack", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, children: [] }) },
+    };
+    const s1 = reducer(s, { newId: "n1", parentId: "root", type: "ADD_CHILD" });
+    const s2 = reducer(s1, { type: "UNDO" });
+    expect(s2.future.length).toBe(1);
+    const s3 = reducer(s2, { newId: "n2", parentId: "root", type: "ADD_CHILD" });
+    expect(s3.future.length).toBe(0);
+    expect(s3.nodes.n2).toBeDefined();
+  });
+
+  it("UNDO on empty past is a no-op", () => {
+    const s = createInitialState();
+    const next = reducer(s, { type: "UNDO" });
+    expect(next).toBe(s);
+  });
+
+  it("REDO on empty future is a no-op", () => {
+    const s = createInitialState();
+    const next = reducer(s, { type: "REDO" });
+    expect(next).toBe(s);
+  });
+
+  it("non-undoable action does not create undo entry", () => {
+    const s = createInitialState();
+    const next = reducer(s, { id: "n1", type: "SELECT" });
+    expect(next.past.length).toBe(0);
+  });
+
+  it("UPDATE_NODE creates undo entry", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: { root: makeNode("root", "b-a", { isRoot: true, children: [] }) },
+    };
+    const updated = reducer(s, {
+      id: "root",
+      patch: { dueDate: "2026-07-01" },
+      type: "UPDATE_NODE",
+    });
+    expect(updated.past.length).toBe(1);
+    const undone = reducer(updated, { type: "UNDO" });
+    expect(undone.nodes.root.dueDate).toBe("");
+  });
+
+  it("DELETE_NODE creates undo entry and restores the deleted node", () => {
+    const s = {
+      ...createInitialState(),
+      nodes: {
+        root: makeNode("root", "b-a", { isRoot: true, children: ["a"] }),
+        a: makeNode("a", "b-a", { parentId: "root", children: ["b"] }),
+        b: makeNode("b", "b-a", { parentId: "a" }),
+      },
+    };
+    const deleted = reducer(s, { id: "a", type: "DELETE_NODE" });
+    expect(deleted.nodes.a).toBeUndefined();
+    const undone = reducer(deleted, { type: "UNDO" });
+    expect(undone.nodes.a).toBeDefined();
+    expect(undone.nodes.b).toBeDefined();
+    expect(undone.nodes.root.children).toContain("a");
+  });
+});

--- a/packages/mintodo/src/store.ts
+++ b/packages/mintodo/src/store.ts
@@ -12,6 +12,8 @@ import type {
 import { nextStatus } from "./lib/status-cycle";
 import { applyRadialLayout } from "./layout/radial";
 
+export type StateSnapshot = Omit<State, "past" | "future">;
+
 export interface State {
   boards: Board[];
   currentBoardId: string | null;
@@ -25,6 +27,8 @@ export interface State {
   searchQuery: string;
   selectedNodeId: string;
   view: View;
+  past: StateSnapshot[];
+  future: StateSnapshot[];
 }
 
 export type Action =
@@ -33,6 +37,7 @@ export type Action =
   | { type: "DELETE_BOARD"; id: string; nextBoardId: string | null }
   | { type: "DELETE_NODE"; id: string }
   | { type: "OPEN_MODAL"; modal: Modal }
+  | { type: "REDO" }
   | { type: "REPARENT"; id: string; newParentId: string }
   | { type: "REORDER_CHILDREN"; nodeId: string; targetId: string }
   | { type: "RENAME_BOARD"; id: string; name: string }
@@ -52,6 +57,7 @@ export type Action =
   | { type: "TOGGLE_HIDE_COMPLETED" }
   | { type: "SET_STATUS"; id: string; status: TaskStatus }
   | { type: "SET_VIEW_MODE"; viewMode: ViewMode }
+  | { type: "UNDO" }
   | { type: "DELETE_COMPLETED" }
   | {
       type: "CREATE_CHILD";
@@ -83,7 +89,61 @@ export function createInitialState(): State {
     searchQuery: "",
     selectedNodeId: "",
     view: { pan: { x: 0, y: 0 }, zoom: 1 },
+    past: [],
+    future: [],
   };
+}
+
+const UNDOABLE_ACTIONS = new Set<Action["type"]>([
+  "ADD_BOARD",
+  "ADD_CHILD",
+  "CREATE_CHILD",
+  "DELETE_BOARD",
+  "DELETE_COMPLETED",
+  "DELETE_NODE",
+  "DELETE_WORK_LOG",
+  "ADD_WORK_LOG",
+  "RENAME_BOARD",
+  "REORDER_CHILDREN",
+  "REPARENT",
+  "RESET",
+  "SET_NODES",
+  "SET_STATUS",
+  "TOGGLE_COLLAPSE",
+  "TOGGLE_COMPLETE",
+  "UPDATE_NODE",
+]);
+
+function isUndoableAction(type: Action["type"]): boolean {
+  return UNDOABLE_ACTIONS.has(type);
+}
+
+function snapshotState(state: State): StateSnapshot {
+  return {
+    boards: state.boards,
+    currentBoardId: state.currentBoardId,
+    draggingNodeId: state.draggingNodeId,
+    drawerOpen: state.drawerOpen,
+    hideCompleted: state.hideCompleted,
+    layoutVersion: state.layoutVersion,
+    modal: state.modal,
+    viewMode: state.viewMode,
+    nodes: state.nodes,
+    searchQuery: state.searchQuery,
+    selectedNodeId: state.selectedNodeId,
+    view: state.view,
+  };
+}
+
+function pushUndo(state: State, nextState: State): State {
+  if (nextState === state) return state;
+  const snapshot = snapshotState(state);
+  const maxHistory = 50;
+  const past =
+    state.past.length >= maxHistory
+      ? [...state.past.slice(-(maxHistory - 1)), snapshot]
+      : [...state.past, snapshot];
+  return { ...nextState, past, future: [] };
 }
 
 function withRadialLayout(state: State, nodes: Record<string, MindNode>): State {
@@ -103,7 +163,7 @@ export function isDescendant(
   return false;
 }
 
-export function reducer(state: State, action: Action): State {
+function applyAction(state: State, action: Action): State {
   switch (action.type) {
     case "SET_BOARDS": {
       return { ...state, boards: action.boards };
@@ -305,7 +365,7 @@ export function reducer(state: State, action: Action): State {
       const target = state.nodes[action.id];
       if (!target) return state;
       const next: TaskStatus = target.completed ? "inbox" : nextStatus(target.status);
-      return reducer(state, { id: action.id, status: next, type: "SET_STATUS" });
+      return applyAction(state, { id: action.id, status: next, type: "SET_STATUS" });
     }
     case "TOGGLE_COLLAPSE": {
       const node = state.nodes[action.id];
@@ -469,6 +529,42 @@ export function reducer(state: State, action: Action): State {
     }
     default: {
       return state;
+    }
+  }
+}
+
+export function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "UNDO": {
+      if (state.past.length === 0) return state;
+      const snapshot = state.past.at(-1);
+      const newPast = state.past.slice(0, -1);
+      const newFuture = [snapshotState(state), ...state.future];
+      return {
+        ...state,
+        ...snapshot,
+        past: newPast,
+        future: newFuture,
+      };
+    }
+    case "REDO": {
+      if (state.future.length === 0) return state;
+      const [snapshot] = state.future;
+      const newFuture = state.future.slice(1);
+      const newPast = [...state.past, snapshotState(state)];
+      return {
+        ...state,
+        ...snapshot,
+        past: newPast,
+        future: newFuture,
+      };
+    }
+    default: {
+      const next = applyAction(state, action);
+      if (isUndoableAction(action.type)) {
+        return pushUndo(state, next);
+      }
+      return next;
     }
   }
 }


### PR DESCRIPTION
## Summary

- **undo/redo**: Ctrl+Z / Ctrl+Shift+Z で操作の取り消し・やり直し（50件のスナップショット履歴）
- **ログバッジ**: NodeCard / KanbanCard の作業履歴アイコンにコメント数バッジを表示
- **カンバンスクロール**: スマホでのタッチ縦スクロール対応（drag delay + touch-action 修正）
- **ガントチャート修正**: toPxFromOrigin の非単調性を修正し、日付境界でバーが崩れる問題を解決