### PR TITLE
feat(emolog): add emolog with summary view

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -19,6 +19,7 @@
     "@mijime/blog": "workspace:*",
     "@mijime/lords-of-the-stigmata": "workspace:*",
     "@mijime/madories": "workspace:*",
+    "@mijime/emolog": "workspace:*",
     "@mijime/mintodo": "workspace:*",
     "@mijime/saiflow": "workspace:*",
     "@mijime/theme": "workspace:*",

--- a/apps/main/src/pages/apps/emolog.astro
+++ b/apps/main/src/pages/apps/emolog.astro
@@ -1,6 +1,6 @@
 ---
 import { App as EmologApp } from "@mijime/emolog";
-import BaseLayout from "../layouts/base-layout.astro";
+import BaseLayout from "../../layouts/base-layout.astro";
 import "@mijime/emolog/index.css";
 ---
 

--- a/apps/main/src/pages/apps/index.astro
+++ b/apps/main/src/pages/apps/index.astro
@@ -1,0 +1,166 @@
+---
+import BaseLayout from "../../layouts/base-layout.astro";
+
+const apps = [
+  { slug: "madories", desc: "floor plan editor", i: 0 },
+  { slug: "mintodo", desc: "mindmap todo", i: 1 },
+  { slug: "saiflow", desc: "life simulation", i: 2 },
+  { slug: "lords-of-the-stigmata", desc: "3D board game", i: 3 },
+  { slug: "emolog", desc: "emotion logger", i: 4 },
+];
+---
+
+<BaseLayout title="apps">
+  <div class="apps">
+    <div class="apps-rule apps-rule--top"></div>
+
+    <div class="apps-masthead">
+      <h1 class="apps-title">apps</h1>
+    </div>
+
+    <div class="apps-rule apps-rule--mid"></div>
+
+    <div class="apps-body">
+      <ul class="apps-list">
+        {apps.map((app) => (
+          <li class="apps-item" style={`--i:${app.i}`}>
+            <a href={`/apps/${app.slug}/`} class="apps-link">
+              <span class="apps-slug">{app.slug}</span>
+              <span class="apps-desc">{app.desc}</span>
+              <span class="apps-arrow">→</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    <div class="apps-rule apps-rule--bottom"></div>
+
+    <footer class="apps-footer">
+      <a href="/" class="apps-back">← home</a>
+    </footer>
+  </div>
+</BaseLayout>
+
+<style>
+  .apps {
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+
+  .apps-rule {
+    border: none;
+    border-top: 1px solid var(--border);
+  }
+  .apps-rule--top { margin-top: 48px; }
+  .apps-rule--mid { margin: 0; }
+  .apps-rule--bottom { margin-top: auto; }
+
+  .apps-masthead {
+    padding: 32px 0 28px;
+    animation: fadeUp 0.6s ease both;
+  }
+
+  .apps-title {
+    font-family: "Crimson Pro", serif;
+    font-size: clamp(48px, 10vw, 80px);
+    font-weight: 600;
+    line-height: 0.92;
+    letter-spacing: -0.03em;
+    color: var(--ink);
+    margin: 0;
+
+    &::after {
+      content: "";
+      display: block;
+      width: 3ch;
+      height: 3px;
+      background: var(--terra);
+      margin-top: 14px;
+    }
+  }
+
+  .apps-body {
+    padding: 40px 0;
+    animation: fadeUp 0.6s 0.1s ease both;
+  }
+
+  .apps-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .apps-item {
+    animation: fadeUp 0.5s calc(var(--i) * 0.08s + 0.2s) ease both;
+    border-bottom: 1px solid var(--grid);
+    &:first-child { border-top: 1px solid var(--grid); }
+  }
+
+  .apps-link {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 0;
+    color: var(--ink);
+    text-decoration: none;
+    transition: color 0.15s;
+
+    &:hover {
+      color: var(--terra);
+      .apps-arrow { transform: translateX(4px); }
+    }
+  }
+
+  .apps-slug {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+
+  .apps-desc {
+    font-size: 11px;
+    color: var(--mid);
+  }
+
+  .apps-arrow {
+    font-size: 14px;
+    color: var(--terra);
+    transition: transform 0.2s ease;
+    opacity: 0.6;
+  }
+
+  .apps-footer {
+    padding: 20px 0 32px;
+    animation: fadeUp 0.5s 0.5s ease both;
+  }
+
+  .apps-back {
+    font-size: 12px;
+    color: var(--mid);
+    text-decoration: none;
+    transition: color 0.15s;
+
+    &:hover { color: var(--terra); }
+  }
+
+  @keyframes fadeUp {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/apps/main/src/pages/apps/lords-of-the-stigmata.astro
+++ b/apps/main/src/pages/apps/lords-of-the-stigmata.astro
@@ -1,6 +1,6 @@
 ---
 import { App as StigmataApp } from "@mijime/lords-of-the-stigmata";
-import BaseLayout from "../layouts/base-layout.astro";
+import BaseLayout from "../../layouts/base-layout.astro";
 import "@mijime/lords-of-the-stigmata/styles.css";
 ---
 

--- a/apps/main/src/pages/apps/madories.astro
+++ b/apps/main/src/pages/apps/madories.astro
@@ -1,6 +1,6 @@
 ---
 import { App as MadoriesApp } from "@mijime/madories";
-import BaseLayout from "../layouts/base-layout.astro";
+import BaseLayout from "../../layouts/base-layout.astro";
 import "@mijime/madories/index.css";
 ---
 

--- a/apps/main/src/pages/apps/mintodo.astro
+++ b/apps/main/src/pages/apps/mintodo.astro
@@ -1,6 +1,6 @@
 ---
 import { App as MintodoApp } from "@mijime/mintodo";
-import BaseLayout from "../layouts/base-layout.astro";
+import BaseLayout from "../../layouts/base-layout.astro";
 import "@mijime/mintodo/index.css";
 ---
 

--- a/apps/main/src/pages/apps/saiflow.astro
+++ b/apps/main/src/pages/apps/saiflow.astro
@@ -1,6 +1,6 @@
 ---
 import { App as SaiflowApp } from "@mijime/saiflow";
-import BaseLayout from "../layouts/base-layout.astro";
+import BaseLayout from "../../layouts/base-layout.astro";
 import "@mijime/saiflow/index.css";
 ---
 

--- a/apps/main/src/pages/emolog.astro
+++ b/apps/main/src/pages/emolog.astro
@@ -1,0 +1,9 @@
+---
+import { App as EmologApp } from "@mijime/emolog";
+import BaseLayout from "../layouts/base-layout.astro";
+import "@mijime/emolog/index.css";
+---
+
+<BaseLayout title="emolog">
+  <EmologApp client:only="react" />
+</BaseLayout>

--- a/apps/main/src/pages/index.astro
+++ b/apps/main/src/pages/index.astro
@@ -52,6 +52,13 @@ import BaseLayout from "../layouts/base-layout.astro";
               <span class="home-app-arrow">→</span>
             </a>
           </li>
+          <li class="home-app-item" style="--i:5">
+            <a href="/emolog/" class="home-app-link">
+              <span class="home-app-slug">emolog</span>
+              <span class="home-app-desc">emotion logger</span>
+              <span class="home-app-arrow">→</span>
+            </a>
+          </li>
         </ul>
       </section>
 

--- a/apps/main/src/pages/index.astro
+++ b/apps/main/src/pages/index.astro
@@ -25,37 +25,9 @@ import BaseLayout from "../layouts/base-layout.astro";
             </a>
           </li>
           <li class="home-app-item" style="--i:1">
-            <a href="/madories/" class="home-app-link">
-              <span class="home-app-slug">madories</span>
-              <span class="home-app-desc">floor plan editor</span>
-              <span class="home-app-arrow">→</span>
-            </a>
-          </li>
-          <li class="home-app-item" style="--i:2">
-            <a href="/mintodo/" class="home-app-link">
-              <span class="home-app-slug">mintodo</span>
-              <span class="home-app-desc">mindmap todo</span>
-              <span class="home-app-arrow">→</span>
-            </a>
-          </li>
-          <li class="home-app-item" style="--i:3">
-            <a href="/saiflow/" class="home-app-link">
-              <span class="home-app-slug">saiflow</span>
-              <span class="home-app-desc">life simulation</span>
-              <span class="home-app-arrow">→</span>
-            </a>
-          </li>
-          <li class="home-app-item" style="--i:4">
-            <a href="/lords-of-the-stigmata/" class="home-app-link">
-              <span class="home-app-slug">lords-of-the-stigmata</span>
-              <span class="home-app-desc">3D board game</span>
-              <span class="home-app-arrow">→</span>
-            </a>
-          </li>
-          <li class="home-app-item" style="--i:5">
-            <a href="/emolog/" class="home-app-link">
-              <span class="home-app-slug">emolog</span>
-              <span class="home-app-desc">emotion logger</span>
+            <a href="/apps/" class="home-app-link">
+              <span class="home-app-slug">apps</span>
+              <span class="home-app-desc">all applications</span>
               <span class="home-app-arrow">→</span>
             </a>
           </li>

--- a/packages/emolog/.oxlintrc.json
+++ b/packages/emolog/.oxlintrc.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../.oxlintrc.json"],
+  "rules": {
+    "eslint/max-lines": "off",
+    "eslint/complexity": "off",
+    "eslint/no-nested-ternary": "off",
+    "unicorn/no-nested-ternary": "off",
+    "eslint/no-plusplus": "off",
+    "eslint/no-continue": "off",
+    "eslint/no-alert": "off",
+    "eslint/no-console": "off",
+    "eslint/no-inline-comments": "off",
+    "unicorn/filename-case": "off",
+    "oxc/no-optional-chaining": "off",
+    "typescript/no-non-null-assertion": "off",
+    "eslint/require-await": "off",
+    "eslint/no-duplicate-imports": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-array-reduce": "off",
+    "typescript/no-explicit-any": "off"
+  }
+}

--- a/packages/emolog/index.html
+++ b/packages/emolog/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>emolog</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/App.tsx"></script>
+</body>
+</html>

--- a/packages/emolog/index.html
+++ b/packages/emolog/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>emolog</title>
-</head>
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/App.tsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>emolog</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/App.tsx"></script>
+  </body>
 </html>

--- a/packages/emolog/package.json
+++ b/packages/emolog/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@mijime/emolog",
+  "version": "1.0.0",
+  "description": "Emoji-based emotion logger",
+  "type": "module",
+  "exports": {
+    ".": "./src/App.tsx",
+    "./index.css": "./src/index.css"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsgo --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "check": "pnpm run check:format && pnpm run check:tsgo && pnpm run check:oxlint",
+    "check:format": "oxfmt --check",
+    "check:tsgo": "tsgo --noEmit",
+    "check:oxlint": "oxlint --format=github --fix",
+    "format": "pnpm run format:oxfmt",
+    "format:oxfmt": "oxfmt"
+  },
+  "dependencies": {
+    "@mijime/theme": "workspace:*",
+    "dexie": "^4.4.4",
+    "emoji-picker-element": "^1.29.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.2",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@typescript/native-preview": "7.0.0-dev.20260604.1",
+    "@vitejs/plugin-react": "^5.2.0",
+    "fake-indexeddb": "^6.2.5",
+    "jsdom": "^25.0.1",
+    "oxfmt": "^0.46.0",
+    "oxlint": "^1.72.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "tailwindcss": "^4.3.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3",
+    "vitest": "^3.2.7"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/emolog/pages/emolog.astro
+++ b/packages/emolog/pages/emolog.astro
@@ -1,0 +1,9 @@
+---
+import { App as EmologApp } from "@mijime/emolog";
+import BaseLayout from "../layouts/base-layout.astro";
+import "@mijime/emolog/index.css";
+---
+
+<BaseLayout title="emolog">
+  <EmologApp client:only="react" />
+</BaseLayout>

--- a/packages/emolog/src/App.tsx
+++ b/packages/emolog/src/App.tsx
@@ -31,7 +31,7 @@ function getFavMap(): Record<string, number> {
 function getTopFavorites(): string[] {
   const map = getFavMap();
   return Object.entries(map)
-    .sort(([, a], [, b]) => b - a)
+    .toSorted(([, a], [, b]) => b - a)
     .slice(0, MAX_FAV)
     .map(([emoji]) => emoji);
 }
@@ -114,7 +114,7 @@ export function App() {
     const el = pickerRef.current;
     if (!el) return;
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
+      const { detail } = e as CustomEvent;
       const emoji = detail.unicode || detail.emoji?.native || detail.emoji;
       if (emoji) {
         handleTap(emoji);
@@ -214,7 +214,7 @@ export function App() {
 
   async function copyLog() {
     const dateGroups = groupByDate(entries);
-    const dateKeys = Object.keys(dateGroups).sort();
+    const dateKeys = Object.keys(dateGroups).toSorted();
     if (dateKeys.length === 0) {
       await navigator.clipboard.writeText("📋 記録なし");
       return;
@@ -298,7 +298,7 @@ export function App() {
   const isToday = selectedDate === todayStr;
   const filteredEntries = filterEmoji ? entries.filter((e) => e.emoji === filterEmoji) : entries;
   const groupedEntries = groupByDate(filteredEntries);
-  const dateLabels = Object.keys(groupedEntries).sort();
+  const dateLabels = Object.keys(groupedEntries).toSorted();
   const hasAnyEntry = dateLabels.length > 0;
 
   return (
@@ -463,13 +463,7 @@ export function App() {
 
           {/* ── タイムライン ── */}
           <div className="emolog-timeline">
-            {!hasAnyEntry ? (
-              <p className="emolog-empty">
-                {selectedDate === todayStr
-                  ? "絵文字をタップして気持ちを記録しよう 👆"
-                  : "この期間の記録はありません"}
-              </p>
-            ) : (
+            {hasAnyEntry ? (
               dateLabels.map((date) => (
                 <div key={date} className="emolog-timeline-group">
                   <div className="emolog-timeline-date">
@@ -522,6 +516,12 @@ export function App() {
                   ))}
                 </div>
               ))
+            ) : (
+              <p className="emolog-empty">
+                {selectedDate === todayStr
+                  ? "絵文字をタップして気持ちを記録しよう 👆"
+                  : "この期間の記録はありません"}
+              </p>
             )}
           </div>
         </>

--- a/packages/emolog/src/App.tsx
+++ b/packages/emolog/src/App.tsx
@@ -1,8 +1,19 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { getEntriesByDateRange, addEntry, deleteEntry, updateEntryNote, getLists, addList, renameList, removeList, ensureDefaultList } from "./store";
+import {
+  getEntriesByDateRange,
+  addEntry,
+  deleteEntry,
+  updateEntryNote,
+  getLists,
+  addList,
+  renameList,
+  removeList,
+  ensureDefaultList,
+} from "./store";
 import { type Entry, today, formatTime } from "./types";
 import type { ListDef } from "./store";
 import { CalendarView } from "./CalendarView";
+import { SummaryView } from "./SummaryView";
 import "emoji-picker-element";
 
 const FAV_KEY = "emolog-favs";
@@ -53,7 +64,7 @@ export function App() {
   const [editNote, setEditNote] = useState("");
   const [showPicker, setShowPicker] = useState(false);
   const [favorites, setFavorites] = useState<string[]>(() => getTopFavorites());
-  const [viewMode, setViewMode] = useState<"timeline" | "calendar">("timeline");
+  const [viewMode, setViewMode] = useState<"timeline" | "calendar" | "summary">("timeline");
   const [selectedList, setSelectedList] = useState<string>("");
   const [lists, setLists] = useState<ListDef[]>([]);
   const [menuOpen, setMenuOpen] = useState<string | null>(null);
@@ -73,13 +84,16 @@ export function App() {
   // Load lists on mount
   useEffect(() => {
     setListError(null);
-    ensureDefaultList().then((defaultName) => {
-      setSelectedList(defaultName);
-      return getLists();
-    }).then(setLists).catch((err) => {
-      console.error('list loading error:', err);
-      setListError(err?.message || String(err));
-    });
+    ensureDefaultList()
+      .then((defaultName) => {
+        setSelectedList(defaultName);
+        return getLists();
+      })
+      .then(setLists)
+      .catch((err) => {
+        console.error("list loading error:", err);
+        setListError(err?.message || String(err));
+      });
   }, []);
 
   // Refresh lists after changes
@@ -193,6 +207,11 @@ export function App() {
     setFilterEmoji((prev) => (prev === emoji ? null : emoji));
   }
 
+  function handleSelectEmojiFromSummary(emoji: string) {
+    setFilterEmoji(emoji);
+    setViewMode("timeline");
+  }
+
   async function copyLog() {
     const dateGroups = groupByDate(entries);
     const dateKeys = Object.keys(dateGroups).sort();
@@ -239,7 +258,8 @@ export function App() {
       alert("最後のリストは削除できません");
       return;
     }
-    if (!window.confirm(`「${name}」を削除しますか？\nこのリストの記録は「リストなし」になります`)) return;
+    if (!window.confirm(`「${name}」を削除しますか？\nこのリストの記録は「リストなし」になります`))
+      return;
     await removeList(name);
     await refreshLists();
     if (selectedList === name) {
@@ -276,9 +296,7 @@ export function App() {
   }
 
   const isToday = selectedDate === todayStr;
-  const filteredEntries = filterEmoji
-    ? entries.filter((e) => e.emoji === filterEmoji)
-    : entries;
+  const filteredEntries = filterEmoji ? entries.filter((e) => e.emoji === filterEmoji) : entries;
   const groupedEntries = groupByDate(filteredEntries);
   const dateLabels = Object.keys(groupedEntries).sort();
   const hasAnyEntry = dateLabels.length > 0;
@@ -288,7 +306,9 @@ export function App() {
       {/* ── リストタブ ── */}
       <div className="emolog-lists">
         {listError ? (
-          <div className="emolog-list-placeholder" style={{color:'#e74c3c'}}>エラー: {listError}</div>
+          <div className="emolog-list-placeholder" style={{ color: "#e74c3c" }}>
+            エラー: {listError}
+          </div>
         ) : lists.length === 0 ? (
           <div className="emolog-list-placeholder">読み込み中…</div>
         ) : (
@@ -320,7 +340,10 @@ export function App() {
                     </button>
                   )}
                   {l.name === selectedList && renaming !== l.name && (
-                    <div className="emolog-list-menu-wrap" ref={menuOpen === l.name ? menuRef : undefined}>
+                    <div
+                      className="emolog-list-menu-wrap"
+                      ref={menuOpen === l.name ? menuRef : undefined}
+                    >
                       <button
                         className="emolog-list-menu-btn"
                         onClick={(e) => {
@@ -332,9 +355,7 @@ export function App() {
                       </button>
                       {menuOpen === l.name && (
                         <div className="emolog-list-menu">
-                          <button onClick={() => handleStartRename(l.name)}>
-                            ✏️ 名前を変更
-                          </button>
+                          <button onClick={() => handleStartRename(l.name)}>✏️ 名前を変更</button>
                           <button
                             className="emolog-list-menu-del"
                             onClick={() => handleRemoveList(l.name)}
@@ -372,15 +393,27 @@ export function App() {
               →
             </button>
           </>
-        ) : (
+        ) : viewMode === "calendar" ? (
           <span className="emolog-date-label">📅 カレンダー</span>
+        ) : (
+          <span className="emolog-date-label">📊 集計</span>
         )}
         <button
-          onClick={() => setViewMode((v) => (v === "timeline" ? "calendar" : "timeline"))}
-          className={`emolog-nav-btn emolog-view-toggle${viewMode === "calendar" ? " emolog-view-active" : ""}`}
-          title={viewMode === "timeline" ? "カレンダー表示" : "タイムラインに戻る"}
+          onClick={() =>
+            setViewMode((v) =>
+              v === "timeline" ? "calendar" : v === "calendar" ? "summary" : "timeline",
+            )
+          }
+          className={`emolog-nav-btn emolog-view-toggle${viewMode === "calendar" || viewMode === "summary" ? " emolog-view-active" : ""}`}
+          title={
+            viewMode === "timeline"
+              ? "カレンダー表示"
+              : viewMode === "calendar"
+                ? "集計表示"
+                : "タイムラインに戻る"
+          }
         >
-          {viewMode === "timeline" ? "📅" : "📋"}
+          {viewMode === "timeline" ? "📅" : viewMode === "calendar" ? "📊" : "📋"}
         </button>
         {viewMode === "timeline" && (
           <button onClick={copyLog} className="emolog-copy-btn" title="コピー">
@@ -391,6 +424,8 @@ export function App() {
 
       {viewMode === "calendar" ? (
         <CalendarView onSelectDate={handleSelectDate} todayStr={todayStr} list={selectedList} />
+      ) : viewMode === "summary" ? (
+        <SummaryView onSelectEmoji={handleSelectEmojiFromSummary} list={selectedList} />
       ) : (
         <>
           {/* ── フィルター表示 ── */}
@@ -445,12 +480,14 @@ export function App() {
                     <div key={entry.id} className="emolog-timeline-entry">
                       <span className="emolog-entry-time">{formatTime(entry.timestamp)}</span>
                       <span
-    className={`emolog-entry-emoji${filterEmoji === entry.emoji ? " emolog-emoji-filter-active" : ""}`}
-    onClick={() => handleFilterEmoji(entry.emoji)}
-    title={filterEmoji === entry.emoji ? "フィルター解除" : "この絵文字でフィルター"}
-  >
-    {entry.emoji}
-  </span>
+                        className={`emolog-entry-emoji${filterEmoji === entry.emoji ? " emolog-emoji-filter-active" : ""}`}
+                        onClick={() => handleFilterEmoji(entry.emoji)}
+                        title={
+                          filterEmoji === entry.emoji ? "フィルター解除" : "この絵文字でフィルター"
+                        }
+                      >
+                        {entry.emoji}
+                      </span>
                       {editingId === entry.id ? (
                         <input
                           ref={editInputRef}

--- a/packages/emolog/src/App.tsx
+++ b/packages/emolog/src/App.tsx
@@ -1,0 +1,494 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { getEntriesByDateRange, addEntry, deleteEntry, updateEntryNote, getLists, addList, renameList, removeList, ensureDefaultList } from "./store";
+import { type Entry, today, formatTime } from "./types";
+import type { ListDef } from "./store";
+import { CalendarView } from "./CalendarView";
+import "emoji-picker-element";
+
+const FAV_KEY = "emolog-favs";
+const MAX_FAV = 8;
+const TIMELINE_DAYS = 3;
+
+function getFavMap(): Record<string, number> {
+  try {
+    return JSON.parse(localStorage.getItem(FAV_KEY) || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function getTopFavorites(): string[] {
+  const map = getFavMap();
+  return Object.entries(map)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, MAX_FAV)
+    .map(([emoji]) => emoji);
+}
+
+function incrementFavorite(emoji: string) {
+  const map = getFavMap();
+  map[emoji] = (map[emoji] || 0) + 1;
+  localStorage.setItem(FAV_KEY, JSON.stringify(map));
+}
+
+function getFullDate(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  return `${m}/${d}（${weekdays[date.getDay()]}）`;
+}
+
+export function App() {
+  const todayStr = today();
+  const [selectedDate, setSelectedDate] = useState(todayStr);
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editNote, setEditNote] = useState("");
+  const [showPicker, setShowPicker] = useState(false);
+  const [favorites, setFavorites] = useState<string[]>(() => getTopFavorites());
+  const [viewMode, setViewMode] = useState<"timeline" | "calendar">("timeline");
+  const [selectedList, setSelectedList] = useState<string>("");
+  const [lists, setLists] = useState<ListDef[]>([]);
+  const [menuOpen, setMenuOpen] = useState<string | null>(null);
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [listError, setListError] = useState<string | null>(null);
+  const [filterEmoji, setFilterEmoji] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const pickerRef = useRef<HTMLElement>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshFavorites = useCallback(() => {
+    setFavorites(getTopFavorites());
+  }, []);
+
+  // Load lists on mount
+  useEffect(() => {
+    setListError(null);
+    ensureDefaultList().then((defaultName) => {
+      setSelectedList(defaultName);
+      return getLists();
+    }).then(setLists).catch((err) => {
+      console.error('list loading error:', err);
+      setListError(err?.message || String(err));
+    });
+  }, []);
+
+  // Refresh lists after changes
+  const refreshLists = useCallback(() => {
+    getLists().then(setLists);
+  }, []);
+
+  // Load entries for TIMELINE_DAYS window
+  useEffect(() => {
+    if (!selectedList) return;
+    const start = new Date(selectedDate);
+    start.setDate(start.getDate() - (TIMELINE_DAYS - 1));
+    const startStr = getFullDate(start);
+    getEntriesByDateRange(startStr, selectedDate, selectedList).then(setEntries);
+  }, [selectedDate, selectedList]);
+
+  useEffect(() => {
+    const el = pickerRef.current;
+    if (!el) return;
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      const emoji = detail.unicode || detail.emoji?.native || detail.emoji;
+      if (emoji) {
+        handleTap(emoji);
+      }
+    };
+    el.addEventListener("emoji-click", handler);
+    return () => el.removeEventListener("emoji-click", handler);
+  }, [selectedDate, showPicker, selectedList]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  // Focus rename input
+  useEffect(() => {
+    if (renaming && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [renaming]);
+
+  async function handleTap(emoji: string) {
+    const id = await addEntry({
+      date: selectedDate,
+      timestamp: Date.now(),
+      emoji,
+      list: selectedList || undefined,
+    });
+    setEntries((prev) => [
+      ...prev,
+      { id, date: selectedDate, timestamp: Date.now(), emoji, list: selectedList || undefined },
+    ]);
+    incrementFavorite(emoji);
+    refreshFavorites();
+  }
+
+  async function handleDelete(id: number) {
+    await deleteEntry(id);
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }
+
+  function handleStartEdit(entry: Entry) {
+    setEditingId(entry.id ?? null);
+    setEditNote(entry.note || "");
+    setTimeout(() => editInputRef.current?.focus(), 50);
+  }
+
+  async function handleSaveNote() {
+    if (editingId === null) return;
+    const note = editNote.trim();
+    await updateEntryNote(editingId, note || "");
+    setEntries((prev) =>
+      prev.map((e) => (e.id === editingId ? { ...e, note: note || undefined } : e)),
+    );
+    setEditingId(null);
+    setEditNote("");
+  }
+
+  function handleCancelEdit() {
+    setEditingId(null);
+    setEditNote("");
+  }
+
+  function handlePrevDay() {
+    const d = new Date(selectedDate);
+    d.setDate(d.getDate() - 1);
+    setSelectedDate(getFullDate(d));
+  }
+
+  function handleNextDay() {
+    const d = new Date(selectedDate);
+    d.setDate(d.getDate() + 1);
+    setSelectedDate(getFullDate(d));
+  }
+
+  function handleSelectDate(dateStr: string) {
+    setSelectedDate(dateStr);
+    setViewMode("timeline");
+  }
+
+  function handleFilterEmoji(emoji: string) {
+    setFilterEmoji((prev) => (prev === emoji ? null : emoji));
+  }
+
+  async function copyLog() {
+    const dateGroups = groupByDate(entries);
+    const dateKeys = Object.keys(dateGroups).sort();
+    if (dateKeys.length === 0) {
+      await navigator.clipboard.writeText("📋 記録なし");
+      return;
+    }
+    const lines: string[] = [];
+    for (const date of dateKeys) {
+      lines.push(`📅 ${formatDateLabel(date)}`);
+      for (const e of dateGroups[date]) {
+        const time = formatTime(e.timestamp);
+        const note = e.note ? ` (${e.note})` : "";
+        lines.push(`  ${time} ${e.emoji}${note}`);
+      }
+    }
+    await navigator.clipboard.writeText(lines.join("\n"));
+  }
+
+  function groupByDate(list: Entry[]): Record<string, Entry[]> {
+    return list.reduce<Record<string, Entry[]>>((acc, entry) => {
+      (acc[entry.date] ??= []).push(entry);
+      return acc;
+    }, {});
+  }
+
+  // ── List management ──
+
+  async function handleAddList() {
+    const name = window.prompt("新しいリスト名");
+    if (!name || !name.trim()) return;
+    const trimmed = name.trim();
+    if (lists.some((l) => l.name === trimmed)) {
+      alert("同じ名前のリストが既にあります");
+      return;
+    }
+    await addList(trimmed);
+    await refreshLists();
+    setSelectedList(trimmed);
+  }
+
+  async function handleRemoveList(name: string) {
+    if (lists.length <= 1) {
+      alert("最後のリストは削除できません");
+      return;
+    }
+    if (!window.confirm(`「${name}」を削除しますか？\nこのリストの記録は「リストなし」になります`)) return;
+    await removeList(name);
+    await refreshLists();
+    if (selectedList === name) {
+      const remaining = await getLists();
+      setSelectedList(remaining[0]?.name || "メイン");
+    }
+    setMenuOpen(null);
+  }
+
+  function handleStartRename(name: string) {
+    setRenaming(name);
+    setRenameValue(name);
+    setMenuOpen(null);
+  }
+
+  async function handleCommitRename() {
+    const oldName = renaming;
+    if (!oldName) return;
+    const newName = renameValue.trim();
+    if (!newName || newName === oldName) {
+      setRenaming(null);
+      return;
+    }
+    if (lists.some((l) => l.name === newName && l.name !== oldName)) {
+      alert("同じ名前のリストが既にあります");
+      return;
+    }
+    await renameList(oldName, newName);
+    await refreshLists();
+    if (selectedList === oldName) {
+      setSelectedList(newName);
+    }
+    setRenaming(null);
+  }
+
+  const isToday = selectedDate === todayStr;
+  const filteredEntries = filterEmoji
+    ? entries.filter((e) => e.emoji === filterEmoji)
+    : entries;
+  const groupedEntries = groupByDate(filteredEntries);
+  const dateLabels = Object.keys(groupedEntries).sort();
+  const hasAnyEntry = dateLabels.length > 0;
+
+  return (
+    <div className="emolog">
+      {/* ── リストタブ ── */}
+      <div className="emolog-lists">
+        {listError ? (
+          <div className="emolog-list-placeholder" style={{color:'#e74c3c'}}>エラー: {listError}</div>
+        ) : lists.length === 0 ? (
+          <div className="emolog-list-placeholder">読み込み中…</div>
+        ) : (
+          <>
+            <div className="emolog-list-tabs">
+              {lists.map((l) => (
+                <div key={l.name} className="emolog-list-tab-wrap">
+                  {renaming === l.name ? (
+                    <input
+                      ref={renameInputRef}
+                      type="text"
+                      className="emolog-list-rename-input"
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onBlur={handleCommitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleCommitRename();
+                        if (e.key === "Escape") setRenaming(null);
+                      }}
+                      maxLength={20}
+                    />
+                  ) : (
+                    <button
+                      className={`emolog-list-tab${l.name === selectedList ? " emolog-list-active" : ""}`}
+                      onClick={() => setSelectedList(l.name)}
+                    >
+                      {l.name === selectedList && <span className="emolog-list-indicator">📋</span>}
+                      {l.name}
+                    </button>
+                  )}
+                  {l.name === selectedList && renaming !== l.name && (
+                    <div className="emolog-list-menu-wrap" ref={menuOpen === l.name ? menuRef : undefined}>
+                      <button
+                        className="emolog-list-menu-btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setMenuOpen(menuOpen === l.name ? null : l.name);
+                        }}
+                      >
+                        ·
+                      </button>
+                      {menuOpen === l.name && (
+                        <div className="emolog-list-menu">
+                          <button onClick={() => handleStartRename(l.name)}>
+                            ✏️ 名前を変更
+                          </button>
+                          <button
+                            className="emolog-list-menu-del"
+                            onClick={() => handleRemoveList(l.name)}
+                          >
+                            🗑️ 削除
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button className="emolog-list-add" onClick={handleAddList} title="リストを追加">
+              ＋
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* ── 日付ナビ ── */}
+      <div className="emolog-date-nav">
+        {viewMode === "timeline" ? (
+          <>
+            <button onClick={handlePrevDay} className="emolog-nav-btn" aria-label="前日">
+              ←
+            </button>
+            <span className="emolog-date-label">{formatDateLabel(selectedDate)}</span>
+            <button
+              onClick={handleNextDay}
+              className="emolog-nav-btn"
+              disabled={isToday}
+              aria-label="翌日"
+            >
+              →
+            </button>
+          </>
+        ) : (
+          <span className="emolog-date-label">📅 カレンダー</span>
+        )}
+        <button
+          onClick={() => setViewMode((v) => (v === "timeline" ? "calendar" : "timeline"))}
+          className={`emolog-nav-btn emolog-view-toggle${viewMode === "calendar" ? " emolog-view-active" : ""}`}
+          title={viewMode === "timeline" ? "カレンダー表示" : "タイムラインに戻る"}
+        >
+          {viewMode === "timeline" ? "📅" : "📋"}
+        </button>
+        {viewMode === "timeline" && (
+          <button onClick={copyLog} className="emolog-copy-btn" title="コピー">
+            📋
+          </button>
+        )}
+      </div>
+
+      {viewMode === "calendar" ? (
+        <CalendarView onSelectDate={handleSelectDate} todayStr={todayStr} list={selectedList} />
+      ) : (
+        <>
+          {/* ── フィルター表示 ── */}
+          {filterEmoji && (
+            <div className="emolog-filter-bar">
+              <span className="emolog-filter-label">🔍 {filterEmoji} のみ表示</span>
+              <button className="emolog-filter-clear" onClick={() => setFilterEmoji(null)}>
+                ×
+              </button>
+            </div>
+          )}
+
+          {/* ── 絵文字ピッカー ── */}
+          <div className="emolog-picker">
+            {favorites.length > 0 && (
+              <div className="emolog-favs">
+                {favorites.map((emoji) => (
+                  <button key={emoji} className="emolog-fav-btn" onClick={() => handleTap(emoji)}>
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="emolog-picker-toggle">
+              <button className="emolog-toggle-btn" onClick={() => setShowPicker((v) => !v)}>
+                {showPicker ? "▲ 閉じる" : "＋ 絵文字を選ぶ"}
+              </button>
+            </div>
+            {showPicker && (
+              <div className="emolog-picker-panel">
+                <emoji-picker ref={pickerRef} class="emolog-picker-element" />
+              </div>
+            )}
+          </div>
+
+          {/* ── タイムライン ── */}
+          <div className="emolog-timeline">
+            {!hasAnyEntry ? (
+              <p className="emolog-empty">
+                {selectedDate === todayStr
+                  ? "絵文字をタップして気持ちを記録しよう 👆"
+                  : "この期間の記録はありません"}
+              </p>
+            ) : (
+              dateLabels.map((date) => (
+                <div key={date} className="emolog-timeline-group">
+                  <div className="emolog-timeline-date">
+                    {formatDateLabel(date)}
+                    {date === todayStr && <span className="emolog-timeline-today">今日</span>}
+                  </div>
+                  {groupedEntries[date].map((entry) => (
+                    <div key={entry.id} className="emolog-timeline-entry">
+                      <span className="emolog-entry-time">{formatTime(entry.timestamp)}</span>
+                      <span
+    className={`emolog-entry-emoji${filterEmoji === entry.emoji ? " emolog-emoji-filter-active" : ""}`}
+    onClick={() => handleFilterEmoji(entry.emoji)}
+    title={filterEmoji === entry.emoji ? "フィルター解除" : "この絵文字でフィルター"}
+  >
+    {entry.emoji}
+  </span>
+                      {editingId === entry.id ? (
+                        <input
+                          ref={editInputRef}
+                          type="text"
+                          value={editNote}
+                          onChange={(e) => setEditNote(e.target.value)}
+                          onBlur={handleSaveNote}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") handleSaveNote();
+                            if (e.key === "Escape") handleCancelEdit();
+                          }}
+                          className="emolog-edit-input"
+                          maxLength={40}
+                          placeholder="メモを入力"
+                        />
+                      ) : (
+                        <span
+                          className={`emolog-entry-note${entry.note ? "" : " emolog-entry-note-empty"}`}
+                          onClick={() => handleStartEdit(entry)}
+                        >
+                          {entry.note || "＋"}
+                        </span>
+                      )}
+                      <button
+                        className="emolog-entry-delete"
+                        onClick={() => entry.id && handleDelete(entry.id)}
+                        title="削除"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/emolog/src/CalendarView.tsx
+++ b/packages/emolog/src/CalendarView.tsx
@@ -34,7 +34,7 @@ function aggregateByDate(entries: Entry[]): Map<string, { emoji: string; count: 
   }
   const result = new Map<string, { emoji: string; count: number }>();
   for (const [date, data] of map) {
-    const sorted = Object.entries(data.counts).sort(([, a], [, b]) => b - a);
+    const sorted = Object.entries(data.counts).toSorted(([, a], [, b]) => b - a);
     result.set(date, { emoji: sorted[0][0], count: data.total });
   }
   return result;
@@ -70,7 +70,7 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
     cells.push(
       <button
         key={dateStr}
-        className={`emolog-cal-cell${isToday ? " emolog-cal-today" : ""}${!data ? " emolog-cal-empty-day" : ""}`}
+        className={`emolog-cal-cell${isToday ? " emolog-cal-today" : ""}${data ? "" : " emolog-cal-empty-day"}`}
         onClick={() => onSelectDate(dateStr)}
         title={`${dateStr}${data ? ` - ${data.count}件 / ${data.emoji}` : ""}`}
       >

--- a/packages/emolog/src/CalendarView.tsx
+++ b/packages/emolog/src/CalendarView.tsx
@@ -1,81 +1,71 @@
-import { useState, useEffect, useMemo } from "react"
-import { getEntriesByDateRange } from "./store"
-import type { Entry } from "./types"
+import { useState, useEffect, useMemo } from "react";
+import { getEntriesByDateRange } from "./store";
+import type { Entry } from "./types";
 
 interface CalendarViewProps {
-  onSelectDate: (date: string) => void
-  todayStr: string
-  list?: string
+  onSelectDate: (date: string) => void;
+  todayStr: string;
+  list?: string;
 }
 
-function getMonthDateRange(
-  year: number,
-  month: number,
-): { from: string; to: string } {
-  const from = `${year}-${String(month + 1).padStart(2, "0")}-01`
-  const lastDay = new Date(year, month + 1, 0).getDate()
-  const to = `${year}-${String(month + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
-  return { from, to }
+function getMonthDateRange(year: number, month: number): { from: string; to: string } {
+  const from = `${year}-${String(month + 1).padStart(2, "0")}-01`;
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  const to = `${year}-${String(month + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+  return { from, to };
 }
 
 function getWeekdayStart(year: number, month: number): number {
-  return new Date(year, month, 1).getDay()
+  return new Date(year, month, 1).getDay();
 }
 
 function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate()
+  return new Date(year, month + 1, 0).getDate();
 }
 
-function aggregateByDate(
-  entries: Entry[],
-): Map<string, { emoji: string; count: number }> {
-  const map = new Map<
-    string,
-    { counts: Record<string, number>; total: number }
-  >()
+function aggregateByDate(entries: Entry[]): Map<string, { emoji: string; count: number }> {
+  const map = new Map<string, { counts: Record<string, number>; total: number }>();
   for (const e of entries) {
-    if (!e.date) continue
-    const day = map.get(e.date) || { counts: {}, total: 0 }
-    day.counts[e.emoji] = (day.counts[e.emoji] || 0) + 1
-    day.total++
-    map.set(e.date, day)
+    if (!e.date) continue;
+    const day = map.get(e.date) || { counts: {}, total: 0 };
+    day.counts[e.emoji] = (day.counts[e.emoji] || 0) + 1;
+    day.total++;
+    map.set(e.date, day);
   }
-  const result = new Map<string, { emoji: string; count: number }>()
+  const result = new Map<string, { emoji: string; count: number }>();
   for (const [date, data] of map) {
-    const sorted = Object.entries(data.counts).sort(([, a], [, b]) => b - a)
-    result.set(date, { emoji: sorted[0][0], count: data.total })
+    const sorted = Object.entries(data.counts).sort(([, a], [, b]) => b - a);
+    result.set(date, { emoji: sorted[0][0], count: data.total });
   }
-  return result
+  return result;
 }
 
 export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps) {
-  const today = new Date()
-  const [year, setYear] = useState(today.getFullYear())
-  const [month, setMonth] = useState(today.getMonth())
-  const [dayData, setDayData] = useState<
-    Map<string, { emoji: string; count: number }>
-  >(new Map())
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+  const [dayData, setDayData] = useState<Map<string, { emoji: string; count: number }>>(new Map());
 
-  const { from, to } = useMemo(() => getMonthDateRange(year, month), [year, month])
+  const { from, to } = useMemo(() => getMonthDateRange(year, month), [year, month]);
 
   useEffect(() => {
     getEntriesByDateRange(from, to, list).then((entries) => {
-      setDayData(aggregateByDate(entries))
-    })
-  }, [from, to, list])
+      setDayData(aggregateByDate(entries));
+    });
+  }, [from, to, list]);
 
-  const daysInMonth = getDaysInMonth(year, month)
-  const startWeekday = getWeekdayStart(year, month)
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"]
+  const daysInMonth = getDaysInMonth(year, month);
+  const startWeekday = getWeekdayStart(year, month);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
 
-  const cells: React.ReactNode[] = []
+  const cells: React.ReactNode[] = [];
   for (let i = 0; i < startWeekday; i++) {
-    cells.push(<div key={`empty-${i}`} className="emolog-cal-cell" />)
+    cells.push(<div key={`empty-${i}`} className="emolog-cal-cell" />);
   }
   for (let d = 1; d <= daysInMonth; d++) {
-    const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`
-    const data = dayData.get(dateStr)
-    const isToday = dateStr === todayStr
+    const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    const data = dayData.get(dateStr);
+    const isToday = dateStr === todayStr;
 
     cells.push(
       <button
@@ -91,7 +81,7 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
           </span>
         )}
       </button>,
-    )
+    );
   }
 
   return (
@@ -100,10 +90,10 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
         <button
           onClick={() => {
             if (month === 0) {
-              setYear((y) => y - 1)
-              setMonth(11)
+              setYear((y) => y - 1);
+              setMonth(11);
             } else {
-              setMonth((m) => m - 1)
+              setMonth((m) => m - 1);
             }
           }}
           className="emolog-nav-btn"
@@ -117,10 +107,10 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
         <button
           onClick={() => {
             if (month === 11) {
-              setYear((y) => y + 1)
-              setMonth(0)
+              setYear((y) => y + 1);
+              setMonth(0);
             } else {
-              setMonth((m) => m + 1)
+              setMonth((m) => m + 1);
             }
           }}
           className="emolog-nav-btn"
@@ -131,8 +121,8 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
         {!(year === today.getFullYear() && month === today.getMonth()) && (
           <button
             onClick={() => {
-              setYear(today.getFullYear())
-              setMonth(today.getMonth())
+              setYear(today.getFullYear());
+              setMonth(today.getMonth());
             }}
             className="emolog-today-btn"
           >
@@ -149,5 +139,5 @@ export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps
         {cells}
       </div>
     </div>
-  )
+  );
 }

--- a/packages/emolog/src/CalendarView.tsx
+++ b/packages/emolog/src/CalendarView.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useMemo } from "react"
+import { getEntriesByDateRange } from "./store"
+import type { Entry } from "./types"
+
+interface CalendarViewProps {
+  onSelectDate: (date: string) => void
+  todayStr: string
+  list?: string
+}
+
+function getMonthDateRange(
+  year: number,
+  month: number,
+): { from: string; to: string } {
+  const from = `${year}-${String(month + 1).padStart(2, "0")}-01`
+  const lastDay = new Date(year, month + 1, 0).getDate()
+  const to = `${year}-${String(month + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
+  return { from, to }
+}
+
+function getWeekdayStart(year: number, month: number): number {
+  return new Date(year, month, 1).getDay()
+}
+
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate()
+}
+
+function aggregateByDate(
+  entries: Entry[],
+): Map<string, { emoji: string; count: number }> {
+  const map = new Map<
+    string,
+    { counts: Record<string, number>; total: number }
+  >()
+  for (const e of entries) {
+    if (!e.date) continue
+    const day = map.get(e.date) || { counts: {}, total: 0 }
+    day.counts[e.emoji] = (day.counts[e.emoji] || 0) + 1
+    day.total++
+    map.set(e.date, day)
+  }
+  const result = new Map<string, { emoji: string; count: number }>()
+  for (const [date, data] of map) {
+    const sorted = Object.entries(data.counts).sort(([, a], [, b]) => b - a)
+    result.set(date, { emoji: sorted[0][0], count: data.total })
+  }
+  return result
+}
+
+export function CalendarView({ onSelectDate, todayStr, list }: CalendarViewProps) {
+  const today = new Date()
+  const [year, setYear] = useState(today.getFullYear())
+  const [month, setMonth] = useState(today.getMonth())
+  const [dayData, setDayData] = useState<
+    Map<string, { emoji: string; count: number }>
+  >(new Map())
+
+  const { from, to } = useMemo(() => getMonthDateRange(year, month), [year, month])
+
+  useEffect(() => {
+    getEntriesByDateRange(from, to, list).then((entries) => {
+      setDayData(aggregateByDate(entries))
+    })
+  }, [from, to, list])
+
+  const daysInMonth = getDaysInMonth(year, month)
+  const startWeekday = getWeekdayStart(year, month)
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"]
+
+  const cells: React.ReactNode[] = []
+  for (let i = 0; i < startWeekday; i++) {
+    cells.push(<div key={`empty-${i}`} className="emolog-cal-cell" />)
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`
+    const data = dayData.get(dateStr)
+    const isToday = dateStr === todayStr
+
+    cells.push(
+      <button
+        key={dateStr}
+        className={`emolog-cal-cell${isToday ? " emolog-cal-today" : ""}${!data ? " emolog-cal-empty-day" : ""}`}
+        onClick={() => onSelectDate(dateStr)}
+        title={`${dateStr}${data ? ` - ${data.count}件 / ${data.emoji}` : ""}`}
+      >
+        <span className="emolog-cal-day">{d}</span>
+        {data && (
+          <span className={`emolog-cal-emoji emolog-cal-density-${Math.min(data.count, 5)}`}>
+            {data.emoji}
+          </span>
+        )}
+      </button>,
+    )
+  }
+
+  return (
+    <div className="emolog-calendar">
+      <div className="emolog-cal-header">
+        <button
+          onClick={() => {
+            if (month === 0) {
+              setYear((y) => y - 1)
+              setMonth(11)
+            } else {
+              setMonth((m) => m - 1)
+            }
+          }}
+          className="emolog-nav-btn"
+          aria-label="前月"
+        >
+          ←
+        </button>
+        <span className="emolog-cal-title">
+          {year}年{month + 1}月
+        </span>
+        <button
+          onClick={() => {
+            if (month === 11) {
+              setYear((y) => y + 1)
+              setMonth(0)
+            } else {
+              setMonth((m) => m + 1)
+            }
+          }}
+          className="emolog-nav-btn"
+          aria-label="翌月"
+        >
+          →
+        </button>
+        {!(year === today.getFullYear() && month === today.getMonth()) && (
+          <button
+            onClick={() => {
+              setYear(today.getFullYear())
+              setMonth(today.getMonth())
+            }}
+            className="emolog-today-btn"
+          >
+            今日
+          </button>
+        )}
+      </div>
+      <div className="emolog-cal-grid">
+        {weekdays.map((w) => (
+          <div key={w} className="emolog-cal-weekday">
+            {w}
+          </div>
+        ))}
+        {cells}
+      </div>
+    </div>
+  )
+}

--- a/packages/emolog/src/SummaryView.test.tsx
+++ b/packages/emolog/src/SummaryView.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SummaryView } from "./SummaryView";
+import * as store from "./store";
+import type { Entry } from "./types";
+
+function e(emoji: string, overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: Math.random(),
+    date: "2026-07-15",
+    timestamp: 0,
+    emoji,
+    ...overrides,
+  };
+}
+
+describe("SummaryView", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders period selector with three buttons", async () => {
+    vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
+    render(<SummaryView onSelectEmoji={() => {}} />);
+    expect(screen.getByText("7日")).toBeDefined();
+    expect(screen.getByText("30日")).toBeDefined();
+    expect(screen.getByText("すべて")).toBeDefined();
+  });
+
+  it("defaults to 7d period", () => {
+    const spy = vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
+    render(<SummaryView onSelectEmoji={() => {}} />);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("shows empty state when no entries", async () => {
+    vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
+    render(<SummaryView onSelectEmoji={() => {}} />);
+    expect(await screen.findByText("この期間の記録はありません")).toBeDefined();
+  });
+
+  it("shows stats and rankings with entries", async () => {
+    vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([e("😊"), e("😊"), e("😢")]);
+    render(<SummaryView onSelectEmoji={() => {}} />);
+    expect(await screen.findByText("3")).toBeDefined();
+    const twos = await screen.findAllByText("2");
+    expect(twos).toHaveLength(2);
+    expect(screen.getByText("66.7%")).toBeDefined();
+    expect(screen.getByText("33.3%")).toBeDefined();
+  });
+
+  it("calls onSelectEmoji when ranking emoji is clicked", async () => {
+    vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([e("😊")]);
+    const onSelect = vi.fn();
+    render(<SummaryView onSelectEmoji={onSelect} />);
+    const emojiBtn = await screen.findByText("😊");
+    fireEvent.click(emojiBtn);
+    expect(onSelect).toHaveBeenCalledWith("😊");
+  });
+
+  it("switches period and calls different store method for all", async () => {
+    const rangeSpy = vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
+    const allSpy = vi.spyOn(store, "getAllEntries").mockResolvedValue([]);
+    render(<SummaryView onSelectEmoji={() => {}} />);
+    expect(rangeSpy).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByText("30日"));
+    expect(rangeSpy).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByText("すべて"));
+    expect(allSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/emolog/src/SummaryView.test.tsx
+++ b/packages/emolog/src/SummaryView.test.tsx
@@ -19,7 +19,7 @@ describe("SummaryView", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders period selector with three buttons", async () => {
+  it("renders period selector with three buttons", () => {
     vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
     render(<SummaryView onSelectEmoji={() => {}} />);
     expect(screen.getByText("7日")).toBeDefined();
@@ -58,7 +58,7 @@ describe("SummaryView", () => {
     expect(onSelect).toHaveBeenCalledWith("😊");
   });
 
-  it("switches period and calls different store method for all", async () => {
+  it("switches period and calls different store method for all", () => {
     const rangeSpy = vi.spyOn(store, "getEntriesByDateRange").mockResolvedValue([]);
     const allSpy = vi.spyOn(store, "getAllEntries").mockResolvedValue([]);
     render(<SummaryView onSelectEmoji={() => {}} />);

--- a/packages/emolog/src/SummaryView.tsx
+++ b/packages/emolog/src/SummaryView.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect, useMemo } from "react";
+import { getEntriesByDateRange, getAllEntries } from "./store";
+import { computeSummary, getDateRangeForPeriod } from "./summary";
+import type { Period, SummaryStats } from "./summary";
+import type { Entry } from "./types";
+
+interface SummaryViewProps {
+  onSelectEmoji: (emoji: string) => void;
+  list?: string;
+}
+
+const PERIODS: { key: Period; label: string }[] = [
+  { key: "7d", label: "7日" },
+  { key: "30d", label: "30日" },
+  { key: "all", label: "すべて" },
+];
+
+export function SummaryView({ onSelectEmoji, list }: SummaryViewProps) {
+  const [period, setPeriod] = useState<Period>("7d");
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setError(null);
+    const range = getDateRangeForPeriod(period);
+    const promise = range ? getEntriesByDateRange(range.from, range.to, list) : getAllEntries(list);
+    promise.then(setEntries).catch((err: unknown) => {
+      setError(err instanceof Error ? err.message : String(err));
+      setEntries([]);
+    });
+  }, [period, list]);
+
+  const summary: SummaryStats = useMemo(() => computeSummary(entries), [entries]);
+
+  if (error) {
+    return <div className="emolog-summary-error">⚠️ {error}</div>;
+  }
+
+  return (
+    <div className="emolog-summary">
+      <div className="emolog-summary-periods">
+        {PERIODS.map((p) => (
+          <button
+            key={p.key}
+            className={`emolog-summary-period${period === p.key ? " emolog-summary-period-active" : ""}`}
+            onClick={() => setPeriod(p.key)}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {summary.total === 0 ? (
+        <div className="emolog-summary-empty">この期間の記録はありません</div>
+      ) : (
+        <>
+          <div className="emolog-summary-stats">
+            <div className="emolog-summary-stat">
+              <span className="emolog-summary-stat-value">{summary.total}</span>
+              <span className="emolog-summary-stat-label">記録</span>
+            </div>
+            <div className="emolog-summary-stat">
+              <span className="emolog-summary-stat-value">{summary.distinct}</span>
+              <span className="emolog-summary-stat-label">感情</span>
+            </div>
+          </div>
+          <div className="emolog-summary-rankings">
+            {summary.rankings.map((r) => (
+              <button
+                key={r.emoji}
+                className="emolog-summary-ranking"
+                onClick={() => onSelectEmoji(r.emoji)}
+              >
+                <span className="emolog-summary-ranking-emoji">{r.emoji}</span>
+                <div className="emolog-summary-ranking-bar-container">
+                  <div
+                    className="emolog-summary-ranking-bar"
+                    style={{ width: `${Math.max(r.pct, 1)}%` }}
+                  />
+                </div>
+                <span className="emolog-summary-ranking-count">{r.count}</span>
+                <span className="emolog-summary-ranking-pct">{r.pct}%</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/emolog/src/SummaryView.tsx
+++ b/packages/emolog/src/SummaryView.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { getEntriesByDateRange, getAllEntries } from "./store";
-import { computeSummary, getDateRangeForPeriod } from "./summary";
-import type { Period, SummaryStats } from "./summary";
+import { computeSummary, getDateRangeForPeriod, type Period, type SummaryStats } from "./summary";
 import type { Entry } from "./types";
 
 interface SummaryViewProps {

--- a/packages/emolog/src/env.d.ts
+++ b/packages/emolog/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+// Extend React JSX types for emoji-picker web component
+declare namespace React {
+  namespace JSX {
+    interface IntrinsicElements {
+      "emoji-picker": any
+    }
+  }
+}
+

--- a/packages/emolog/src/env.d.ts
+++ b/packages/emolog/src/env.d.ts
@@ -4,8 +4,7 @@
 declare namespace React {
   namespace JSX {
     interface IntrinsicElements {
-      "emoji-picker": any
+      "emoji-picker": any;
     }
   }
 }
-

--- a/packages/emolog/src/index.css
+++ b/packages/emolog/src/index.css
@@ -637,7 +637,9 @@
 
 .emolog-entry-emoji {
   cursor: pointer;
-  transition: transform 0.1s, background 0.15s;
+  transition:
+    transform 0.1s,
+    background 0.15s;
   border-radius: 6px;
   padding: 2px 4px;
 }

--- a/packages/emolog/src/index.css
+++ b/packages/emolog/src/index.css
@@ -1,0 +1,682 @@
+.emolog {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 20px 16px 40px;
+  font-family: "IBM Plex Mono", monospace;
+}
+
+/* ── 日付ナビ ── */
+.emolog-date-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.emolog-date-label {
+  font-size: 15px;
+  font-weight: 600;
+  min-width: 120px;
+  text-align: center;
+  letter-spacing: 0.03em;
+}
+
+.emolog-nav-btn {
+  background: none;
+  border: 1px solid var(--grid);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--ink);
+  transition: background 0.15s;
+}
+
+.emolog-nav-btn:hover:not(:disabled) {
+  background: var(--grid);
+}
+
+.emolog-nav-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.emolog-copy-btn {
+  background: none;
+  border: 1px solid var(--grid);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-left: 4px;
+}
+
+.emolog-copy-btn:hover {
+  background: var(--grid);
+}
+
+/* ── 絵文字ピッカー ── */
+.emolog-picker {
+  margin-bottom: 24px;
+}
+
+.emolog-picker-panel {
+  margin-bottom: 12px;
+}
+
+.emolog-picker-element {
+  --background: var(--surface);
+  --border-color: var(--grid);
+  --input-border-color: var(--grid);
+  --input-border-focus-color: var(--terra);
+  --indicator-color: var(--terra);
+  --button-active-background: var(--hover);
+  width: 100%;
+  height: 400px;
+  border: 1px solid var(--grid);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+/* ── よく使う絵文字 ── */
+.emolog-favs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+.emolog-fav-btn {
+  width: 44px;
+  height: 44px;
+  font-size: 24px;
+  background: var(--surface);
+  border: 1px solid var(--grid);
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.1s,
+    background 0.15s,
+    box-shadow 0.15s;
+}
+
+.emolog-fav-btn:hover {
+  transform: scale(1.15);
+  background: var(--hover);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.emolog-fav-btn:active {
+  transform: scale(0.95);
+}
+
+/* ── ピッカートグル ── */
+.emolog-picker-toggle {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+.emolog-toggle-btn {
+  padding: 10px 24px;
+  font-size: 14px;
+  font-family: "IBM Plex Mono", monospace;
+  border: 1px solid var(--grid);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.emolog-toggle-btn:hover {
+  background: var(--hover);
+}
+
+/* ── タイムライン ── */
+.emolog-timeline {
+  position: relative;
+  padding-left: 36px;
+}
+
+/* 縦線 */
+.emolog-timeline::before {
+  content: "";
+  position: absolute;
+  left: 17px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--grid);
+  border-radius: 1px;
+}
+
+/* 日付グループ */
+.emolog-timeline-group:first-child {
+  margin-top: 0;
+}
+
+/* 日付ヘッダー */
+.emolog-timeline-date {
+  position: relative;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--mid);
+  padding: 24px 0 10px 0;
+  letter-spacing: 0.05em;
+}
+
+.emolog-timeline-group:first-child .emolog-timeline-date {
+  padding-top: 0;
+}
+
+/* 日付のドット */
+.emolog-timeline-date::before {
+  content: "";
+  position: absolute;
+  left: -25px;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--mid);
+  border: 2px solid var(--bg);
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+.emolog-timeline-group:first-child .emolog-timeline-date::before {
+  top: 4px;
+  transform: none;
+}
+
+/* 今日バッジ */
+.emolog-timeline-today {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 9px;
+  line-height: 1.4;
+  background: var(--terra);
+  color: white;
+  padding: 1px 7px;
+  border-radius: 8px;
+  vertical-align: middle;
+  font-weight: 700;
+}
+
+/* エントリー */
+.emolog-timeline-entry {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 8px;
+  animation: emoFadeIn 0.3s ease both;
+}
+
+/* エントリーのドット */
+.emolog-timeline-entry::before {
+  content: "";
+  position: absolute;
+  left: -24px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--terra);
+  border: 2px solid var(--bg);
+  box-shadow: 0 0 0 1px var(--terra);
+  transform: translateY(-50%);
+  z-index: 1;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.emolog-timeline-entry:hover::before {
+  transform: translateY(-50%) scale(1.3);
+  box-shadow: 0 0 0 2px var(--terra);
+}
+
+/* 空状態 */
+.emolog-empty {
+  text-align: center;
+  color: var(--mid);
+  font-size: 13px;
+  padding: 40px 0;
+}
+
+/* 時間 */
+.emolog-entry-time {
+  font-size: 12px;
+  color: var(--mid);
+  min-width: 40px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+/* 絵文字 */
+.emolog-entry-emoji {
+  font-size: 28px;
+  line-height: 1;
+}
+
+/* メモ */
+.emolog-entry-note {
+  font-size: 12px;
+  color: var(--mid);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  padding: 4px 0;
+  transition: color 0.15s;
+}
+
+.emolog-entry-note:hover {
+  color: var(--ink);
+}
+
+.emolog-entry-note-empty {
+  color: var(--grid);
+  font-size: 14px;
+}
+
+/* メモ編集 */
+.emolog-edit-input {
+  flex: 1;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-family: "IBM Plex Mono", monospace;
+  border: 1px solid var(--terra);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  outline: none;
+  min-width: 0;
+}
+
+/* 削除ボタン */
+.emolog-entry-delete {
+  background: none;
+  border: none;
+  color: var(--mid);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0.6;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+  flex-shrink: 0;
+}
+
+.emolog-timeline-entry:hover .emolog-entry-delete {
+  opacity: 1;
+}
+
+.emolog-entry-delete:hover {
+  background: var(--grid);
+}
+
+@keyframes emoFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── ビュートグル ── */
+.emolog-view-toggle {
+  margin-left: 4px;
+}
+.emolog-view-active {
+  background: var(--grid) !important;
+}
+
+/* ── カレンダー ── */
+.emolog-calendar {
+  margin-bottom: 24px;
+}
+
+.emolog-cal-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.emolog-cal-title {
+  font-size: 15px;
+  font-weight: 600;
+  min-width: 100px;
+  text-align: center;
+}
+
+.emolog-today-btn {
+  background: var(--surface);
+  border: 1px solid var(--grid);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: "IBM Plex Mono", monospace;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-left: 4px;
+}
+.emolog-today-btn:hover {
+  background: var(--hover);
+}
+
+.emolog-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.emolog-cal-weekday {
+  text-align: center;
+  font-size: 10px;
+  color: var(--mid);
+  padding: 6px 0;
+  font-weight: 600;
+}
+
+.emolog-cal-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 6px;
+  background: var(--surface);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    transform 0.1s;
+  padding: 2px;
+  min-height: 44px;
+}
+.emolog-cal-cell:hover {
+  background: var(--hover);
+  transform: scale(1.05);
+}
+.emolog-cal-cell:active {
+  transform: scale(0.95);
+}
+
+.emolog-cal-today {
+  outline: 2px solid var(--terra);
+  outline-offset: -2px;
+}
+
+.emolog-cal-empty-day {
+  opacity: 0.35;
+}
+
+.emolog-cal-day {
+  font-size: 10px;
+  color: var(--mid);
+  line-height: 1;
+}
+
+.emolog-cal-emoji {
+  font-size: 20px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.emolog-cal-density-1 {
+  opacity: 0.7;
+}
+.emolog-cal-density-2 {
+  opacity: 0.85;
+}
+.emolog-cal-density-3 {
+  opacity: 1;
+}
+.emolog-cal-density-4 {
+  opacity: 1;
+  transform: scale(1.1);
+}
+.emolog-cal-density-5 {
+  opacity: 1;
+  transform: scale(1.15);
+}
+
+/* ── リストタブ ── */
+.emolog-lists {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 16px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.emolog-lists::-webkit-scrollbar {
+  display: none;
+}
+
+.emolog-list-placeholder {
+  font-size: 12px;
+  color: var(--mid);
+  padding: 8px 0;
+}
+
+.emolog-list-tabs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.emolog-list-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.emolog-list-tab-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.emolog-list-tab {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-family: "IBM Plex Mono", monospace;
+  border: 1px solid var(--grid);
+  border-radius: 20px;
+  background: var(--surface);
+  color: var(--mid);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.emolog-list-tab:hover {
+  background: var(--hover);
+  color: var(--ink);
+}
+
+.emolog-list-active {
+  background: var(--ink) !important;
+  color: var(--bg) !important;
+  border-color: var(--ink) !important;
+  font-weight: 600;
+}
+
+.emolog-list-indicator {
+  font-size: 12px;
+}
+
+.emolog-list-add {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px dashed var(--grid);
+  background: var(--surface);
+  color: var(--mid);
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  padding: 0;
+  line-height: 1;
+}
+
+.emolog-list-add:hover {
+  background: var(--hover);
+  color: var(--ink);
+  border-style: solid;
+}
+
+/* ── リストメニュー ── */
+.emolog-list-menu-wrap {
+  position: relative;
+}
+
+.emolog-list-menu-btn {
+  background: none;
+  border: none;
+  color: var(--mid);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  letter-spacing: 2px;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.emolog-list-menu-btn:hover {
+  opacity: 1;
+}
+
+.emolog-list-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  background: var(--surface);
+  border: 1px solid var(--grid);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  min-width: 150px;
+  overflow: hidden;
+  margin-top: 4px;
+}
+
+.emolog-list-menu button {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-family: "IBM Plex Mono", monospace;
+  border: none;
+  background: none;
+  color: var(--ink);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.emolog-list-menu button:hover {
+  background: var(--hover);
+}
+
+.emolog-list-menu-del {
+  border-top: 1px solid var(--grid) !important;
+  color: #e74c3c !important;
+}
+
+.emolog-list-rename-input {
+  padding: 6px 12px;
+  font-size: 13px;
+  font-family: "IBM Plex Mono", monospace;
+  border: 1px solid var(--terra);
+  border-radius: 20px;
+  background: var(--bg);
+  color: var(--ink);
+  outline: none;
+  width: 100px;
+}
+
+/* ── 絵文字フィルター ── */
+.emolog-emoji-filter-active {
+  background: var(--terra);
+  border-radius: 6px;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+
+.emolog-entry-emoji {
+  cursor: pointer;
+  transition: transform 0.1s, background 0.15s;
+  border-radius: 6px;
+  padding: 2px 4px;
+}
+
+.emolog-entry-emoji:hover {
+  transform: scale(1.2);
+  background: var(--hover);
+}
+
+.emolog-filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 8px 16px;
+  background: var(--surface);
+  border: 1px solid var(--grid);
+  border-radius: 10px;
+}
+
+.emolog-filter-label {
+  font-size: 13px;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.emolog-filter-clear {
+  background: none;
+  border: none;
+  color: var(--mid);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: all 0.15s;
+}
+
+.emolog-filter-clear:hover {
+  background: var(--grid);
+  color: var(--ink);
+}

--- a/packages/emolog/src/store.test.ts
+++ b/packages/emolog/src/store.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { addEntry, getAllEntries, db } from "./store";
+import type { Entry } from "./types";
+
+function makeEntry(emoji: string, date: string, list?: string): Omit<Entry, "id"> {
+  return { date, timestamp: Date.now(), emoji, list };
+}
+
+describe("getAllEntries", () => {
+  beforeEach(async () => {
+    await db.entries.clear();
+  });
+
+  it("returns all entries when no list filter", async () => {
+    await addEntry(makeEntry("😊", "2026-07-10"));
+    await addEntry(makeEntry("😢", "2026-07-12"));
+    const all = await getAllEntries();
+    expect(all).toHaveLength(2);
+  });
+
+  it("filters by list", async () => {
+    await addEntry(makeEntry("😊", "2026-07-10", "listA"));
+    await addEntry(makeEntry("😢", "2026-07-10", "listB"));
+    const a = await getAllEntries("listA");
+    expect(a).toHaveLength(1);
+    expect(a[0].emoji).toBe("😊");
+  });
+
+  it("returns empty array when no entries", async () => {
+    const all = await getAllEntries();
+    expect(all).toEqual([]);
+  });
+});

--- a/packages/emolog/src/store.ts
+++ b/packages/emolog/src/store.ts
@@ -1,45 +1,40 @@
-import Dexie, { type Table } from "dexie"
-import type { Entry } from "./types"
+import Dexie, { type Table } from "dexie";
+import type { Entry } from "./types";
 
 export interface ListDef {
-  id?: number
-  name: string
-  color?: string
-  order: number
+  id?: number;
+  name: string;
+  color?: string;
+  order: number;
 }
 
 const db = new Dexie("emolog") as Dexie & {
-  entries: Table<Entry, number>
-  lists: Table<ListDef, number>
-}
+  entries: Table<Entry, number>;
+  lists: Table<ListDef, number>;
+};
 
 db.version(1).stores({
   entries: "++id, date, timestamp",
-})
+});
 
 db.version(2).stores({
   entries: "++id, date, timestamp, list",
   lists: "++id, name",
-})
+});
 
 db.version(3).stores({
   entries: "++id, date, timestamp, list",
   lists: "++id, name, order",
-})
+});
 
 // ── Entries ──
 
-export async function getEntries(
-  date: string,
-  list?: string,
-): Promise<Entry[]> {
-  let collection = db.entries.where("date").equals(date)
+export async function getEntries(date: string, list?: string): Promise<Entry[]> {
+  let collection = db.entries.where("date").equals(date);
   if (list) {
-    collection = collection.filter(
-      (e) => e.list === list || (!e.list && list === "メイン"),
-    )
+    collection = collection.filter((e) => e.list === list || (!e.list && list === "メイン"));
   }
-  return collection.sortBy("timestamp")
+  return collection.sortBy("timestamp");
 }
 
 export async function getEntriesByDateRange(
@@ -47,70 +42,60 @@ export async function getEntriesByDateRange(
   to: string,
   list?: string,
 ): Promise<Entry[]> {
-  let collection = db.entries
-    .where("date")
-    .between(from, to, true, true)
+  let collection = db.entries.where("date").between(from, to, true, true);
   if (list) {
-    collection = collection.filter(
-      (e) => e.list === list || (!e.list && list === "メイン"),
-    )
+    collection = collection.filter((e) => e.list === list || (!e.list && list === "メイン"));
   }
-  return collection.sortBy("timestamp")
+  return collection.sortBy("timestamp");
 }
 
-export async function addEntry(
-  entry: Omit<Entry, "id">,
-): Promise<number> {
-  return db.entries.add(entry)
+export async function getAllEntries(list?: string): Promise<Entry[]> {
+  let collection = db.entries.orderBy("timestamp");
+  if (list) {
+    collection = collection.filter((e) => e.list === list || (!e.list && list === "メイン"));
+  }
+  return collection.toArray();
+}
+
+export async function addEntry(entry: Omit<Entry, "id">): Promise<number> {
+  return db.entries.add(entry);
 }
 
 export async function deleteEntry(id: number): Promise<void> {
-  return db.entries.delete(id)
+  return db.entries.delete(id);
 }
 
-export async function updateEntryNote(
-  id: number,
-  note: string,
-): Promise<number> {
-  return db.entries.update(id, { note: note || undefined })
+export async function updateEntryNote(id: number, note: string): Promise<number> {
+  return db.entries.update(id, { note: note || undefined });
 }
 
 // ── Lists ──
 
 export async function getLists(): Promise<ListDef[]> {
-  return db.lists.orderBy("order").toArray()
+  return db.lists.orderBy("order").toArray();
 }
 
 export async function addList(name: string): Promise<number> {
-  const count = await db.lists.count()
-  return db.lists.add({ name, order: count })
+  const count = await db.lists.count();
+  return db.lists.add({ name, order: count });
 }
 
-export async function renameList(
-  oldName: string,
-  newName: string,
-): Promise<void> {
-  await db.lists.where("name").equals(oldName).modify({ name: newName })
-  await db.entries
-    .where("list")
-    .equals(oldName)
-    .modify({ list: newName })
+export async function renameList(oldName: string, newName: string): Promise<void> {
+  await db.lists.where("name").equals(oldName).modify({ name: newName });
+  await db.entries.where("list").equals(oldName).modify({ list: newName });
 }
 
 export async function removeList(name: string): Promise<void> {
-  await db.lists.where("name").equals(name).delete()
+  await db.lists.where("name").equals(name).delete();
   // Remove list reference from entries, they become "unlisted"
-  await db.entries
-    .where("list")
-    .equals(name)
-    .modify({ list: undefined })
+  await db.entries.where("list").equals(name).modify({ list: undefined });
 }
 
 export async function ensureDefaultList(): Promise<string> {
-  const lists = await db.lists.toArray()
+  const lists = await db.lists.toArray();
   if (lists.length === 0) {
-    await db.lists.add({ name: "メイン", order: 0 })
-    return "メイン"
+    await db.lists.add({ name: "メイン", order: 0 });
+    return "メイン";
   }
-  return lists[0].name
+  return lists[0].name;
 }

--- a/packages/emolog/src/store.ts
+++ b/packages/emolog/src/store.ts
@@ -1,0 +1,116 @@
+import Dexie, { type Table } from "dexie"
+import type { Entry } from "./types"
+
+export interface ListDef {
+  id?: number
+  name: string
+  color?: string
+  order: number
+}
+
+const db = new Dexie("emolog") as Dexie & {
+  entries: Table<Entry, number>
+  lists: Table<ListDef, number>
+}
+
+db.version(1).stores({
+  entries: "++id, date, timestamp",
+})
+
+db.version(2).stores({
+  entries: "++id, date, timestamp, list",
+  lists: "++id, name",
+})
+
+db.version(3).stores({
+  entries: "++id, date, timestamp, list",
+  lists: "++id, name, order",
+})
+
+// ── Entries ──
+
+export async function getEntries(
+  date: string,
+  list?: string,
+): Promise<Entry[]> {
+  let collection = db.entries.where("date").equals(date)
+  if (list) {
+    collection = collection.filter(
+      (e) => e.list === list || (!e.list && list === "メイン"),
+    )
+  }
+  return collection.sortBy("timestamp")
+}
+
+export async function getEntriesByDateRange(
+  from: string,
+  to: string,
+  list?: string,
+): Promise<Entry[]> {
+  let collection = db.entries
+    .where("date")
+    .between(from, to, true, true)
+  if (list) {
+    collection = collection.filter(
+      (e) => e.list === list || (!e.list && list === "メイン"),
+    )
+  }
+  return collection.sortBy("timestamp")
+}
+
+export async function addEntry(
+  entry: Omit<Entry, "id">,
+): Promise<number> {
+  return db.entries.add(entry)
+}
+
+export async function deleteEntry(id: number): Promise<void> {
+  return db.entries.delete(id)
+}
+
+export async function updateEntryNote(
+  id: number,
+  note: string,
+): Promise<number> {
+  return db.entries.update(id, { note: note || undefined })
+}
+
+// ── Lists ──
+
+export async function getLists(): Promise<ListDef[]> {
+  return db.lists.orderBy("order").toArray()
+}
+
+export async function addList(name: string): Promise<number> {
+  const count = await db.lists.count()
+  return db.lists.add({ name, order: count })
+}
+
+export async function renameList(
+  oldName: string,
+  newName: string,
+): Promise<void> {
+  await db.lists.where("name").equals(oldName).modify({ name: newName })
+  await db.entries
+    .where("list")
+    .equals(oldName)
+    .modify({ list: newName })
+}
+
+export async function removeList(name: string): Promise<void> {
+  await db.lists.where("name").equals(name).delete()
+  // Remove list reference from entries, they become "unlisted"
+  await db.entries
+    .where("list")
+    .equals(name)
+    .modify({ list: undefined })
+}
+
+export async function ensureDefaultList(): Promise<string> {
+  const lists = await db.lists.toArray()
+  if (lists.length === 0) {
+    await db.lists.add({ name: "メイン", order: 0 })
+    return "メイン"
+  }
+  return lists[0].name
+}

--- a/packages/emolog/src/store.ts
+++ b/packages/emolog/src/store.ts
@@ -8,7 +8,7 @@ export interface ListDef {
   order: number;
 }
 
-const db = new Dexie("emolog") as Dexie & {
+export const db = new Dexie("emolog") as Dexie & {
   entries: Table<Entry, number>;
   lists: Table<ListDef, number>;
 };

--- a/packages/emolog/src/summary.test.ts
+++ b/packages/emolog/src/summary.test.ts
@@ -72,24 +72,24 @@ describe("getDateRangeForPeriod", () => {
 
   it("7d period ends today and starts 6 days before", () => {
     const range = getDateRangeForPeriod("7d");
-    expect(range).not.toBeNull();
+    if (!range) throw new Error("expected range");
     const today = new Date();
     const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-    expect(range!.to).toBe(todayStr);
+    expect(range.to).toBe(todayStr);
 
     const expectedFrom = new Date(today);
     expectedFrom.setDate(expectedFrom.getDate() - 6);
     const fromStr = `${expectedFrom.getFullYear()}-${String(expectedFrom.getMonth() + 1).padStart(2, "0")}-${String(expectedFrom.getDate()).padStart(2, "0")}`;
-    expect(range!.from).toBe(fromStr);
+    expect(range.from).toBe(fromStr);
   });
 
   it("30d period starts 29 days before today", () => {
     const range = getDateRangeForPeriod("30d");
-    expect(range).not.toBeNull();
+    if (!range) throw new Error("expected range");
     const today = new Date();
     const expectedFrom = new Date(today);
     expectedFrom.setDate(expectedFrom.getDate() - 29);
     const fromStr = `${expectedFrom.getFullYear()}-${String(expectedFrom.getMonth() + 1).padStart(2, "0")}-${String(expectedFrom.getDate()).padStart(2, "0")}`;
-    expect(range!.from).toBe(fromStr);
+    expect(range.from).toBe(fromStr);
   });
 });

--- a/packages/emolog/src/summary.test.ts
+++ b/packages/emolog/src/summary.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { computeSummary, getDateRangeForPeriod } from "./summary";
+import type { Entry } from "./types";
+
+function e(emoji: string, overrides: Partial<Entry> = {}): Entry {
+  return {
+    date: "2026-07-15",
+    timestamp: 0,
+    emoji,
+    ...overrides,
+  };
+}
+
+describe("computeSummary", () => {
+  it("empty entries returns zero total, zero distinct, empty rankings", () => {
+    const result = computeSummary([]);
+    expect(result.total).toBe(0);
+    expect(result.distinct).toBe(0);
+    expect(result.rankings).toEqual([]);
+  });
+
+  it("single entry returns one total, one distinct, 100%", () => {
+    const result = computeSummary([e("😊")]);
+    expect(result.total).toBe(1);
+    expect(result.distinct).toBe(1);
+    expect(result.rankings).toEqual([{ emoji: "😊", count: 1, pct: 100 }]);
+  });
+
+  it("multiple same emoji aggregates correctly", () => {
+    const result = computeSummary([e("😊"), e("😊"), e("😊")]);
+    expect(result.total).toBe(3);
+    expect(result.distinct).toBe(1);
+    expect(result.rankings).toEqual([{ emoji: "😊", count: 3, pct: 100 }]);
+  });
+
+  it("multiple distinct emoji with different counts", () => {
+    const result = computeSummary([e("😊"), e("😊"), e("😢"), e("😊"), e("😢")]);
+    expect(result.total).toBe(5);
+    expect(result.distinct).toBe(2);
+    expect(result.rankings).toEqual([
+      { emoji: "😊", count: 3, pct: 60 },
+      { emoji: "😢", count: 2, pct: 40 },
+    ]);
+  });
+
+  it("equal counts are ordered deterministically by emoji code point", () => {
+    const result = computeSummary([e("😢"), e("😊")]);
+    expect(result.rankings).toEqual([
+      { emoji: "😊", count: 1, pct: 50 },
+      { emoji: "😢", count: 1, pct: 50 },
+    ]);
+  });
+
+  it("percentage rounds to one decimal", () => {
+    const result = computeSummary([e("😊"), e("😊"), e("😢")]);
+    expect(result.total).toBe(3);
+    expect(result.rankings[0].pct).toBe(66.7);
+    expect(result.rankings[1].pct).toBe(33.3);
+  });
+
+  it("percentage is 0 when total is 0", () => {
+    const result = computeSummary([]);
+    const allZero = result.rankings.every((r) => r.pct === 0);
+    expect(allZero).toBe(true);
+  });
+});
+
+describe("getDateRangeForPeriod", () => {
+  it('returns null for "all" period', () => {
+    expect(getDateRangeForPeriod("all")).toBeNull();
+  });
+
+  it("7d period ends today and starts 6 days before", () => {
+    const range = getDateRangeForPeriod("7d");
+    expect(range).not.toBeNull();
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+    expect(range!.to).toBe(todayStr);
+
+    const expectedFrom = new Date(today);
+    expectedFrom.setDate(expectedFrom.getDate() - 6);
+    const fromStr = `${expectedFrom.getFullYear()}-${String(expectedFrom.getMonth() + 1).padStart(2, "0")}-${String(expectedFrom.getDate()).padStart(2, "0")}`;
+    expect(range!.from).toBe(fromStr);
+  });
+
+  it("30d period starts 29 days before today", () => {
+    const range = getDateRangeForPeriod("30d");
+    expect(range).not.toBeNull();
+    const today = new Date();
+    const expectedFrom = new Date(today);
+    expectedFrom.setDate(expectedFrom.getDate() - 29);
+    const fromStr = `${expectedFrom.getFullYear()}-${String(expectedFrom.getMonth() + 1).padStart(2, "0")}-${String(expectedFrom.getDate()).padStart(2, "0")}`;
+    expect(range!.from).toBe(fromStr);
+  });
+});

--- a/packages/emolog/src/summary.ts
+++ b/packages/emolog/src/summary.ts
@@ -20,7 +20,7 @@ export function computeSummary(entries: Entry[]): SummaryStats {
       count,
       pct: total > 0 ? Math.round((count / total) * 1000) / 10 : 0,
     }))
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       if (b.count !== a.count) return b.count - a.count;
       return a.emoji.localeCompare(b.emoji);
     });

--- a/packages/emolog/src/summary.ts
+++ b/packages/emolog/src/summary.ts
@@ -1,0 +1,42 @@
+import type { Entry } from "./types";
+
+export type Period = "7d" | "30d" | "all";
+
+export interface SummaryStats {
+  total: number;
+  distinct: number;
+  rankings: { emoji: string; count: number; pct: number }[];
+}
+
+export function computeSummary(entries: Entry[]): SummaryStats {
+  const total = entries.length;
+  const countMap = new Map<string, number>();
+  for (const e of entries) {
+    countMap.set(e.emoji, (countMap.get(e.emoji) ?? 0) + 1);
+  }
+  const rankings = [...countMap.entries()]
+    .map(([emoji, count]) => ({
+      emoji,
+      count,
+      pct: total > 0 ? Math.round((count / total) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.emoji.localeCompare(b.emoji);
+    });
+  return { total, distinct: countMap.size, rankings };
+}
+
+export function getDateRangeForPeriod(period: Period): { from: string; to: string } | null {
+  const today = new Date();
+  const to = formatLocalDate(today);
+  if (period === "all") return null;
+  const days = period === "7d" ? 6 : 29;
+  const from = new Date(today);
+  from.setDate(from.getDate() - days);
+  return { from: formatLocalDate(from), to };
+}
+
+function formatLocalDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}

--- a/packages/emolog/src/test-setup.ts
+++ b/packages/emolog/src/test-setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/emolog/src/types.ts
+++ b/packages/emolog/src/types.ts
@@ -1,18 +1,18 @@
 export interface Entry {
-  id?: number
-  date: string // YYYY-MM-DD
-  timestamp: number // unix ms
-  emoji: string
-  note?: string // optional one-line comment
-  list?: string // list/category name
+  id?: number;
+  date: string; // YYYY-MM-DD
+  timestamp: number; // unix ms
+  emoji: string;
+  note?: string; // optional one-line comment
+  list?: string; // list/category name
 }
 
 export function today(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 export function formatTime(ts: number): string {
-  const d = new Date(ts)
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }

--- a/packages/emolog/src/types.ts
+++ b/packages/emolog/src/types.ts
@@ -1,10 +1,10 @@
 export interface Entry {
   id?: number;
   date: string; // YYYY-MM-DD
-  timestamp: number; // unix ms
+  timestamp: number; // Unix ms
   emoji: string;
-  note?: string; // optional one-line comment
-  list?: string; // list/category name
+  note?: string; // Optional one-line comment
+  list?: string; // List/category name
 }
 
 export function today(): string {

--- a/packages/emolog/src/types.ts
+++ b/packages/emolog/src/types.ts
@@ -1,0 +1,18 @@
+export interface Entry {
+  id?: number
+  date: string // YYYY-MM-DD
+  timestamp: number // unix ms
+  emoji: string
+  note?: string // optional one-line comment
+  list?: string // list/category name
+}
+
+export function today(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+export function formatTime(ts: number): string {
+  const d = new Date(ts)
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+}

--- a/packages/emolog/tsconfig.json
+++ b/packages/emolog/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/packages/emolog/vitest.config.ts
+++ b/packages/emolog/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@mijime/blog':
         specifier: workspace:*
         version: link:../../packages/blog
+      '@mijime/emolog':
+        specifier: workspace:*
+        version: link:../../packages/emolog
       '@mijime/lords-of-the-stigmata':
         specifier: workspace:*
         version: link:../../packages/lords-of-the-stigmata
@@ -190,6 +193,67 @@ importers:
       tsx:
         specifier: ^4.23.0
         version: 4.23.0
+
+  packages/emolog:
+    dependencies:
+      '@mijime/theme':
+        specifier: workspace:*
+        version: link:../theme
+      dexie:
+        specifier: ^4.4.4
+        version: 4.4.4
+      emoji-picker-element:
+        specifier: ^1.29.1
+        version: 1.29.1
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260604.1
+        version: 7.0.0-dev.20260604.1
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      oxfmt:
+        specifier: ^0.46.0
+        version: 0.46.0
+      oxlint:
+        specifier: ^1.72.0
+        version: 1.72.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/lords-of-the-stigmata:
     dependencies:
@@ -3991,6 +4055,9 @@ packages:
 
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
+
+  emoji-picker-element@1.29.1:
+    resolution: {integrity: sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -10698,6 +10765,8 @@ snapshots:
       '@emmetio/abbreviation': 2.3.3
       '@emmetio/css-abbreviation': 2.1.8
 
+  emoji-picker-element@1.29.1: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -14660,16 +14729,15 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@25.9.4)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 5.4.21(@types/node@25.9.4)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
-      - jiti
       - less
       - lightningcss
       - sass
@@ -14678,8 +14746,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-      - tsx
-      - yaml
 
   vite@5.4.21(@types/node@25.9.4)(lightningcss@1.32.0):
     dependencies:
@@ -14801,7 +14867,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.9.4)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13


### PR DESCRIPTION
## Summary

emolog — emoji-based emotion logger with summary view.

### Features
- Simple emotion logging with emoji
- Calendar and timeline views
- **Summary view**: 7d/30d/all-time emotion statistics (count, diversity, ranking)
- Click emoji in summary to filter timeline

### Route changes
- Apps moved under `/apps/<name>/`
- `/apps/` listing page added

### Technical
- 19 tests (3 files)
- oxlintrc.json, vitest config